### PR TITLE
fix(ci): skip workspaces without a test script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,8 +30,11 @@ jobs:
       - name: Install + build (via prepare hooks)
         run: npm install
 
+      # --if-present skips workspaces without a 'test' script. Plugin
+      # shells (plugins/deskwork, plugins/deskwork-studio) ship metadata
+      # + bash wrappers + bundles only — no tests.
       - name: Run all tests
-        run: npm --workspaces test
+        run: npm --workspaces --if-present test
 
       # The committed bundle paths. If `npm install` (which ran prepare
       # → build) produced output that differs from what's checked in,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Install + build
         run: npm install
 
+      # --if-present skips workspaces without a 'test' script (plugin
+      # shells ship metadata + wrappers + bundles only).
       - name: Run all tests
-        run: npm --workspaces test
+        run: npm --workspaces --if-present test
 
       - name: Verify bundles match the tagged source
         run: |


### PR DESCRIPTION
Workflow fix. `npm --workspaces test` iterated over ALL workspaces including the plugin shells, which don't have a `test` script — npm errored "Missing script: test" and both check.yml and release.yml workflows exited 1 even when all real tests passed.

Adding `--if-present` so workspaces without the script are skipped silently.

Affects: `.github/workflows/check.yml`, `.github/workflows/release.yml`. Same one-line fix in both.

This is what made the v0.1.0 release workflow fail — the release page never got created. After this merges, I'll delete + re-tag v0.1.0 to retrigger the workflow.