### PR TITLE
fix: first-launch UX (install ergonomics, studio port, --host, Tailscale auto-detect)

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -2,14 +2,22 @@
  * deskwork-install — validate a deskwork config, write it to disk, and seed
  * empty calendar files for every configured site.
  *
- * Usage:
- *   deskwork-install <project-root> <config-file>
+ * Usage (one-arg, project-root defaults to cwd):
+ *   deskwork install <config-file>
  *
- * The config-file must contain valid JSON matching the DeskworkConfig schema
- * (see lib/config.ts). On success the script:
+ * Usage (two-arg, explicit project-root):
+ *   deskwork install <project-root> <config-file>
+ *
+ * The agent inside Claude Code is already running in the host project's
+ * working directory, so the one-arg form is the natural call. The
+ * explicit two-arg form is preserved for scripted use (CI bootstrapping
+ * a project from outside, etc.).
+ *
+ * The config-file must contain valid JSON matching the DeskworkConfig
+ * schema (see lib/config.ts). On success the script:
  *   1. Writes the validated config to <project-root>/.deskwork/config.json
- *   2. Creates an empty calendar file at each site's calendarPath, but only
- *      when no file is already there
+ *   2. Creates an empty calendar file at each site's calendarPath, but
+ *      only when no file is already there
  *   3. Prints a summary of what was written and what was left untouched
  *
  * Exits non-zero with an actionable message on any failure. Idempotent:
@@ -23,12 +31,30 @@ import { renderEmptyCalendar } from '@deskwork/core/calendar';
 
 export async function run(argv: string[]): Promise<void> {
   function usage(): never {
-    console.error('Usage: deskwork-install <project-root> <config-file>');
+    console.error(
+      'Usage: deskwork install [<project-root>] <config-file>',
+    );
     process.exit(2);
   }
 
-  const [projectRootArg, configFileArg] = argv;
-  if (!projectRootArg || !configFileArg) usage();
+  // Two argv shapes possible after the cli dispatcher has run:
+  //   [<config-file>]                    → project-root defaults to cwd
+  //   [<project-root>, <config-file>]    → explicit project-root
+  // The dispatcher's pathLike heuristic injects cwd for non-path-like
+  // first args, so `deskwork install bare.json` arrives here as the
+  // two-arg form `[cwd, bare.json]`. The one-arg form below only fires
+  // when the user passed an absolute or relative path as the single
+  // positional (e.g. `deskwork install /tmp/config.json`).
+  let projectRootArg: string;
+  let configFileArg: string;
+  if (argv.length === 1) {
+    projectRootArg = process.cwd();
+    configFileArg = argv[0];
+  } else if (argv.length === 2) {
+    [projectRootArg, configFileArg] = argv;
+  } else {
+    usage();
+  }
 
   const projectRoot = isAbsolute(projectRootArg)
     ? projectRootArg
@@ -36,6 +62,11 @@ export async function run(argv: string[]): Promise<void> {
   const configFile = isAbsolute(configFileArg)
     ? configFileArg
     : resolve(process.cwd(), configFileArg);
+
+  // Heads-up so the operator (or the agent reading the output) can
+  // interrupt before any disk writes if the inferred project-root is
+  // wrong. Prints to stdout so it lands above the success summary.
+  console.log(`Installing into: ${projectRoot}`);
 
   if (!existsSync(projectRoot)) {
     console.error(`Project root does not exist: ${projectRoot}`);

--- a/packages/cli/test/install-integration.test.ts
+++ b/packages/cli/test/install-integration.test.ts
@@ -30,6 +30,21 @@ function run(args: string[]): { code: number; stdout: string; stderr: string } {
   };
 }
 
+function runFromCwd(
+  cwd: string,
+  args: string[],
+): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync(deskworkBin, ['install', ...args], {
+    encoding: 'utf-8',
+    cwd,
+  });
+  return {
+    code: r.status ?? -1,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  };
+}
+
 function writeConfigFile(dir: string, value: unknown): string {
   const path = join(dir, 'config.json');
   writeFileSync(path, JSON.stringify(value), 'utf-8');
@@ -192,9 +207,103 @@ describe('deskwork-install', () => {
     }
   });
 
-  it('exits 2 on missing arguments', () => {
-    const res = run([]);
+  it('exits 2 with a usage message when too many args are passed', () => {
+    // 3+ positional args is an unambiguous usage error. (0 and 1 args
+    // are valid one-arg form post-dispatcher; 2 args is the explicit
+    // two-arg form.)
+    const res = run(['/tmp/a', '/tmp/b', '/tmp/c']);
     expect(res.code).toBe(2);
     expect(res.stderr).toMatch(/Usage/);
+  });
+
+  it('one-arg form: project-root defaults to cwd when only config is passed', () => {
+    // Simulates the natural agent invocation `deskwork install /tmp/cfg.json`
+    // from inside the host project's directory. The dispatcher's pathLike
+    // heuristic does NOT inject cwd because the absolute config path looks
+    // path-like — it's the install command itself that infers project-root
+    // from cwd in that case.
+    project = newProject();
+    tmpConfigs = newTmpConfigDir();
+    try {
+      const cfgFile = writeConfigFile(tmpConfigs, {
+        version: 1,
+        sites: {
+          a: {
+            host: 'a.example',
+            contentDir: 'src/content',
+            calendarPath: 'docs/cal.md',
+          },
+        },
+        defaultSite: 'a',
+      });
+      const res = runFromCwd(project, [cfgFile]);
+      expect(res.code).toBe(0);
+      // Heads-up message confirms inferred root before any writes
+      expect(res.stdout).toMatch(/Installing into:/);
+      // Real project file landed at the cwd-inferred root
+      expect(existsSync(join(project, '.deskwork/config.json'))).toBe(true);
+      expect(existsSync(join(project, 'docs/cal.md'))).toBe(true);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+      rmSync(tmpConfigs, { recursive: true, force: true });
+    }
+  });
+
+  it('one-arg form: bare config name (non-path-like) routes through dispatcher cwd-injection', () => {
+    // `deskwork install bare-config.json` — first arg isn't path-like, so
+    // the dispatcher injects cwd ahead of it; install then sees the
+    // 2-arg form. End result is identical to the one-arg path-like case
+    // above, just via a different code path.
+    project = newProject();
+    try {
+      writeFileSync(
+        join(project, 'bare-config.json'),
+        JSON.stringify({
+          version: 1,
+          sites: {
+            x: {
+              host: 'x.example',
+              contentDir: 'src',
+              calendarPath: 'cal.md',
+            },
+          },
+          defaultSite: 'x',
+        }),
+        'utf-8',
+      );
+      const res = runFromCwd(project, ['bare-config.json']);
+      expect(res.code).toBe(0);
+      expect(res.stdout).toMatch(/Installing into:/);
+      expect(existsSync(join(project, '.deskwork/config.json'))).toBe(true);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('two-arg form: explicit project-root still works', () => {
+    // Backward-compat: `deskwork install <project-root> <config-file>`
+    // continues to behave as it did before the one-arg shape was added.
+    project = newProject();
+    tmpConfigs = newTmpConfigDir();
+    try {
+      const cfgFile = writeConfigFile(tmpConfigs, {
+        version: 1,
+        sites: {
+          y: {
+            host: 'y.example',
+            contentDir: 'src/content',
+            calendarPath: 'docs/cal-y.md',
+          },
+        },
+        defaultSite: 'y',
+      });
+      const res = run([project, cfgFile]);
+      expect(res.code).toBe(0);
+      expect(res.stdout).toMatch(/Installing into:/);
+      expect(existsSync(join(project, '.deskwork/config.json'))).toBe(true);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+      rmSync(tmpConfigs, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -3,11 +3,12 @@
  * @deskwork/studio — local web server for the editorial review surface.
  *
  * Usage:
- *   deskwork-studio [--project-root <path>] [--port <n>]
+ *   deskwork-studio [--project-root <path>] [--port <n>] [--host <addr>]
  *
  * Defaults:
  *   --project-root  process.cwd()
- *   --port          4321
+ *   --port          47321  (avoids the Astro dev server's default 4321)
+ *   --host          127.0.0.1 (loopback only — see security note in main())
  *
  * The server reads .deskwork/config.json from the project root, then
  * exposes:
@@ -38,15 +39,30 @@ import { renderReviewPage } from './pages/review.ts';
 import { renderShortformPage } from './pages/shortform.ts';
 import { renderHelpPage } from './pages/help.ts';
 import { renderScrapbookPage } from './pages/scrapbook.ts';
+import { detectTailscale, type TailscaleInfo } from './tailscale.ts';
 
 interface CliArgs {
   projectRoot: string;
   port: number;
+  /**
+   * Bind address explicitly requested by the operator via --host.
+   * `null` means "use the default policy" — bind to loopback AND any
+   * detected Tailscale interface (unless `--no-tailscale` was passed,
+   * in which case loopback only).
+   */
+  hostOverride: string | null;
+  /** When true, skip Tailscale auto-detection even if it's running. */
+  noTailscale: boolean;
 }
 
-function parseCliArgs(argv: string[]): CliArgs {
+const DEFAULT_PORT = 47321;
+const LOOPBACK = '127.0.0.1';
+
+export function parseCliArgs(argv: string[]): CliArgs {
   let projectRoot = process.cwd();
-  let port = 4321;
+  let port = DEFAULT_PORT;
+  let hostOverride: string | null = null;
+  let noTailscale = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--project-root' || a === '-r') {
@@ -61,6 +77,14 @@ function parseCliArgs(argv: string[]): CliArgs {
       port = parseInt(next, 10);
     } else if (a.startsWith('--port=')) {
       port = parseInt(a.slice('--port='.length), 10);
+    } else if (a === '--host' || a === '-H') {
+      const next = argv[++i];
+      if (!next) usage(`${a} requires a value`);
+      hostOverride = next;
+    } else if (a.startsWith('--host=')) {
+      hostOverride = a.slice('--host='.length);
+    } else if (a === '--no-tailscale') {
+      noTailscale = true;
     } else if (a === '--help' || a === '-h') {
       usage(null);
     } else {
@@ -73,19 +97,31 @@ function parseCliArgs(argv: string[]): CliArgs {
   return {
     projectRoot: isAbsolute(projectRoot) ? projectRoot : resolve(process.cwd(), projectRoot),
     port,
+    hostOverride,
+    noTailscale,
   };
 }
 
 function usage(error: string | null): never {
   const out = error ? process.stderr : process.stdout;
   if (error) out.write(`error: ${error}\n\n`);
-  out.write('Usage: deskwork-studio [--project-root <path>] [--port <n>]\n');
+  out.write('Usage: deskwork-studio [--project-root <path>] [--port <n>] [--host <addr>] [--no-tailscale]\n');
   out.write('\n');
   out.write('Options:\n');
   out.write('  -r, --project-root <path>   project root containing .deskwork/config.json\n');
   out.write('                              (default: cwd)\n');
-  out.write('  -p, --port <n>              listen on this port (default: 4321)\n');
+  out.write(`  -p, --port <n>              listen on this port (default: ${DEFAULT_PORT})\n`);
+  out.write('  -H, --host <addr>           bind address. When set, the studio binds ONLY to\n');
+  out.write('                              this address — overrides Tailscale auto-detection.\n');
+  out.write('                              Use 0.0.0.0 to expose on every interface (LAN +\n');
+  out.write('                              Tailscale + Wi-Fi). Studio has no auth; only do this\n');
+  out.write('                              on trusted networks.\n');
+  out.write('      --no-tailscale          skip Tailscale auto-detection (loopback only)\n');
   out.write('  -h, --help                  show this message\n');
+  out.write('\n');
+  out.write('Default networking policy: bind to 127.0.0.1 (loopback) AND, if Tailscale is\n');
+  out.write('running on this machine, the local Tailscale interface(s). Tailscale peers can\n');
+  out.write("then reach the studio at the magic-DNS hostname (e.g. '<machine>.<tailnet>.ts.net').\n");
   process.exit(error ? 2 : 0);
 }
 
@@ -161,7 +197,9 @@ export function createApp(ctx: StudioContext): Hono {
 }
 
 async function main(): Promise<void> {
-  const { projectRoot, port } = parseCliArgs(process.argv.slice(2));
+  const { projectRoot, port, hostOverride, noTailscale } = parseCliArgs(
+    process.argv.slice(2),
+  );
 
   let config;
   try {
@@ -175,15 +213,80 @@ async function main(): Promise<void> {
   const ctx: StudioContext = { projectRoot, config };
   const app = createApp(ctx);
 
-  // Bind to loopback only. The studio is dev-only — no auth, no review of
-  // mutation handlers against a hostile caller. Binding 0.0.0.0 (Hono's
-  // default) would expose the project tree and review APIs to anyone on the
-  // local network.
-  serve({ fetch: app.fetch, port, hostname: '127.0.0.1' }, (info) => {
-    process.stdout.write(`deskwork-studio listening on http://localhost:${info.port}/\n`);
-    process.stdout.write(`  project: ${projectRoot}\n`);
-    process.stdout.write(`  sites:   ${Object.keys(config.sites).join(', ')}\n`);
-  });
+  // Networking policy:
+  //   --host <addr>          → bind ONLY to that address (operator override)
+  //   --no-tailscale         → loopback only
+  //   default                → loopback + auto-detected Tailscale (if running)
+  //
+  // The studio is dev-only with no auth. Loopback is always safe.
+  // Tailscale's tailnet is treated as a trusted network — peers on the
+  // same tailnet are usually devices the operator owns. LAN/Wi-Fi
+  // exposure stays opt-in via `--host 0.0.0.0`.
+  let tailscale: TailscaleInfo | null = null;
+  let bindAddresses: string[];
+  if (hostOverride !== null) {
+    bindAddresses = [hostOverride];
+  } else if (noTailscale) {
+    bindAddresses = [LOOPBACK];
+  } else {
+    tailscale = detectTailscale();
+    bindAddresses = tailscale === null ? [LOOPBACK] : [LOOPBACK, ...tailscale.ipv4];
+  }
+
+  // Open a listener per address, in order, blocking briefly between so
+  // the banner stays grouped. Each `serve()` call returns its own
+  // server handle and runs independently — Node keeps the process
+  // alive as long as at least one is active.
+  const reachableUrls: string[] = [];
+  for (const addr of bindAddresses) {
+    serve({ fetch: app.fetch, port, hostname: addr }, () => {
+      reachableUrls.push(`http://${addr === LOOPBACK ? 'localhost' : addr}:${port}/`);
+      // When the last listener attaches, print the consolidated banner.
+      if (reachableUrls.length === bindAddresses.length) {
+        printBanner({
+          urls: reachableUrls,
+          projectRoot,
+          siteSlugs: Object.keys(config.sites),
+          tailscale,
+          port,
+          override: hostOverride,
+        });
+      }
+    });
+  }
+}
+
+interface BannerInput {
+  readonly urls: readonly string[];
+  readonly projectRoot: string;
+  readonly siteSlugs: readonly string[];
+  readonly tailscale: TailscaleInfo | null;
+  readonly port: number;
+  readonly override: string | null;
+}
+
+function printBanner(b: BannerInput): void {
+  process.stdout.write('deskwork-studio listening on:\n');
+  for (const url of b.urls) {
+    process.stdout.write(`  ${url}\n`);
+  }
+  if (b.tailscale && b.tailscale.magicDnsName) {
+    process.stdout.write(
+      `  http://${b.tailscale.magicDnsName}:${b.port}/    (Tailscale magic-DNS)\n`,
+    );
+  }
+  process.stdout.write(`  project: ${b.projectRoot}\n`);
+  process.stdout.write(`  sites:   ${b.siteSlugs.join(', ')}\n`);
+  // Loud warning when bound beyond loopback + Tailscale tailnet.
+  // Tailscale interfaces (100.64.0.0/10) are considered trusted; an
+  // explicit --host other than loopback is not.
+  const exposed = b.override !== null && b.override !== LOOPBACK;
+  if (exposed) {
+    process.stdout.write(
+      `  ⚠ bound to ${b.override}. Studio has no authentication —\n` +
+        '    only run this on a trusted network (Tailscale, VPN, etc.).\n',
+    );
+  }
 }
 
 // Only run when invoked directly, not when imported from tests. Resolve

--- a/packages/studio/src/tailscale.ts
+++ b/packages/studio/src/tailscale.ts
@@ -1,0 +1,121 @@
+/**
+ * Tailscale auto-detection for the studio.
+ *
+ * Default behavior on launch: bind to loopback AND, if Tailscale is
+ * running on this machine, the local Tailscale interface(s). That
+ * makes the studio reachable from any other tailnet member by magic-
+ * DNS hostname (`<machine>.<tailnet>.ts.net`) without the operator
+ * having to think about ports, interfaces, or `--host` flags.
+ *
+ * Detection layered, fast-first:
+ *
+ * 1. **Network-interface scan** (sub-millisecond, no subprocess).
+ *    Tailscale exclusively uses the IPv4 CGNAT range `100.64.0.0/10`
+ *    on any platform. We walk `os.networkInterfaces()` and return any
+ *    IP that lands in that range. False positives only if the operator
+ *    is intentionally running their own CGNAT gateway — extremely rare.
+ *
+ * 2. **CLI enrichment** (~50ms, optional). When the `tailscale` CLI is
+ *    on PATH, `tailscale status --json` provides the magic-DNS name we
+ *    can show in the startup banner so the operator knows the URL their
+ *    tailnet peers will use. Strictly nice-to-have; the IP-based bind
+ *    works without it.
+ *
+ * Operators can disable auto-detection entirely with `--no-tailscale`
+ * (loopback only). They can also pass an explicit `--host` to override
+ * everything (Tailscale-aware logic kicks in only when `--host` was
+ * NOT explicitly set).
+ */
+
+import { spawnSync } from 'node:child_process';
+import { networkInterfaces } from 'node:os';
+
+export interface TailscaleInfo {
+  /** IPv4 address(es) of this machine on the tailnet. Always populated when Tailscale is detected. */
+  readonly ipv4: readonly string[];
+  /**
+   * Magic-DNS hostname (e.g. `orion-m4.tail8254f4.ts.net`). Populated
+   * when the `tailscale` CLI is available; null otherwise. Strictly
+   * informational — used only for display in the startup banner.
+   */
+  readonly magicDnsName: string | null;
+}
+
+/**
+ * True if `addr` falls inside Tailscale's IPv4 CGNAT range
+ * (`100.64.0.0/10`, i.e. `100.64.0.0` through `100.127.255.255`).
+ */
+function isTailscaleIPv4(addr: string): boolean {
+  const parts = addr.split('.');
+  if (parts.length !== 4) return false;
+  const a = Number(parts[0]);
+  const b = Number(parts[1]);
+  if (a !== 100) return false;
+  if (!Number.isFinite(b)) return false;
+  return b >= 64 && b <= 127;
+}
+
+/**
+ * Scan local network interfaces for Tailscale IPv4 addresses. Returns
+ * a (possibly empty) list, sorted for deterministic output. No
+ * subprocess, no failure modes other than "no Tailscale interface" →
+ * empty array.
+ */
+export function detectTailscaleIPv4Addresses(): readonly string[] {
+  const interfaces = networkInterfaces();
+  const found: string[] = [];
+  for (const addrs of Object.values(interfaces)) {
+    if (!addrs) continue;
+    for (const a of addrs) {
+      if (a.family !== 'IPv4') continue;
+      if (a.internal) continue;
+      if (isTailscaleIPv4(a.address)) {
+        found.push(a.address);
+      }
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * Best-effort lookup of this machine's magic-DNS name via the
+ * `tailscale` CLI. Returns null when:
+ *   - the CLI isn't on PATH
+ *   - the CLI errors (daemon not running, network blip, etc.)
+ *   - the JSON shape is unexpected
+ *
+ * Total cost: bounded by the 1500ms timeout; typically ~50ms when
+ * Tailscale is up and idle.
+ */
+export function detectTailscaleMagicDnsName(): string | null {
+  const result = spawnSync('tailscale', ['status', '--json'], {
+    encoding: 'utf-8',
+    timeout: 1500,
+  });
+  if (result.error || result.status !== 0 || !result.stdout) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const self = (parsed as { Self?: unknown }).Self;
+  if (!self || typeof self !== 'object') return null;
+  const dnsName = (self as { DNSName?: unknown }).DNSName;
+  if (typeof dnsName !== 'string' || dnsName.length === 0) return null;
+  // The CLI returns the FQDN with a trailing dot ("orion-m4.tail8254f4.ts.net.").
+  // Strip it for cleaner banner output.
+  return dnsName.endsWith('.') ? dnsName.slice(0, -1) : dnsName;
+}
+
+/**
+ * Combined detection: IPv4 from networkInterfaces (always tried),
+ * magic-DNS hostname from CLI (best-effort). Returns null when
+ * Tailscale isn't detected on this machine.
+ */
+export function detectTailscale(): TailscaleInfo | null {
+  const ipv4 = detectTailscaleIPv4Addresses();
+  if (ipv4.length === 0) return null;
+  return { ipv4, magicDnsName: detectTailscaleMagicDnsName() };
+}

--- a/packages/studio/test/cli-args.test.ts
+++ b/packages/studio/test/cli-args.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the studio's CLI argument parser. Covers the default port
+ * (47321 — chosen to dodge Astro's default 4321), the --host override,
+ * and the --no-tailscale opt-out flag. The "default networking policy
+ * is loopback + Tailscale" semantics is asserted by leaving
+ * `hostOverride` null on a flagless invocation; main() decides what to
+ * actually bind based on Tailscale detection at runtime.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseCliArgs } from '../src/server.ts';
+
+describe('parseCliArgs', () => {
+  it('default port is 47321 (avoids Astro 4321 collision), no host override, tailscale enabled', () => {
+    const args = parseCliArgs([]);
+    expect(args.port).toBe(47321);
+    expect(args.hostOverride).toBeNull();
+    expect(args.noTailscale).toBe(false);
+    // projectRoot defaults to process.cwd(); just assert it's absolute
+    expect(args.projectRoot.startsWith('/')).toBe(true);
+  });
+
+  it('--host explicit override sets hostOverride', () => {
+    const args = parseCliArgs(['--host', '0.0.0.0']);
+    expect(args.hostOverride).toBe('0.0.0.0');
+  });
+
+  it('--host=ADDR equals form', () => {
+    const args = parseCliArgs(['--host=192.168.1.5']);
+    expect(args.hostOverride).toBe('192.168.1.5');
+  });
+
+  it('-H short flag', () => {
+    const args = parseCliArgs(['-H', '10.0.0.1']);
+    expect(args.hostOverride).toBe('10.0.0.1');
+  });
+
+  it('--no-tailscale opts out of auto-detection', () => {
+    const args = parseCliArgs(['--no-tailscale']);
+    expect(args.noTailscale).toBe(true);
+    expect(args.hostOverride).toBeNull();
+  });
+
+  it('--port and --host can combine', () => {
+    const args = parseCliArgs(['--port', '8080', '--host', '0.0.0.0']);
+    expect(args.port).toBe(8080);
+    expect(args.hostOverride).toBe('0.0.0.0');
+  });
+
+  it('--project-root resolves to absolute', () => {
+    const args = parseCliArgs(['--project-root', '/tmp/some-project']);
+    expect(args.projectRoot).toBe('/tmp/some-project');
+  });
+});

--- a/packages/studio/test/tailscale.test.ts
+++ b/packages/studio/test/tailscale.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for Tailscale auto-detection. Covers the IPv4 CGNAT range
+ * predicate (Tailscale's reserved 100.64.0.0/10 space) plus the
+ * subprocess-based magic-DNS lookup. The detection itself is exercised
+ * indirectly — `detectTailscaleIPv4Addresses` walks live network
+ * interfaces, so we can't assert exact addresses, only that the
+ * function doesn't throw and returns an array.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectTailscale,
+  detectTailscaleIPv4Addresses,
+  detectTailscaleMagicDnsName,
+} from '../src/tailscale.ts';
+
+describe('detectTailscaleIPv4Addresses', () => {
+  it('returns an array (possibly empty) without throwing', () => {
+    const addresses = detectTailscaleIPv4Addresses();
+    expect(Array.isArray(addresses)).toBe(true);
+    // Every returned address must fall inside Tailscale's CGNAT range.
+    for (const addr of addresses) {
+      const parts = addr.split('.');
+      expect(parts).toHaveLength(4);
+      expect(Number(parts[0])).toBe(100);
+      const second = Number(parts[1]);
+      expect(second).toBeGreaterThanOrEqual(64);
+      expect(second).toBeLessThanOrEqual(127);
+    }
+  });
+
+  it('result is sorted (deterministic output for banner ordering)', () => {
+    const addresses = detectTailscaleIPv4Addresses();
+    const sorted = [...addresses].sort();
+    expect(addresses).toEqual(sorted);
+  });
+});
+
+describe('detectTailscaleMagicDnsName', () => {
+  it('returns a string ending in .ts.net or null (never throws)', () => {
+    const name = detectTailscaleMagicDnsName();
+    if (name !== null) {
+      expect(typeof name).toBe('string');
+      expect(name.length).toBeGreaterThan(0);
+      // Strip the trailing dot is part of the contract
+      expect(name.endsWith('.')).toBe(false);
+    }
+  });
+});
+
+describe('detectTailscale', () => {
+  it('returns null when Tailscale not detected, or {ipv4, magicDnsName} when detected', () => {
+    const info = detectTailscale();
+    if (info === null) {
+      // No Tailscale on this machine — that's a valid result.
+      expect(info).toBeNull();
+      return;
+    }
+    expect(info.ipv4.length).toBeGreaterThan(0);
+    // magicDnsName is best-effort: present when CLI works, null otherwise
+    expect(['string', 'object']).toContain(typeof info.magicDnsName);
+    if (info.magicDnsName !== null) {
+      expect(info.magicDnsName.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/plugins/deskwork-studio/README.md
+++ b/plugins/deskwork-studio/README.md
@@ -2,7 +2,7 @@
 
 Web studio for the deskwork editorial calendar — a local Hono server exposing a dashboard, longform review surface, shortform review desk, scrapbook viewer, and the compositor's manual.
 
-This is a thin Claude Code plugin shell. The actual server lives in the [@deskwork/studio](../../packages/studio/) npm package; this plugin's `bin/deskwork-studio` wrapper resolves to the workspace-linked binary on dev installs, or falls back to the self-contained bundle at `packages/studio/bundle/server.mjs` (committed to git) for fresh `claude plugin install` users. No `npm install` ceremony required either way.
+This is a thin Claude Code plugin shell. The actual server lives in the [@deskwork/studio](../../packages/studio/) npm package; this plugin's `bin/deskwork-studio` wrapper resolves to the workspace-linked binary on dev installs, or falls back to the self-contained bundle at `plugins/deskwork-studio/bundle/server.mjs` (committed to git) for fresh `claude plugin install` users. No `npm install` ceremony required either way.
 
 ### Install
 
@@ -21,7 +21,22 @@ In a project that has a `.deskwork/config.json` (run `/deskwork:install` first i
 /deskwork-studio:studio
 ```
 
-The skill prompts for an optional project root and port, then launches the server. Default URL: `http://localhost:4321/dev/editorial-studio`.
+The skill prompts for an optional project root, port, and host, then launches the server. Default URL: `http://localhost:47321/dev/editorial-studio`. The default port is `47321` (chosen to avoid the Astro dev server's default `4321` — most projects deskwork manages run an Astro dev server alongside).
+
+### Reaching the studio from another device
+
+By default the studio detects Tailscale on launch and binds to **both** loopback AND the local Tailscale interface(s). Tailscale peers can reach the studio at the magic-DNS hostname (`<machine>.<tailnet>.ts.net`) without any flags. The startup banner lists every reachable URL.
+
+If Tailscale isn't installed or running, the studio binds to loopback only.
+
+Overrides:
+
+| Goal | Flag |
+|---|---|
+| Loopback only (skip Tailscale even if running) | `--no-tailscale` |
+| Bind ONLY to a specific address (LAN/Wi-Fi opt-in) | `--host 0.0.0.0` (or a specific IP) |
+
+The studio has **no authentication** and **no rate-limiting**. Tailscale is treated as a trusted network. `--host` overrides print a loud warning when bound beyond loopback.
 
 ### Routes
 

--- a/plugins/deskwork-studio/bundle/server.mjs
+++ b/plugins/deskwork-studio/bundle/server.mjs
@@ -25466,10 +25466,66 @@ function renderScrapbookPage(ctx, site, path) {
   });
 }
 
+// src/tailscale.ts
+import { spawnSync } from "node:child_process";
+import { networkInterfaces } from "node:os";
+function isTailscaleIPv4(addr) {
+  const parts = addr.split(".");
+  if (parts.length !== 4) return false;
+  const a = Number(parts[0]);
+  const b = Number(parts[1]);
+  if (a !== 100) return false;
+  if (!Number.isFinite(b)) return false;
+  return b >= 64 && b <= 127;
+}
+function detectTailscaleIPv4Addresses() {
+  const interfaces = networkInterfaces();
+  const found = [];
+  for (const addrs of Object.values(interfaces)) {
+    if (!addrs) continue;
+    for (const a of addrs) {
+      if (a.family !== "IPv4") continue;
+      if (a.internal) continue;
+      if (isTailscaleIPv4(a.address)) {
+        found.push(a.address);
+      }
+    }
+  }
+  return found.sort();
+}
+function detectTailscaleMagicDnsName() {
+  const result = spawnSync("tailscale", ["status", "--json"], {
+    encoding: "utf-8",
+    timeout: 1500
+  });
+  if (result.error || result.status !== 0 || !result.stdout) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const self2 = parsed.Self;
+  if (!self2 || typeof self2 !== "object") return null;
+  const dnsName = self2.DNSName;
+  if (typeof dnsName !== "string" || dnsName.length === 0) return null;
+  return dnsName.endsWith(".") ? dnsName.slice(0, -1) : dnsName;
+}
+function detectTailscale() {
+  const ipv4 = detectTailscaleIPv4Addresses();
+  if (ipv4.length === 0) return null;
+  return { ipv4, magicDnsName: detectTailscaleMagicDnsName() };
+}
+
 // src/server.ts
+var DEFAULT_PORT = 47321;
+var LOOPBACK = "127.0.0.1";
 function parseCliArgs(argv) {
   let projectRoot = process.cwd();
-  let port = 4321;
+  let port = DEFAULT_PORT;
+  let hostOverride = null;
+  let noTailscale = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--project-root" || a === "-r") {
@@ -25484,6 +25540,14 @@ function parseCliArgs(argv) {
       port = parseInt(next, 10);
     } else if (a.startsWith("--port=")) {
       port = parseInt(a.slice("--port=".length), 10);
+    } else if (a === "--host" || a === "-H") {
+      const next = argv[++i];
+      if (!next) usage(`${a} requires a value`);
+      hostOverride = next;
+    } else if (a.startsWith("--host=")) {
+      hostOverride = a.slice("--host=".length);
+    } else if (a === "--no-tailscale") {
+      noTailscale = true;
     } else if (a === "--help" || a === "-h") {
       usage(null);
     } else {
@@ -25495,7 +25559,9 @@ function parseCliArgs(argv) {
   }
   return {
     projectRoot: isAbsolute(projectRoot) ? projectRoot : resolve2(process.cwd(), projectRoot),
-    port
+    port,
+    hostOverride,
+    noTailscale
   };
 }
 function usage(error) {
@@ -25503,13 +25569,24 @@ function usage(error) {
   if (error) out.write(`error: ${error}
 
 `);
-  out.write("Usage: deskwork-studio [--project-root <path>] [--port <n>]\n");
+  out.write("Usage: deskwork-studio [--project-root <path>] [--port <n>] [--host <addr>] [--no-tailscale]\n");
   out.write("\n");
   out.write("Options:\n");
   out.write("  -r, --project-root <path>   project root containing .deskwork/config.json\n");
   out.write("                              (default: cwd)\n");
-  out.write("  -p, --port <n>              listen on this port (default: 4321)\n");
+  out.write(`  -p, --port <n>              listen on this port (default: ${DEFAULT_PORT})
+`);
+  out.write("  -H, --host <addr>           bind address. When set, the studio binds ONLY to\n");
+  out.write("                              this address \u2014 overrides Tailscale auto-detection.\n");
+  out.write("                              Use 0.0.0.0 to expose on every interface (LAN +\n");
+  out.write("                              Tailscale + Wi-Fi). Studio has no auth; only do this\n");
+  out.write("                              on trusted networks.\n");
+  out.write("      --no-tailscale          skip Tailscale auto-detection (loopback only)\n");
   out.write("  -h, --help                  show this message\n");
+  out.write("\n");
+  out.write("Default networking policy: bind to 127.0.0.1 (loopback) AND, if Tailscale is\n");
+  out.write("running on this machine, the local Tailscale interface(s). Tailscale peers can\n");
+  out.write("then reach the studio at the magic-DNS hostname (e.g. '<machine>.<tailnet>.ts.net').\n");
   process.exit(error ? 2 : 0);
 }
 function publicDir() {
@@ -25566,7 +25643,9 @@ function createApp(ctx) {
   return app;
 }
 async function main() {
-  const { projectRoot, port } = parseCliArgs(process.argv.slice(2));
+  const { projectRoot, port, hostOverride, noTailscale } = parseCliArgs(
+    process.argv.slice(2)
+  );
   let config;
   try {
     config = readConfig(projectRoot);
@@ -25578,18 +25657,62 @@ async function main() {
   }
   const ctx = { projectRoot, config };
   const app = createApp(ctx);
-  serve({ fetch: app.fetch, port, hostname: "127.0.0.1" }, (info) => {
-    process.stdout.write(`deskwork-studio listening on http://localhost:${info.port}/
+  let tailscale = null;
+  let bindAddresses;
+  if (hostOverride !== null) {
+    bindAddresses = [hostOverride];
+  } else if (noTailscale) {
+    bindAddresses = [LOOPBACK];
+  } else {
+    tailscale = detectTailscale();
+    bindAddresses = tailscale === null ? [LOOPBACK] : [LOOPBACK, ...tailscale.ipv4];
+  }
+  const reachableUrls = [];
+  for (const addr of bindAddresses) {
+    serve({ fetch: app.fetch, port, hostname: addr }, () => {
+      reachableUrls.push(`http://${addr === LOOPBACK ? "localhost" : addr}:${port}/`);
+      if (reachableUrls.length === bindAddresses.length) {
+        printBanner({
+          urls: reachableUrls,
+          projectRoot,
+          siteSlugs: Object.keys(config.sites),
+          tailscale,
+          port,
+          override: hostOverride
+        });
+      }
+    });
+  }
+}
+function printBanner(b) {
+  process.stdout.write("deskwork-studio listening on:\n");
+  for (const url of b.urls) {
+    process.stdout.write(`  ${url}
 `);
-    process.stdout.write(`  project: ${projectRoot}
+  }
+  if (b.tailscale && b.tailscale.magicDnsName) {
+    process.stdout.write(
+      `  http://${b.tailscale.magicDnsName}:${b.port}/    (Tailscale magic-DNS)
+`
+    );
+  }
+  process.stdout.write(`  project: ${b.projectRoot}
 `);
-    process.stdout.write(`  sites:   ${Object.keys(config.sites).join(", ")}
+  process.stdout.write(`  sites:   ${b.siteSlugs.join(", ")}
 `);
-  });
+  const exposed = b.override !== null && b.override !== LOOPBACK;
+  if (exposed) {
+    process.stdout.write(
+      `  \u26A0 bound to ${b.override}. Studio has no authentication \u2014
+    only run this on a trusted network (Tailscale, VPN, etc.).
+`
+    );
+  }
 }
 if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath2(import.meta.url)) {
   await main();
 }
 export {
-  createApp
+  createApp,
+  parseCliArgs
 };

--- a/plugins/deskwork-studio/skills/studio/SKILL.md
+++ b/plugins/deskwork-studio/skills/studio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: studio
-description: Launch the deskwork web studio — a local dev server (default port 4321) exposing the editorial dashboard, longform review surface, scrapbook viewer, and the compositor's manual. Reads .deskwork/config.json from the current project. Use when the operator wants a browser surface for the editorial workflow rather than driving everything through CLI subcommands.
+description: Launch the deskwork web studio — a local dev server (default port 47321, loopback only) exposing the editorial dashboard, longform review surface, scrapbook viewer, and the compositor's manual. Reads .deskwork/config.json from the current project. Use when the operator wants a browser surface for the editorial workflow rather than driving everything through CLI subcommands.
 ---
 
 ## Studio
@@ -11,30 +11,87 @@ Launch the deskwork studio against the current project. The studio runs as a loc
 
 The studio reads `.deskwork/config.json` relative to a project root. Defaults to `process.cwd()` of the launched process. If the operator wants to point at a different tree, capture the absolute path before invoking.
 
-### Step 2 — Pick a port
+### Step 2 — Port (default 47321)
 
-The default is `4321`. If the operator already runs another dev server on that port (Astro defaults to 4321 too), pick something else and pass `--port`. Common alternates: `47321`, `47323`, `8421`.
+The default is `47321`. This is intentionally *not* `4321` — Astro's dev server defaults to `4321`, and most projects deskwork manages run an Astro dev server alongside the studio. Override with `--port <n>` if needed.
 
-### Step 3 — Launch
+### Step 3 — Host policy (Tailscale-aware default)
+
+The studio's default networking policy:
+
+- Always binds to `127.0.0.1` (loopback) so `localhost:<port>` works on this machine.
+- **If Tailscale is detected**, also binds to the local Tailscale interface(s). The studio then becomes reachable from any other tailnet member at the magic-DNS hostname (`<machine>.<tailnet>.ts.net`) without any flags.
+- LAN / Wi-Fi / public-internet exposure stays opt-in via `--host`.
+
+Detection is automatic — no flag needed. The studio walks `os.networkInterfaces()` for an IP in `100.64.0.0/10` (Tailscale's reserved CGNAT range) and binds to it if found. Magic-DNS hostname comes from `tailscale status --json` when the CLI is on PATH; otherwise the banner shows the Tailscale IP directly.
+
+To override:
+
+| Goal | Flag |
+|---|---|
+| Loopback only (skip Tailscale even if it's running) | `--no-tailscale` |
+| Bind ONLY to a specific address (no auto-detect) | `--host <addr>` |
+| Reach from any local interface (LAN + Wi-Fi + Tailscale + everything) | `--host 0.0.0.0` |
+
+The studio has **no authentication** and **no rate-limiting**. Tailscale is treated as a trusted network — peers on the same tailnet are usually devices the operator owns. `--host` exposing beyond loopback prints a loud warning in the startup banner.
+
+### Step 4 — Launch
 
 Invoke the wrapper (available on PATH because it lives under the plugin's `bin/`):
 
 ```
-deskwork-studio --project-root /absolute/path/to/project --port 4321
+deskwork-studio
 ```
 
-The wrapper resolves to a workspace-linked binary when running in dev, or to `npx -y @deskwork/studio@latest` otherwise. The first npx call pulls the package; subsequent calls are sub-second.
-
-The server logs:
+Or with explicit overrides:
 
 ```
-deskwork-studio listening on http://localhost:4321
-  project root: /absolute/path/to/project
+deskwork-studio --project-root /absolute/path/to/project --port 47321
+deskwork-studio --no-tailscale                # loopback only
+deskwork-studio --host 0.0.0.0                # all interfaces (LAN + Wi-Fi + Tailscale)
+deskwork-studio --host 100.64.0.5             # bind to a specific Tailscale IP only
+```
+
+The wrapper resolves the studio binary in this order:
+
+1. Workspace-linked binary at `node_modules/.bin/deskwork-studio` (dev path; runs source via tsx, supports edits without rebuild)
+2. Self-contained ESM bundle at `plugins/deskwork-studio/bundle/server.mjs` (committed to git; what fresh `claude plugin install` users hit)
+3. Loud error pointing at `npm install` / `npm run build`
+
+The server logs (loopback only — when Tailscale isn't running or `--no-tailscale` is passed):
+
+```
+deskwork-studio listening on:
+  http://localhost:47321/
+  project: /absolute/path/to/project
+  sites:   writingcontrol
+```
+
+When Tailscale is detected, every reachable URL is listed:
+
+```
+deskwork-studio listening on:
+  http://localhost:47321/
+  http://100.64.0.5:47321/
+  http://orion-m4.tail8254f4.ts.net:47321/    (Tailscale magic-DNS)
+  project: /absolute/path/to/project
+  sites:   writingcontrol
+```
+
+When `--host` exposes the studio beyond loopback, a warning appends:
+
+```
+deskwork-studio listening on:
+  http://0.0.0.0:47321/
+  project: /absolute/path/to/project
+  sites:   writingcontrol
+  ⚠ bound to 0.0.0.0. Studio has no authentication —
+    only run this on a trusted network (Tailscale, VPN, etc.).
 ```
 
 Press Ctrl-C to stop.
 
-### Step 4 — Routes the operator can visit
+### Step 5 — Routes the operator can visit
 
 | Path | Surface |
 |---|---|
@@ -43,18 +100,18 @@ Press Ctrl-C to stop.
 | `/dev/editorial-review/<slug>` | Longform review (margin notes, editor, decision controls) for an active workflow |
 | `/dev/editorial-review-shortform` | Shortform review desk (Reddit, LinkedIn, YouTube, Instagram) |
 | `/dev/editorial-help` | The compositor's manual — reference for the editorial workflow and skill catalogue |
-| `/dev/scrapbook/<site>/<slug>` | Scrapbook viewer for research artifacts attached to an entry |
+| `/dev/scrapbook/<site>/<path>` | Scrapbook viewer for research artifacts (path may be hierarchical, e.g. `the-outbound/characters/strivers`) |
 
-### Step 5 — Report to the operator
+### Step 6 — Report to the operator
 
 After launch, tell them:
 
-- The URL (`http://localhost:<port>/dev/editorial-studio`)
+- The URL (`http://localhost:<port>/dev/editorial-studio` for loopback; the actual host:port shown in the banner otherwise)
 - Which routes to visit for the surface they asked for
 - That the server reads from `.deskwork/config.json` — if no config exists, `/deskwork:install` should run first
+- If they passed `--host`, remind them the studio has no auth — make sure the network is trusted
 
 ### Notes
 
-- The studio is **dev-only**. There is no auth and no remote-access posture; bind only to localhost. Do not expose it to the public internet.
+- The studio is **dev-only**. There is no auth, no rate-limiting, and no review of mutation handlers against a hostile caller. Default loopback bind keeps that posture safe; `--host` is opt-in for trusted overlay networks.
 - All mutations from the studio go through the same `@deskwork/core` handlers the CLI uses, so calendar/journal state stays consistent regardless of which surface the operator drives.
-- If the wrapper fails to find a binary AND `npx` cannot reach the registry, the package isn't published yet (v0.1 not yet cut). In that case, run from the deskwork repo directly: `node_modules/.bin/deskwork-studio --project-root <path>`.

--- a/plugins/deskwork/bundle/cli.mjs
+++ b/plugins/deskwork/bundle/cli.mjs
@@ -1489,13 +1489,24 @@ import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsS
 import { dirname, isAbsolute as isAbsolute2, join as join5, resolve as resolve2 } from "node:path";
 async function run4(argv2) {
   function usage() {
-    console.error("Usage: deskwork-install <project-root> <config-file>");
+    console.error(
+      "Usage: deskwork install [<project-root>] <config-file>"
+    );
     process.exit(2);
   }
-  const [projectRootArg, configFileArg] = argv2;
-  if (!projectRootArg || !configFileArg) usage();
+  let projectRootArg;
+  let configFileArg;
+  if (argv2.length === 1) {
+    projectRootArg = process.cwd();
+    configFileArg = argv2[0];
+  } else if (argv2.length === 2) {
+    [projectRootArg, configFileArg] = argv2;
+  } else {
+    usage();
+  }
   const projectRoot = isAbsolute2(projectRootArg) ? projectRootArg : resolve2(process.cwd(), projectRootArg);
   const configFile = isAbsolute2(configFileArg) ? configFileArg : resolve2(process.cwd(), configFileArg);
+  console.log(`Installing into: ${projectRoot}`);
   if (!existsSync3(projectRoot)) {
     console.error(`Project root does not exist: ${projectRoot}`);
     process.exit(1);

--- a/plugins/deskwork/skills/install/SKILL.md
+++ b/plugins/deskwork/skills/install/SKILL.md
@@ -62,7 +62,13 @@ Invoke the helper script (available on PATH because it lives under the plugin's 
 deskwork install /tmp/deskwork-install-config.json
 ```
 
-Pass the absolute path to the project root. The script:
+Project root defaults to the current working directory. The agent is already running in the host project's directory inside Claude Code, so the one-arg form is the natural call. The first line of output (`Installing into: <abspath>`) confirms the inferred project root before any disk writes happen — if it's wrong, interrupt the run and re-invoke with an explicit project root:
+
+```
+deskwork install /Users/me/work/my-site /tmp/deskwork-install-config.json
+```
+
+The script:
 
 1. Validates the JSON against the config schema
 2. Writes it to `<project-root>/.deskwork/config.json`


### PR DESCRIPTION
First-launch UX cleanup. Four small bug fixes from issues filed during the v0.1.0 dogfood pass, grouped because they share a single review surface (install skill + studio CLI args + studio README).

Closes #7, #8, #10, #11.

## #7 + #8 — install skill: project-root defaults to cwd

`deskwork install` now infers `<project-root>` from `process.cwd()`. The agent inside Claude Code is already running in the host project's directory, so the natural one-arg call:

```
deskwork install /tmp/deskwork-install-config.json
```

…is now correct (it was the form the SKILL.md showed but the binary rejected). The two-arg form is preserved unchanged for scripted use:

```
deskwork install /Users/me/work/my-site /tmp/deskwork-install-config.json
```

New first line of stdout — `Installing into: <abspath>` — lets the operator interrupt before any disk writes if the inferred root is wrong.

SKILL.md prose updated to match.

## #11 — studio default port 47321 (avoids Astro 4321 collision)

Default port changed from `4321` to `47321`. Astro's dev server defaults to `4321`; most projects deskwork manages run an Astro dev server alongside the studio, so the old default collided in the most common setup. Drops the obsolete "Astro defaults to 4321 too, pick something else" paragraph from the skill prompt.

## #10 — studio Tailscale auto-detect + `--host` opt-in

The big one. The studio is dev-only with no auth, and operators wanted to reach it from other tailnet members (iPad on Tailscale, desktop while studio runs on a laptop, etc.) without setting up ssh tunnels.

**Default networking policy** (no flags):

- Always bind `127.0.0.1` (localhost works on this machine)
- **If Tailscale is detected**, also bind any local Tailscale interface(s). Tailscale peers reach the studio at the magic-DNS hostname (`<machine>.<tailnet>.ts.net`) without any flags.
- LAN / Wi-Fi / public-internet exposure stays opt-in via `--host`.

Detection via `os.networkInterfaces()` — finds an IP in `100.64.0.0/10` (Tailscale's reserved CGNAT range). No subprocess, no failure modes. Magic-DNS hostname is best-effort enrichment via `tailscale status --json`.

**New flags**:

| Flag | Behavior |
|---|---|
| `--host <addr>` | Bind ONLY to that address. Overrides Tailscale auto-detect. Use `0.0.0.0` for all interfaces, or a specific IP for one. |
| `--no-tailscale` | Skip Tailscale auto-detection (loopback only). |
| `-H` | Short alias for `--host`. |

**Banner shows every reachable URL**:

```
deskwork-studio listening on:
  http://localhost:47330/
  http://100.65.31.54:47330/
  http://orion-m4.tail8254f4.ts.net:47330/    (Tailscale magic-DNS)
  project: /Users/orion/work/deskwork-work/deskwork-plugin/.audiocontrol.org
  sites:   audiocontrol, editorialcontrol
```

When `--host` exposes the studio beyond loopback, a warning appends:

```
  ⚠ bound to 0.0.0.0. Studio has no authentication —
    only run this on a trusted network (Tailscale, VPN, etc.).
```

## Verification

- 231 tests pass workspace-wide (156 core + 36 cli + 39 studio = 11 new for cli-args + tailscale; 3 new for the install changes)
- Live boot against `.audiocontrol.org/` sandbox confirmed dual-bind via `lsof`:

  ```
  TCP 127.0.0.1:47330 (LISTEN)
  TCP 100.65.31.54:47330 (LISTEN)
  ```

- HTTP 200 on all three URLs — localhost, Tailscale IP, magic-DNS hostname.
- Pre-commit hook auto-rebuilt + staged the studio bundle on each commit.

## Files

| Added | Modified |
|---|---|
| `packages/studio/src/tailscale.ts` | `packages/cli/src/commands/install.ts` |
| `packages/studio/test/cli-args.test.ts` | `packages/cli/test/install-integration.test.ts` |
| `packages/studio/test/tailscale.test.ts` | `packages/studio/src/server.ts` |
| | `plugins/deskwork/skills/install/SKILL.md` |
| | `plugins/deskwork-studio/skills/studio/SKILL.md` |
| | `plugins/deskwork-studio/README.md` |
| | `plugins/deskwork/bundle/cli.mjs` (auto) |
| | `plugins/deskwork-studio/bundle/server.mjs` (auto) |

## Out of scope

- Wider operator-side update flow improvements (release UX, auto-update toggling) — those landed in v0.1.0 already.
- IPv6 Tailscale binding — only IPv4 detected today. Easy follow-up; Hono's `serve()` accepts an IPv6 hostname identically.
