### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Open-source Claude Code plugins — editorial calendar, feature images, analytics",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,13 +14,13 @@
       "name": "deskwork",
       "source": "./plugins/deskwork",
       "description": "Editorial calendar lifecycle: capture, plan, draft, publish, distribute",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "name": "deskwork-studio",
       "source": "./plugins/deskwork-studio",
       "description": "Web studio for deskwork — dashboard, longform review, scrapbook, manual. Optional companion to the deskwork plugin",
-      "version": "0.1.0"
+      "version": "0.2.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Open-source Claude Code plugins monorepo — deskwork editorial calendar plugin, feature-image, analytics",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Editorial calendar + review CLI for the deskwork plugin",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Editorial calendar + review pipeline library — shared by @deskwork/cli and @deskwork/studio",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/studio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Editorial review studio — local web UI for the deskwork plugin",

--- a/plugins/deskwork-studio/.claude-plugin/plugin.json
+++ b/plugins/deskwork-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork-studio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Web studio for the deskwork editorial calendar — dashboard, longform review, scrapbook, and a manual at /dev/editorial-help",
   "homepage": "https://github.com/audiocontrol-org/deskwork",
   "repository": "https://github.com/audiocontrol-org/deskwork",

--- a/plugins/deskwork-studio/package.json
+++ b/plugins/deskwork-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/plugin-studio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Web studio plugin for Claude Code — thin shell pointing at @deskwork/studio",
   "license": "GPL-3.0-or-later",

--- a/plugins/deskwork/.claude-plugin/plugin.json
+++ b/plugins/deskwork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Editorial calendar lifecycle for Claude Code — capture, plan, draft, publish, and distribute content through an agent-driven workflow",
   "homepage": "https://github.com/audiocontrol-org/deskwork",
   "repository": "https://github.com/audiocontrol-org/deskwork",

--- a/plugins/deskwork/package.json
+++ b/plugins/deskwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Editorial calendar lifecycle plugin for Claude Code — thin shell pointing at @deskwork/cli",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary

Bumps the marketplace + every plugin/package to **v0.2.0**.

Touches 9 manifests:
- root `package.json`
- `packages/{core,cli,studio}/package.json`
- `plugins/{deskwork,deskwork-studio}/package.json`
- `plugins/{deskwork,deskwork-studio}/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (top-level + per-plugin entries)

## Why 0.2.0 (not 0.1.1)

Per `RELEASING.md`: minor bump for new user-visible capability. Since v0.1.0:

- **Tailscale auto-detection** in `deskwork-studio` — studio binds to loopback + any detected Tailscale interface, reachable on the magic-DNS hostname without flags. New `--no-tailscale` opt-out and `--host <addr>` override (#12)
- **Install ergonomics** — `/deskwork:install` now defaults `<project-root>` to `process.cwd()` (#12)
- **Studio port** changed from 4321 → 47321 to dodge the Astro dev server collision (#12)
- **CI hygiene** — `npm --workspaces --if-present test` skips workspaces with no test script (#9)

These are additive/backward-compatible behavior changes — minor, not patch.

## Test plan

- [ ] `gh pr merge` → squash to main
- [ ] `git tag -a v0.2.0 origin/main -m "Release v0.2.0" && git push origin v0.2.0`
- [ ] `release.yml` workflow runs to completion
- [ ] GitHub release page lands at `releases/tag/v0.2.0`
- [ ] `/plugin marketplace update deskwork` in a fresh project pulls v0.2.0
