### PR TITLE
feat(cli): add 'deskwork ingest' for backfilling existing content (#15)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Open-source Claude Code plugins — editorial calendar, feature images, analytics",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,13 +14,13 @@
       "name": "deskwork",
       "source": "./plugins/deskwork",
       "description": "Editorial calendar lifecycle: capture, plan, draft, publish, distribute",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     {
       "name": "deskwork-studio",
       "source": "./plugins/deskwork-studio",
       "description": "Web studio for deskwork — dashboard, longform review, scrapbook, manual. Optional companion to the deskwork plugin",
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Open-source Claude Code plugins — editorial calendar, feature images, analytics",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,13 +14,13 @@
       "name": "deskwork",
       "source": "./plugins/deskwork",
       "description": "Editorial calendar lifecycle: capture, plan, draft, publish, distribute",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "name": "deskwork-studio",
       "source": "./plugins/deskwork-studio",
       "description": "Web studio for deskwork — dashboard, longform review, scrapbook, manual. Optional companion to the deskwork plugin",
-      "version": "0.1.0"
+      "version": "0.2.0"
     }
   ]
 }

--- a/.claude/skills/feature-pickup/SKILL.md
+++ b/.claude/skills/feature-pickup/SKILL.md
@@ -25,8 +25,14 @@ user_invocable: true
 5. **Read feature README:**
    - Read: `docs/1.0/001-IN-PROGRESS/<slug>/README.md`
 
-6. **Report to user:**
-   - Feature, branch, progress, current phase, next task, open issues, last session summary
-   - Proposed approach for this session
+6. **Plan sub-agent delegation for the proposed approach:**
+   - Consult the **Sub-Agent Delegation** table in `.claude/CLAUDE.md` and map each chunk of work to its specialist (e.g. TypeScript implementation → `typescript-pro`; SKILL.md prose → `documentation-engineer`; multi-chunk implementation with PR delivery → `feature-orchestrator`).
+   - Default to delegating: per the project's "Before Committing" checklist, *"Could this task have been delegated to a sub-agent?"* is the leading question. The default answer is yes. The `[PROCESS] didn't delegate` correction in `.claude/rules/session-analytics.md` exists because in-thread implementation is a recurring failure mode.
+   - When in doubt — multi-chunk feature work, anything that crosses package boundaries, anything matching a row in the delegation table — pick `feature-orchestrator` and let it dispatch the specialists.
+   - Keep work in-thread only for trivial single-file edits, doc-only changes, or skill/workplan updates where delegation overhead exceeds the task itself.
 
-7. **Wait for confirmation** — do NOT start implementation.
+7. **Report to user:**
+   - Feature, branch, progress, current phase, next task, open issues, last session summary
+   - Proposed approach **including which sub-agents will own which chunks** (or an explicit note that the work is small enough to keep in-thread)
+
+8. **Wait for confirmation** — do NOT start implementation.

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -24,10 +24,16 @@ Read the following and report a concise summary to the user:
 4. **Check open GitHub issues**:
    - Run: `gh issue list --state open`
 
-5. **Report to the user**:
+5. **Plan sub-agent delegation for the proposed goal:**
+   - Consult the **Sub-Agent Delegation** table in `.claude/CLAUDE.md` and map each chunk of work to its specialist (e.g. TypeScript implementation → `typescript-pro`; SKILL.md prose → `documentation-engineer`; multi-chunk implementation with PR delivery → `feature-orchestrator`).
+   - Default to delegating: per the project's "Before Committing" checklist, *"Could this task have been delegated to a sub-agent?"* is the leading question. The default answer is yes. The `[PROCESS] didn't delegate` correction in `.claude/rules/session-analytics.md` exists because in-thread implementation is a recurring failure mode.
+   - When in doubt — multi-chunk feature work, anything that crosses package boundaries, anything matching a row in the delegation table — pick `feature-orchestrator` and let it dispatch the specialists.
+   - Keep work in-thread only for trivial single-file edits, doc-only changes, or skill/workplan updates where delegation overhead exceeds the task itself.
+
+6. **Report to the user**:
    - Feature name and current phase
    - Last session's key accomplishments and failures
    - Top unresolved issues
-   - Proposed goal for this session
+   - Proposed goal for this session **including which sub-agents will own which chunks** (or an explicit note that the work is small enough to keep in-thread)
 
 Do NOT start coding until the user confirms the session goal.

--- a/docs/1.0/001-IN-PROGRESS/deskwork-plugin/README.md
+++ b/docs/1.0/001-IN-PROGRESS/deskwork-plugin/README.md
@@ -21,7 +21,7 @@ Extract the editorial calendar skills from audiocontrol.org into an open-source 
 | 12 | End-to-end dogfood (CLI + studio) against sandbox | Complete |
 | 13 | Hierarchical content + scrapbook secret subdir | Complete |
 | 14 | Versioning, release process, and build correctness | Complete (v0.1.0, v0.2.0 released) |
-| 15 | `deskwork ingest` — backfill existing content into calendar | Not started ([#15](https://github.com/audiocontrol-org/deskwork/issues/15)) |
+| 15 | `deskwork ingest` — backfill existing content into calendar | Complete ([#15](https://github.com/audiocontrol-org/deskwork/issues/15), [PR #17](https://github.com/audiocontrol-org/deskwork/pull/17)) |
 
 ### Key Links
 

--- a/docs/1.0/001-IN-PROGRESS/deskwork-plugin/README.md
+++ b/docs/1.0/001-IN-PROGRESS/deskwork-plugin/README.md
@@ -20,7 +20,8 @@ Extract the editorial calendar skills from audiocontrol.org into an open-source 
 | 11 | Add deskwork-studio plugin shell + marketplace entry | Complete |
 | 12 | End-to-end dogfood (CLI + studio) against sandbox | Complete |
 | 13 | Hierarchical content + scrapbook secret subdir | Complete |
-| 14 | Versioning, release process, and build correctness | Not started |
+| 14 | Versioning, release process, and build correctness | Complete (v0.1.0, v0.2.0 released) |
+| 15 | `deskwork ingest` — backfill existing content into calendar | Not started ([#15](https://github.com/audiocontrol-org/deskwork/issues/15)) |
 
 ### Key Links
 

--- a/docs/1.0/001-IN-PROGRESS/deskwork-plugin/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/deskwork-plugin/prd.md
@@ -192,3 +192,36 @@ Three workstreams that share infrastructure (the `npm run build` invocation):
 - **Not a migration path for breaking changes.** When we eventually break a calendar format or config schema, that's a separate concern handled by the calendar parser's own backward-compat (which already does UUID backfill and column-presence detection).
 
 **Plan reference.** Approved during the `/feature-extend` invocation that produced Phase 14.
+
+---
+
+## Extension: backfill existing content via `deskwork ingest`
+
+Added as Phase 15. Issue: [#15](https://github.com/audiocontrol-org/deskwork/issues/15). Triggered while installing deskwork into writingcontrol.org, a literary site that already had three published essays — the calendar starts empty and there is no first-class way to populate it from existing content.
+
+### Why now
+
+The lifecycle is forward-only: every entry must enter at `add` (Ideas) and walk through `plan → outline → draft → publish`. Anyone adopting deskwork on a project that already has content hits this on day one. Today's workarounds are all bad: walking the lifecycle per file overwrites existing scaffolds (and stamps today's date on every transition); hand-editing the calendar bypasses the validated state machine and produces no journal entry; doing nothing leaves the calendar inaccurate forever.
+
+This is the kind of feature that can't be added later in a way that doesn't feel bolted-on, because it touches the calendar's row schema (provenance — `add` vs. `ingest`?), the journal (event shape), and the operator's mental model (when do I reach for `ingest` vs. `add`?). Better to land it before there's a body of users with their own ad-hoc backfill scripts.
+
+### Scope
+
+A new `deskwork ingest [<project-root>] [--site <slug>] [options] <path>...` subcommand. `<path>` accepts a single file, a directory walked recursively, a glob, or multiple of those in one call. For each discovered file:
+
+1. **Parse YAML frontmatter** (any frontmatter — no Astro-specific fields required).
+2. **Derive slug** from `--slug-from {frontmatter,path}` (default `path` — `<dir>/index.md` → parent dir name; Jekyll `YYYY-MM-DD-<slug>.md` recognized; otherwise filename) or explicit `--slug` (single-file only).
+3. **Derive state** from `--state-from {frontmatter,datePublished}` (default `frontmatter` — reads the `state:` field) or explicit `--state <ideas|planned|outlining|drafting|published>`.
+4. **Derive date** from frontmatter (`datePublished` then `date`), falling back to file mtime, falling back to today.
+5. **Idempotency**: skip slugs already in the calendar; report skipped + reason. `--force` overrides after operator manually reconciles.
+6. **Dry-run by default.** Print the plan; nothing on disk changes until `--apply`.
+
+Layout-agnostic discovery — `<slug>/index.md`, flat `<slug>.md`, dated `YYYY-MM-DD-<slug>.md`, Hugo leaf bundles, Eleventy `src/posts/`, Jekyll `_posts/`, Next.js `pages/blog/`, plain markdown notes folders all work without configuration. Frontmatter field names are configurable: `--title-field`, `--date-field`, `--state-field`, `--slug-field`.
+
+### What this is not
+
+- **Not a migration tool for other editorial-calendar formats.** Source is markdown files on disk + their frontmatter. Importing from Notion / Airtable / a different calendar markdown shape is a separate concern.
+- **Not a publishing-platform sync.** `ingest` reads the host project's content tree; it does not pull from Substack, Ghost, or RSS.
+- **Not auto-detection of the content tree.** The operator passes paths explicitly. Walking the entire repo to "discover" content is intentionally out of scope — too easy to scoop up `node_modules/` test fixtures, vendored docs, or unrelated markdown.
+
+**Plan reference.** Issue #15 design; expanded into Phase 15 of the workplan during this `/feature-extend` invocation.

--- a/docs/1.0/001-IN-PROGRESS/deskwork-plugin/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/deskwork-plugin/workplan.md
@@ -325,3 +325,39 @@ Tasks:
 - The CI workflow doubles as a regression gate — it runs the full test suite on every PR. If we add more packages later, the workflow's `npm --workspaces test` line scales without changes.
 - Release notes are auto-generated from commit messages between tags. We've been writing meaningful commit messages all along; that pays off here. No special prefix convention required.
 - Version bump is intentionally manual — the script writes, you review the diff and decide whether to commit. No "auto-publish on every merge" semantics.
+
+---
+
+### Phase 15: `deskwork ingest` — backfill existing content into the calendar
+
+**Deliverable:** A new `deskwork ingest` subcommand that walks a project's existing markdown/MDX files and populates the editorial calendar at the right stage, layout-agnostic. Closes [#15](https://github.com/audiocontrol-org/deskwork/issues/15).
+
+Tasks:
+- [ ] `packages/core/src/ingest.ts` — discovery primitive. Inputs: a list of paths (file, directory, glob). Outputs: `IngestCandidate[]` with `{ filePath, frontmatter, derivedSlug, derivedState, derivedDate, source: 'frontmatter'|'path'|'mtime'|'today' }`. Recursive directory walking + glob expansion. No mutations.
+- [ ] `packages/core/src/ingest.ts` — slug derivation. `<dir>/index.md` → parent dir name. Jekyll `YYYY-MM-DD-<slug>.md` recognized. Else filename minus extension. Slug field name configurable.
+- [ ] `packages/core/src/ingest.ts` — state derivation. `--state-from frontmatter` (default) reads `state:` field, normalizes to a calendar lane. `--state-from datePublished` infers from date relative to today. Unknown states report ambiguous; require `--state` override.
+- [ ] `packages/core/src/ingest.ts` — date derivation. Tries `datePublished`, then `date`, then file mtime, then today. Records the source.
+- [ ] `packages/core/src/ingest.ts` — idempotency. Filter candidates against the existing calendar; emit `IngestSkip[]` for duplicates with reason. `--force` bypasses after manual reconciliation.
+- [ ] `packages/cli/src/commands/ingest.ts` — dispatcher entry. Argv shape: `[<project-root>] [--site <slug>] [options] <path>...`. Parses flags, calls core, prints plan, applies on `--apply`.
+- [ ] `packages/cli/src/commands/ingest.ts` — dry-run output. Pretty-print the plan: per-file `{ slug, state, date, source-of-each, action: 'add'|'skip' }`. Single line per file. `--json` for machine-readable.
+- [ ] `packages/cli/src/commands/ingest.ts` — apply path. On `--apply`, write calendar rows via `addEntry` (or a new `bulkAddEntries`); also append a journal entry per ingested file (event shape: `'ingest'`, captures source frontmatter snapshot for provenance).
+- [ ] `plugins/deskwork/skills/ingest/SKILL.md` — operator-facing prompt. When to use ingest vs. add. The dry-run-first contract. Layout-agnostic discovery examples (Astro / Hugo / Jekyll / Eleventy / plain). Common flag combinations.
+- [ ] `packages/core/test/ingest.test.ts` — unit coverage for slug derivation, state derivation, date derivation, idempotency, frontmatter field-name overrides, glob expansion.
+- [ ] `packages/cli/test/ingest-integration.test.ts` — end-to-end against tmp project trees: Astro-shaped (`<slug>/index.md`), Hugo-shaped (leaf bundles), Jekyll-shaped (`YYYY-MM-DD-<slug>.md`), flat (`<slug>.md`), mixed states (published / draft / future-dated).
+
+**Acceptance Criteria:**
+- [ ] `deskwork ingest <path>` (no `--apply`) prints a complete plan to stdout and writes nothing to disk; exit 0 even if every file would be skipped (so it composes with shell pipelines).
+- [ ] `deskwork ingest <path> --apply` writes calendar rows for non-skipped candidates and journal entries with `event: 'ingest'`. Re-running the same command produces only "skipped" output (idempotent).
+- [ ] Discovery works against a synthetic Astro tree (`src/content/essays/<slug>/index.md`), Hugo tree (`content/posts/<slug>/index.md`), Jekyll tree (`_posts/2024-01-01-foo.md`), and flat tree (`posts/<slug>.md`) without per-tree configuration — only the path argument differs.
+- [ ] Files in `scrapbook/` are skipped by default. `blogFilenameTemplate` (when set on the site config) is used as a validation hint, not a hard filter — operators ingesting from a different layout than what new content uses still succeed.
+- [ ] Frontmatter with unrecognized `state:` values produces a "state ambiguous" report; the operator can re-run with `--state <known-lane>` to commit.
+- [ ] Slug collision with an existing calendar row reports skipped + reason; `--force` overrides.
+- [ ] writingcontrol.org dogfood: ingesting `src/content/essays/` lands the three known essays in the right lanes (`whats-in-a-name` + `the-deskwork-experiment` → Published with their `datePublished` values; `on-revising-in-the-open` → Drafting with placeholder date).
+
+**Notes:**
+- The `state:` frontmatter field is project-specific. Default mapping: `published` → Published, `draft` → Drafting, `outline`/`outlining` → Outlining, `planned` → Planned, `idea`/`ideas` → Ideas. Anything else is ambiguous and requires an explicit `--state` override.
+- The journal entry on ingest is what makes a row reviewable later. Without it, a `review-start` against an ingested slug would have no provenance to anchor against.
+- `--apply` is a single global flag, not per-file. Keeps the dry-run discipline coherent: either all of nothing happens, or all of it happens.
+- Glob handling uses Node 22+ built-in `fs.glob` (already in use elsewhere in the codebase) rather than adding a new dependency.
+
+**GitHub tracking:** [#15](https://github.com/audiocontrol-org/deskwork/issues/15) is the implementation issue.

--- a/docs/1.0/001-IN-PROGRESS/deskwork-plugin/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/deskwork-plugin/workplan.md
@@ -333,26 +333,26 @@ Tasks:
 **Deliverable:** A new `deskwork ingest` subcommand that walks a project's existing markdown/MDX files and populates the editorial calendar at the right stage, layout-agnostic. Closes [#15](https://github.com/audiocontrol-org/deskwork/issues/15).
 
 Tasks:
-- [ ] `packages/core/src/ingest.ts` — discovery primitive. Inputs: a list of paths (file, directory, glob). Outputs: `IngestCandidate[]` with `{ filePath, frontmatter, derivedSlug, derivedState, derivedDate, source: 'frontmatter'|'path'|'mtime'|'today' }`. Recursive directory walking + glob expansion. No mutations.
-- [ ] `packages/core/src/ingest.ts` — slug derivation. `<dir>/index.md` → parent dir name. Jekyll `YYYY-MM-DD-<slug>.md` recognized. Else filename minus extension. Slug field name configurable.
-- [ ] `packages/core/src/ingest.ts` — state derivation. `--state-from frontmatter` (default) reads `state:` field, normalizes to a calendar lane. `--state-from datePublished` infers from date relative to today. Unknown states report ambiguous; require `--state` override.
-- [ ] `packages/core/src/ingest.ts` — date derivation. Tries `datePublished`, then `date`, then file mtime, then today. Records the source.
-- [ ] `packages/core/src/ingest.ts` — idempotency. Filter candidates against the existing calendar; emit `IngestSkip[]` for duplicates with reason. `--force` bypasses after manual reconciliation.
-- [ ] `packages/cli/src/commands/ingest.ts` — dispatcher entry. Argv shape: `[<project-root>] [--site <slug>] [options] <path>...`. Parses flags, calls core, prints plan, applies on `--apply`.
-- [ ] `packages/cli/src/commands/ingest.ts` — dry-run output. Pretty-print the plan: per-file `{ slug, state, date, source-of-each, action: 'add'|'skip' }`. Single line per file. `--json` for machine-readable.
-- [ ] `packages/cli/src/commands/ingest.ts` — apply path. On `--apply`, write calendar rows via `addEntry` (or a new `bulkAddEntries`); also append a journal entry per ingested file (event shape: `'ingest'`, captures source frontmatter snapshot for provenance).
-- [ ] `plugins/deskwork/skills/ingest/SKILL.md` — operator-facing prompt. When to use ingest vs. add. The dry-run-first contract. Layout-agnostic discovery examples (Astro / Hugo / Jekyll / Eleventy / plain). Common flag combinations.
-- [ ] `packages/core/test/ingest.test.ts` — unit coverage for slug derivation, state derivation, date derivation, idempotency, frontmatter field-name overrides, glob expansion.
-- [ ] `packages/cli/test/ingest-integration.test.ts` — end-to-end against tmp project trees: Astro-shaped (`<slug>/index.md`), Hugo-shaped (leaf bundles), Jekyll-shaped (`YYYY-MM-DD-<slug>.md`), flat (`<slug>.md`), mixed states (published / draft / future-dated).
+- [x] `packages/core/src/ingest.ts` — discovery primitive. Inputs: a list of paths (file, directory, glob). Outputs: `IngestCandidate[]` with `{ filePath, frontmatter, derivedSlug, derivedState, derivedDate, source: 'frontmatter'|'path'|'mtime'|'today' }`. Recursive directory walking + glob expansion. No mutations.
+- [x] `packages/core/src/ingest.ts` — slug derivation. `<dir>/index.md` → parent dir name. Jekyll `YYYY-MM-DD-<slug>.md` recognized. Else filename minus extension. Slug field name configurable.
+- [x] `packages/core/src/ingest.ts` — state derivation. `--state-from frontmatter` (default) reads `state:` field, normalizes to a calendar lane. `--state-from datePublished` infers from date relative to today. Unknown states report ambiguous; require `--state` override.
+- [x] `packages/core/src/ingest.ts` — date derivation. Tries `datePublished`, then `date`, then file mtime, then today. Records the source.
+- [x] `packages/core/src/ingest.ts` — idempotency. Filter candidates against the existing calendar; emit `IngestSkip[]` for duplicates with reason. `--force` bypasses after manual reconciliation.
+- [x] `packages/cli/src/commands/ingest.ts` — dispatcher entry. Argv shape: `[<project-root>] [--site <slug>] [options] <path>...`. Parses flags, calls core, prints plan, applies on `--apply`.
+- [x] `packages/cli/src/commands/ingest.ts` — dry-run output. Pretty-print the plan: per-file `{ slug, state, date, source-of-each, action: 'add'|'skip' }`. Single line per file. `--json` for machine-readable.
+- [x] `packages/cli/src/commands/ingest.ts` — apply path. On `--apply`, write calendar rows via `addEntry` (or a new `bulkAddEntries`); also append a journal entry per ingested file (event shape: `'ingest'`, captures source frontmatter snapshot for provenance).
+- [x] `plugins/deskwork/skills/ingest/SKILL.md` — operator-facing prompt. When to use ingest vs. add. The dry-run-first contract. Layout-agnostic discovery examples (Astro / Hugo / Jekyll / Eleventy / plain). Common flag combinations.
+- [x] `packages/core/test/ingest.test.ts` — unit coverage for slug derivation, state derivation, date derivation, idempotency, frontmatter field-name overrides, glob expansion.
+- [x] `packages/cli/test/ingest-integration.test.ts` — end-to-end against tmp project trees: Astro-shaped (`<slug>/index.md`), Hugo-shaped (leaf bundles), Jekyll-shaped (`YYYY-MM-DD-<slug>.md`), flat (`<slug>.md`), mixed states (published / draft / future-dated).
 
 **Acceptance Criteria:**
-- [ ] `deskwork ingest <path>` (no `--apply`) prints a complete plan to stdout and writes nothing to disk; exit 0 even if every file would be skipped (so it composes with shell pipelines).
-- [ ] `deskwork ingest <path> --apply` writes calendar rows for non-skipped candidates and journal entries with `event: 'ingest'`. Re-running the same command produces only "skipped" output (idempotent).
-- [ ] Discovery works against a synthetic Astro tree (`src/content/essays/<slug>/index.md`), Hugo tree (`content/posts/<slug>/index.md`), Jekyll tree (`_posts/2024-01-01-foo.md`), and flat tree (`posts/<slug>.md`) without per-tree configuration — only the path argument differs.
-- [ ] Files in `scrapbook/` are skipped by default. `blogFilenameTemplate` (when set on the site config) is used as a validation hint, not a hard filter — operators ingesting from a different layout than what new content uses still succeed.
-- [ ] Frontmatter with unrecognized `state:` values produces a "state ambiguous" report; the operator can re-run with `--state <known-lane>` to commit.
-- [ ] Slug collision with an existing calendar row reports skipped + reason; `--force` overrides.
-- [ ] writingcontrol.org dogfood: ingesting `src/content/essays/` lands the three known essays in the right lanes (`whats-in-a-name` + `the-deskwork-experiment` → Published with their `datePublished` values; `on-revising-in-the-open` → Drafting with placeholder date).
+- [x] `deskwork ingest <path>` (no `--apply`) prints a complete plan to stdout and writes nothing to disk; exit 0 even if every file would be skipped (so it composes with shell pipelines).
+- [x] `deskwork ingest <path> --apply` writes calendar rows for non-skipped candidates and journal entries with `event: 'ingest'`. Re-running the same command produces only "skipped" output (idempotent).
+- [x] Discovery works against a synthetic Astro tree (`src/content/essays/<slug>/index.md`), Hugo tree (`content/posts/<slug>/index.md`), Jekyll tree (`_posts/2024-01-01-foo.md`), and flat tree (`posts/<slug>.md`) without per-tree configuration — only the path argument differs.
+- [x] Files in `scrapbook/` are skipped by default. `blogFilenameTemplate` (when set on the site config) is used as a validation hint, not a hard filter — operators ingesting from a different layout than what new content uses still succeed.
+- [x] Frontmatter with unrecognized `state:` values produces a "state ambiguous" report; the operator can re-run with `--state <known-lane>` to commit.
+- [x] Slug collision with an existing calendar row reports skipped + reason; `--force` overrides.
+- [x] writingcontrol.org dogfood: ingesting `src/content/essays/` lands the three known essays in the right lanes (`whats-in-a-name` + `the-deskwork-experiment` → Published with their `datePublished` values; `on-revising-in-the-open` → Drafting with placeholder date).
 
 **Notes:**
 - The `state:` frontmatter field is project-specific. Default mapping: `published` → Published, `draft` → Drafting, `outline`/`outlining` → Outlining, `planned` → Planned, `idea`/`ideas` → Ideas. Anything else is ambiguous and requires an explicit `--state` override.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Open-source Claude Code plugins monorepo — deskwork editorial calendar plugin, feature-image, analytics",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Open-source Claude Code plugins monorepo — deskwork editorial calendar plugin, feature-image, analytics",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Editorial calendar + review CLI for the deskwork plugin",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Editorial calendar + review CLI for the deskwork plugin",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,6 +20,7 @@ const SUBCOMMANDS: Record<string, () => Promise<{ run: (argv: string[]) => Promi
   add: () => import('./commands/add.ts'),
   approve: () => import('./commands/approve.ts'),
   draft: () => import('./commands/draft.ts'),
+  ingest: () => import('./commands/ingest.ts'),
   install: () => import('./commands/install.ts'),
   iterate: () => import('./commands/iterate.ts'),
   outline: () => import('./commands/outline.ts'),
@@ -72,6 +73,7 @@ function printUsage(): void {
   out.write('Usage: deskwork <subcommand> [args...]\n\n');
   out.write('Lifecycle:\n');
   out.write('  install         bootstrap deskwork in a project\n');
+  out.write('  ingest          backfill existing markdown into the calendar\n');
   out.write('  add             append an idea to the calendar\n');
   out.write('  plan            move Ideas → Planned with keywords\n');
   out.write('  outline         scaffold + move Planned → Outlining\n');

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -1,0 +1,412 @@
+/**
+ * deskwork ingest — backfill existing markdown content into the editorial
+ * calendar.
+ *
+ * Discovery is the heavy lifting; this module is the CLI surface around
+ * `discoverIngestCandidates` from @deskwork/core/ingest.
+ *
+ * Argv shape (after the dispatcher injects projectRoot when needed):
+ *
+ *   <project-root> [flags] <path>...
+ *
+ * Flags:
+ *   --site <slug>             Target site (defaults to config.defaultSite)
+ *   --apply                   Commit the plan; default is dry-run
+ *   --json                    Machine-readable plan output
+ *   --force                   Bypass duplicate-slug skip
+ *   --slug-from <where>       'frontmatter' or 'path' (default 'path')
+ *   --state-from <where>      'frontmatter' (default) or 'datePublished'
+ *   --slug <value>            Explicit slug (only with single-file ingest)
+ *   --state <stage>           Explicit stage; wins over derivation
+ *   --date <YYYY-MM-DD>       Explicit ISO date; wins over derivation
+ *   --title-field <name>      Frontmatter field for title (default: title)
+ *   --description-field <n>   Frontmatter field for description
+ *                             (default: description)
+ *   --slug-field <name>       Frontmatter field for slug (default: slug)
+ *   --state-field <name>      Frontmatter field for state (default: state)
+ *   --date-field <name>       Frontmatter field for date (default:
+ *                             datePublished)
+ *
+ * Dry-run output (text mode):
+ *
+ *   Plan: 3 add, 1 skip
+ *
+ *   add  whats-in-a-name             Published  2020-10-01    state:fm date:fm slug:path
+ *   add  the-deskwork-experiment     Published  2026-04-20    state:fm date:fm slug:path
+ *   skip on-revising-in-the-open                              already in calendar
+ *
+ * `--apply` writes calendar rows for non-skipped candidates and appends
+ * a journal entry per ingested file (`event: 'ingest'`) so a future
+ * review-start has provenance to anchor against.
+ */
+
+import { existsSync, mkdirSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { readConfig } from '@deskwork/core/config';
+import { readCalendar, writeCalendar } from '@deskwork/core/calendar';
+import { resolveSite, resolveCalendarPath, resolveContentDir } from '@deskwork/core/paths';
+import { isStage, type CalendarEntry, type Stage } from '@deskwork/core/types';
+import { absolutize, fail, parseArgs } from '@deskwork/core/cli-args';
+import { appendJournal } from '@deskwork/core/journal';
+import {
+  candidateToEntry,
+  discoverIngestCandidates,
+  type IngestCandidate,
+  type IngestSkip,
+  type SlugFrom,
+  type StateFrom,
+} from '@deskwork/core/ingest';
+
+const KNOWN_FLAGS = [
+  'site',
+  'slug-from',
+  'state-from',
+  'slug',
+  'state',
+  'date',
+  'title-field',
+  'description-field',
+  'slug-field',
+  'state-field',
+  'date-field',
+] as const;
+
+const BOOLEAN_FLAGS = ['apply', 'json', 'force'] as const;
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function run(argv: string[]): Promise<void> {
+  const { positional, flags, booleans } = parseInput(argv);
+
+  if (positional.length < 2) {
+    fail(
+      'Usage: deskwork ingest <project-root> [--site <slug>] [--apply] [--json] ' +
+        '[--force] [--slug-from frontmatter|path] [--state-from frontmatter|datePublished] ' +
+        '[--slug <s>] [--state <stage>] [--date YYYY-MM-DD] [--title-field <n>] ' +
+        '[--description-field <n>] [--slug-field <n>] [--state-field <n>] ' +
+        '[--date-field <n>] <path>...',
+      2,
+    );
+  }
+
+  const [rootArg, ...paths] = positional;
+  const projectRoot = absolutize(rootArg);
+
+  const slugFrom = parseSlugFrom(flags['slug-from']);
+  const stateFrom = parseStateFrom(flags['state-from']);
+  const explicitState = parseExplicitState(flags.state);
+  const explicitDate = parseExplicitDate(flags.date);
+
+  let config;
+  try {
+    config = readConfig(projectRoot);
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err));
+  }
+
+  const site = resolveSite(config, flags.site);
+  const calendarPath = resolveCalendarPath(projectRoot, config, site);
+  const calendar = readCalendar(calendarPath);
+
+  // Build absolute path arguments. Relative paths resolve against
+  // the project root (not cwd) — the operator's mental model is
+  // "paths inside this project", and the dispatcher's cwd may differ
+  // from the project root in tests / scripted invocations.
+  const absolutePaths = paths.map((p) =>
+    isAbsolute(p) ? p : resolve(projectRoot, p),
+  );
+
+  // Compute scrapbook root for the resolved site so files under it
+  // are skipped by default (operators have to explicitly opt in to
+  // ingest a sketchpad — `deskwork ingest content/scrapbook/` works
+  // because absolutePaths goes through the scrapbook check on a
+  // file-by-file basis, not on the discovery root).
+  const contentDir = resolveContentDir(projectRoot, config, site);
+  const scrapbookRoots = [join(contentDir, 'scrapbook')];
+
+  let discovery;
+  try {
+    discovery = discoverIngestCandidates(absolutePaths, {
+      projectRoot,
+      ...(slugFrom !== undefined ? { slugFrom } : {}),
+      ...(stateFrom !== undefined ? { stateFrom } : {}),
+      ...(flags.slug !== undefined ? { explicitSlug: flags.slug } : {}),
+      ...(explicitState !== undefined ? { explicitState } : {}),
+      ...(explicitDate !== undefined ? { explicitDate } : {}),
+      fieldNames: buildFieldNames(flags),
+      calendar,
+      ...(booleans.has('force') ? { force: true } : {}),
+      scrapbookRoots,
+    });
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err), 2);
+  }
+
+  // Split candidates into actionable vs. ambiguous-state. Ambiguous
+  // ones don't get applied without an explicit --state — emit them
+  // as skips with an actionable reason.
+  const ambiguous: IngestSkip[] = [];
+  const actionable: { candidate: IngestCandidate; stage: Stage }[] = [];
+  for (const c of discovery.candidates) {
+    if (c.derivedState === null) {
+      ambiguous.push({
+        filePath: c.filePath,
+        relativePath: c.relativePath,
+        slug: c.derivedSlug,
+        reason: `state ambiguous (raw frontmatter value: "${c.rawState ?? ''}"); pass --state <stage> to commit`,
+      });
+      continue;
+    }
+    actionable.push({ candidate: c, stage: c.derivedState });
+  }
+
+  const allSkips = [...discovery.skips, ...ambiguous];
+
+  if (booleans.has('json')) {
+    emitJsonPlan({
+      apply: booleans.has('apply'),
+      site,
+      calendarPath,
+      add: actionable.map((a) => candidatePlanRecord(a.candidate, a.stage)),
+      skip: allSkips,
+    });
+  } else {
+    emitTextPlan({
+      apply: booleans.has('apply'),
+      add: actionable,
+      skip: allSkips,
+    });
+  }
+
+  if (!booleans.has('apply')) return;
+
+  // Apply path: append entries and write journal records. The
+  // calendar is written once at the end so a partial run does not
+  // leave a torn calendar file.
+  for (const { candidate, stage } of actionable) {
+    const id = randomUUID();
+    const entry: CalendarEntry = { id, ...candidateToEntry(candidate, stage) };
+    calendar.entries.push(entry);
+    writeIngestJournalEntry(projectRoot, config, site, candidate, entry);
+  }
+  writeCalendar(calendarPath, calendar);
+}
+
+// ---------------------------------------------------------------------------
+// Argv parsing
+// ---------------------------------------------------------------------------
+
+function parseInput(argv: string[]) {
+  try {
+    return parseArgs(argv, KNOWN_FLAGS, BOOLEAN_FLAGS);
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err), 2);
+  }
+}
+
+function parseSlugFrom(value: string | undefined): SlugFrom | undefined {
+  if (value === undefined) return undefined;
+  if (value !== 'frontmatter' && value !== 'path') {
+    fail(`--slug-from must be 'frontmatter' or 'path' (got "${value}")`, 2);
+  }
+  return value;
+}
+
+function parseStateFrom(value: string | undefined): StateFrom | undefined {
+  if (value === undefined) return undefined;
+  if (value !== 'frontmatter' && value !== 'datePublished') {
+    fail(
+      `--state-from must be 'frontmatter' or 'datePublished' (got "${value}")`,
+      2,
+    );
+  }
+  return value;
+}
+
+function parseExplicitState(value: string | undefined): Stage | undefined {
+  if (value === undefined) return undefined;
+  // Accept the case-insensitive lane name as the operator types it.
+  const normalized = value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+  if (!isStage(normalized)) {
+    fail(
+      `--state must be one of Ideas, Planned, Outlining, Drafting, Review, Published ` +
+        `(got "${value}")`,
+      2,
+    );
+  }
+  return normalized;
+}
+
+function parseExplicitDate(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  if (!DATE_RE.test(value)) {
+    fail(`--date must match YYYY-MM-DD (got "${value}")`, 2);
+  }
+  return value;
+}
+
+function buildFieldNames(flags: Record<string, string>): {
+  title?: string;
+  description?: string;
+  slug?: string;
+  state?: string;
+  date?: string;
+} {
+  const out: {
+    title?: string;
+    description?: string;
+    slug?: string;
+    state?: string;
+    date?: string;
+  } = {};
+  if (flags['title-field'] !== undefined) out.title = flags['title-field'];
+  if (flags['description-field'] !== undefined) out.description = flags['description-field'];
+  if (flags['slug-field'] !== undefined) out.slug = flags['slug-field'];
+  if (flags['state-field'] !== undefined) out.state = flags['state-field'];
+  if (flags['date-field'] !== undefined) out.date = flags['date-field'];
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Plan output
+// ---------------------------------------------------------------------------
+
+interface PlanRecord {
+  action: 'add';
+  slug: string;
+  title: string;
+  stage: Stage;
+  date: string;
+  filePath: string;
+  relativePath: string;
+  sources: {
+    slug: string;
+    state: string;
+    date: string;
+  };
+}
+
+function candidatePlanRecord(c: IngestCandidate, stage: Stage): PlanRecord {
+  return {
+    action: 'add',
+    slug: c.derivedSlug,
+    title: c.title,
+    stage,
+    date: c.derivedDate,
+    filePath: c.filePath,
+    relativePath: c.relativePath,
+    sources: {
+      slug: c.slugSource,
+      state: c.stateSource,
+      date: c.dateSource,
+    },
+  };
+}
+
+function emitJsonPlan(plan: {
+  apply: boolean;
+  site: string;
+  calendarPath: string;
+  add: PlanRecord[];
+  skip: IngestSkip[];
+}): void {
+  process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+}
+
+function emitTextPlan(plan: {
+  apply: boolean;
+  add: { candidate: IngestCandidate; stage: Stage }[];
+  skip: IngestSkip[];
+}): void {
+  const heading = plan.apply
+    ? `Applying: ${plan.add.length} add, ${plan.skip.length} skip`
+    : `Plan: ${plan.add.length} add, ${plan.skip.length} skip (dry-run; pass --apply to commit)`;
+  process.stdout.write(`${heading}\n\n`);
+
+  for (const { candidate, stage } of plan.add) {
+    const sources =
+      `slug:${candidate.slugSource} state:${candidate.stateSource} date:${candidate.dateSource}`;
+    process.stdout.write(
+      `add  ${pad(candidate.derivedSlug, 36)}  ${pad(stage, 10)}  ${pad(candidate.derivedDate, 12)}  ${sources}\n`,
+    );
+  }
+  for (const skip of plan.skip) {
+    const slug = skip.slug ?? '(no slug)';
+    process.stdout.write(`skip ${pad(slug, 36)}  ${skip.reason}\n`);
+  }
+}
+
+function pad(s: string, n: number): string {
+  if (s.length >= n) return s;
+  return s + ' '.repeat(n - s.length);
+}
+
+// ---------------------------------------------------------------------------
+// Journal write on apply
+// ---------------------------------------------------------------------------
+
+interface IngestJournalRecord {
+  id: string;
+  timestamp: string;
+  event: 'ingest';
+  /** Slug recorded on the calendar row. */
+  slug: string;
+  /** Stable UUID of the calendar row. */
+  entryId: string;
+  /** Site the row was added to. */
+  site: string;
+  /** Stage the row was added at. */
+  stage: Stage;
+  /** Path to the source markdown file, relative to project root. */
+  sourceFile: string;
+  /** Snapshot of the source frontmatter for provenance. */
+  frontmatterSnapshot: Record<string, unknown>;
+  /** Where each derived field came from. */
+  derivation: {
+    slug: string;
+    state: string;
+    date: string;
+  };
+}
+
+/**
+ * Append a journal record under `<reviewJournalDir>/ingest/` so a
+ * later review-start (or audit) can find provenance for the ingested
+ * row. We reuse the existing journal infrastructure rather than
+ * inventing a new dir — review-journal already uses one-file-per-event
+ * shape that a tight-fit for ingest events.
+ */
+function writeIngestJournalEntry(
+  projectRoot: string,
+  config: ReturnType<typeof readConfig>,
+  site: string,
+  candidate: IngestCandidate,
+  entry: CalendarEntry,
+): void {
+  const journalRoot = join(
+    projectRoot,
+    config.reviewJournalDir ?? '.deskwork/review-journal',
+    'ingest',
+  );
+  if (!existsSync(journalRoot)) {
+    mkdirSync(journalRoot, { recursive: true });
+  }
+  const record: IngestJournalRecord = {
+    id: entry.id ?? randomUUID(),
+    timestamp: new Date().toISOString(),
+    event: 'ingest',
+    slug: entry.slug,
+    entryId: entry.id ?? '',
+    site,
+    stage: entry.stage,
+    sourceFile: candidate.relativePath,
+    frontmatterSnapshot: candidate.frontmatter,
+    derivation: {
+      slug: candidate.slugSource,
+      state: candidate.stateSource,
+      date: candidate.dateSource,
+    },
+  };
+  appendJournal(journalRoot, record);
+}

--- a/packages/cli/test/ingest-integration.test.ts
+++ b/packages/cli/test/ingest-integration.test.ts
@@ -1,0 +1,609 @@
+/**
+ * End-to-end integration tests for `deskwork ingest`.
+ *
+ * Each test spawns the real CLI binary against a tmp project bootstrapped
+ * via `deskwork install`. Layout matrix: Astro `<slug>/index.md`, Hugo
+ * leaf bundles, Jekyll `YYYY-MM-DD-<slug>.md`, and flat `<slug>.md`.
+ *
+ * Tests assert:
+ *   - dry-run prints a plan and writes nothing
+ *   - --apply commits rows + journal entries (idempotent on re-run)
+ *   - layout-agnostic discovery works across all four shapes
+ *   - state ambiguity is reported, not papered over
+ *   - --force overrides the duplicate skip
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCalendar } from '@deskwork/core/calendar';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(testDir, '../../..');
+const deskworkBin = join(workspaceRoot, 'node_modules/.bin/deskwork');
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  json?: unknown;
+}
+
+function run(subcommand: string, args: string[]): RunResult {
+  const r = spawnSync(deskworkBin, [subcommand, ...args], { encoding: 'utf-8' });
+  const stdout = r.stdout ?? '';
+  let json: unknown;
+  try {
+    json = stdout.trim().length > 0 ? JSON.parse(stdout) : undefined;
+  } catch {
+    // Text mode plan output isn't JSON; tests that care assert via stdout.
+  }
+  return {
+    code: r.status ?? -1,
+    stdout,
+    stderr: r.stderr ?? '',
+    ...(json !== undefined ? { json } : {}),
+  };
+}
+
+let project: string;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'deskwork-ingest-int-'));
+  // Minimal config — ingest doesn't need blogLayout / author to write
+  // calendar rows, since the existing files already exist on disk.
+  const cfg = {
+    version: 1,
+    sites: {
+      main: {
+        host: 'example.com',
+        contentDir: 'src/content',
+        calendarPath: 'docs/calendar.md',
+      },
+    },
+  };
+  const cfgFile = join(project, 'config.tmp.json');
+  writeFileSync(cfgFile, JSON.stringify(cfg), 'utf-8');
+  const installRes = run('install', [project, cfgFile]);
+  if (installRes.code !== 0) {
+    throw new Error(`install failed: ${installRes.stderr || installRes.stdout}`);
+  }
+  rmSync(cfgFile);
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+});
+
+function write(rel: string, contents: string): string {
+  const abs = join(project, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, contents, 'utf-8');
+  return abs;
+}
+
+function readCalendarFile(): ReturnType<typeof parseCalendar> {
+  const raw = readFileSync(join(project, 'docs/calendar.md'), 'utf-8');
+  return parseCalendar(raw);
+}
+
+function journalDir(): string {
+  return join(project, '.deskwork/review-journal/ingest');
+}
+
+describe('deskwork ingest — dry-run defaults', () => {
+  it('prints a plan and writes nothing without --apply', () => {
+    write(
+      'src/content/posts/hello.md',
+      '---\ntitle: Hello\nstate: published\ndatePublished: 2024-01-15\n---\n\nbody',
+    );
+
+    const res = run('ingest', [project, 'src/content/posts/hello.md']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toMatch(/Plan: 1 add, 0 skip/);
+    expect(res.stdout).toMatch(/dry-run/);
+    expect(res.stdout).toMatch(/add\s+hello\s+Published/);
+
+    // Calendar still empty.
+    const cal = readCalendarFile();
+    expect(cal.entries).toHaveLength(0);
+    expect(existsSync(journalDir())).toBe(false);
+  });
+
+  it('exits 0 even when every file would be skipped', () => {
+    // duplicate against an existing entry
+    write(
+      'src/content/posts/dup.md',
+      '---\ntitle: Dup\nstate: published\ndatePublished: 2024-01-15\n---\n',
+    );
+    run('ingest', [project, '--apply', 'src/content/posts/dup.md']);
+    const res = run('ingest', [project, 'src/content/posts/dup.md']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toMatch(/Plan: 0 add, 1 skip/);
+    expect(res.stdout).toMatch(/already has an entry/);
+  });
+
+  it('emits JSON plan with --json', () => {
+    write(
+      'src/content/posts/world.md',
+      '---\ntitle: World\nstate: drafting\n---\n',
+    );
+    const res = run('ingest', [project, '--json', 'src/content/posts/world.md']);
+    expect(res.code).toBe(0);
+    expect(res.json).toMatchObject({
+      apply: false,
+      site: 'main',
+      add: [
+        {
+          action: 'add',
+          slug: 'world',
+          title: 'World',
+          stage: 'Drafting',
+          sources: { slug: 'path', state: 'frontmatter' },
+        },
+      ],
+      skip: [],
+    });
+  });
+});
+
+describe('deskwork ingest — --apply commits rows + journal', () => {
+  it('writes calendar rows and per-file journal entries', () => {
+    write(
+      'src/content/posts/one/index.md',
+      '---\ntitle: One\nstate: published\ndatePublished: 2024-01-01\n---\nbody',
+    );
+    write(
+      'src/content/posts/two/index.md',
+      '---\ntitle: Two\nstate: drafting\n---\nbody',
+    );
+
+    const res = run('ingest', [project, '--apply', 'src/content/posts']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toMatch(/Applying: 2 add, 0 skip/);
+
+    const cal = readCalendarFile();
+    expect(cal.entries).toHaveLength(2);
+    const one = cal.entries.find((e) => e.slug === 'one');
+    expect(one).toMatchObject({
+      slug: 'one',
+      title: 'One',
+      stage: 'Published',
+      datePublished: '2024-01-01',
+    });
+    const two = cal.entries.find((e) => e.slug === 'two');
+    expect(two).toMatchObject({ slug: 'two', stage: 'Drafting' });
+
+    // Journal: one record per ingested row.
+    const records = readdirSync(journalDir()).filter((f) => f.endsWith('.json'));
+    expect(records).toHaveLength(2);
+    const journaled = records.map((f) =>
+      JSON.parse(readFileSync(join(journalDir(), f), 'utf-8')),
+    );
+    expect(journaled.every((r) => r.event === 'ingest')).toBe(true);
+    expect(journaled.map((r) => r.slug).sort()).toEqual(['one', 'two']);
+    expect(journaled[0].frontmatterSnapshot).toBeDefined();
+  });
+
+  it('is idempotent — re-running produces only skips', () => {
+    write(
+      'src/content/posts/x/index.md',
+      '---\ntitle: X\nstate: published\ndatePublished: 2024-01-01\n---\n',
+    );
+    const first = run('ingest', [project, '--apply', 'src/content/posts']);
+    expect(first.code).toBe(0);
+    expect(first.stdout).toMatch(/Applying: 1 add, 0 skip/);
+
+    const second = run('ingest', [project, '--apply', 'src/content/posts']);
+    expect(second.code).toBe(0);
+    expect(second.stdout).toMatch(/Applying: 0 add, 1 skip/);
+    expect(second.stdout).toMatch(/already has an entry/);
+
+    const cal = readCalendarFile();
+    expect(cal.entries).toHaveLength(1);
+  });
+});
+
+describe('deskwork ingest — layout matrix', () => {
+  it('Astro: <slug>/index.md', () => {
+    write(
+      'src/content/essays/whats-in-a-name/index.md',
+      '---\ntitle: Whats In A Name\nstate: published\ndatePublished: 2020-10-01\n---\n',
+    );
+    write(
+      'src/content/essays/the-deskwork-experiment/index.md',
+      '---\ntitle: The Deskwork Experiment\nstate: published\ndatePublished: 2026-04-20\n---\n',
+    );
+    write(
+      'src/content/essays/on-revising-in-the-open/index.md',
+      '---\ntitle: On Revising In The Open\nstate: draft\ndatePublished: 2026-05-15\n---\n',
+    );
+
+    const res = run('ingest', [
+      project,
+      '--apply',
+      'src/content/essays',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries.map((e) => e.slug).sort()).toEqual([
+      'on-revising-in-the-open',
+      'the-deskwork-experiment',
+      'whats-in-a-name',
+    ]);
+    const whats = cal.entries.find((e) => e.slug === 'whats-in-a-name')!;
+    expect(whats.stage).toBe('Published');
+    expect(whats.datePublished).toBe('2020-10-01');
+    const revising = cal.entries.find((e) => e.slug === 'on-revising-in-the-open')!;
+    expect(revising.stage).toBe('Drafting');
+  });
+
+  it('Hugo: leaf bundles under content/posts/', () => {
+    write(
+      'src/content/posts/first/index.md',
+      '---\ntitle: First\nstate: published\ndatePublished: 2023-02-02\n---\n',
+    );
+    write(
+      'src/content/posts/second/index.md',
+      '---\ntitle: Second\nstate: published\ndatePublished: 2023-03-03\n---\n',
+    );
+
+    const res = run('ingest', [project, '--apply', 'src/content/posts']);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries.map((e) => e.slug).sort()).toEqual(['first', 'second']);
+  });
+
+  it('Jekyll: _posts/YYYY-MM-DD-slug.md', () => {
+    write(
+      '_posts/2024-01-15-hello-world.md',
+      '---\ntitle: Hello World\nstate: published\n---\n',
+    );
+    write(
+      '_posts/2024-02-20-second-post.md',
+      '---\ntitle: Second Post\nstate: published\n---\n',
+    );
+
+    const res = run('ingest', [project, '--apply', '_posts']);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries.map((e) => e.slug).sort()).toEqual([
+      'hello-world',
+      'second-post',
+    ]);
+  });
+
+  it('flat: <slug>.md', () => {
+    write(
+      'src/content/blog/foo.md',
+      '---\ntitle: Foo\nstate: published\ndatePublished: 2022-06-15\n---\n',
+    );
+    write(
+      'src/content/blog/bar.md',
+      '---\ntitle: Bar\nstate: drafting\n---\n',
+    );
+
+    const res = run('ingest', [project, '--apply', 'src/content/blog']);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries.map((e) => e.slug).sort()).toEqual(['bar', 'foo']);
+    expect(cal.entries.find((e) => e.slug === 'foo')!.stage).toBe('Published');
+    expect(cal.entries.find((e) => e.slug === 'bar')!.stage).toBe('Drafting');
+  });
+
+  it('hierarchical: nested content nodes with own index.md', () => {
+    write(
+      'src/content/the-outbound/index.md',
+      '---\ntitle: The Outbound\nstate: drafting\n---\n',
+    );
+    write(
+      'src/content/the-outbound/characters/index.md',
+      '---\ntitle: Characters\nstate: drafting\n---\n',
+    );
+    write(
+      'src/content/the-outbound/characters/strivers/index.md',
+      '---\ntitle: Strivers\nstate: drafting\n---\n',
+    );
+
+    const res = run('ingest', [
+      project,
+      '--apply',
+      'src/content/the-outbound',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    const slugs = cal.entries.map((e) => e.slug).sort();
+    expect(slugs).toEqual([
+      'the-outbound',
+      'the-outbound/characters',
+      'the-outbound/characters/strivers',
+    ]);
+  });
+});
+
+describe('deskwork ingest — state derivation overrides', () => {
+  it('reports ambiguous state and refuses to apply that row', () => {
+    write(
+      'src/content/posts/weird.md',
+      '---\ntitle: Weird\nstate: published-elsewhere\n---\n',
+    );
+
+    const res = run('ingest', [project, '--apply', 'src/content/posts/weird.md']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toMatch(/Applying: 0 add, 1 skip/);
+    expect(res.stdout).toMatch(/state ambiguous/);
+    const cal = readCalendarFile();
+    expect(cal.entries).toHaveLength(0);
+  });
+
+  it('--state override commits an ambiguous-state file', () => {
+    write(
+      'src/content/posts/weird.md',
+      '---\ntitle: Weird\nstate: published-elsewhere\n---\n',
+    );
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--state',
+      'Published',
+      '--date',
+      '2020-01-01',
+      'src/content/posts/weird.md',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries).toHaveLength(1);
+    expect(cal.entries[0].stage).toBe('Published');
+    expect(cal.entries[0].datePublished).toBe('2020-01-01');
+  });
+
+  it('--state-from datePublished + future date → Drafting', () => {
+    write(
+      'src/content/posts/future.md',
+      '---\ntitle: Future\ndatePublished: 2099-01-01\n---\n',
+    );
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--state-from',
+      'datePublished',
+      'src/content/posts/future.md',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries[0].stage).toBe('Drafting');
+  });
+
+  it('--force bypasses duplicate skip', () => {
+    write(
+      'src/content/posts/foo.md',
+      '---\ntitle: Foo\nstate: published\ndatePublished: 2024-01-01\n---\n',
+    );
+    run('ingest', [project, '--apply', 'src/content/posts/foo.md']);
+
+    const second = run('ingest', [
+      project,
+      '--apply',
+      '--force',
+      'src/content/posts/foo.md',
+    ]);
+    expect(second.code).toBe(0);
+    expect(second.stdout).toMatch(/Applying: 1 add, 0 skip/);
+
+    // Two rows now (force is the operator's choice — the apply layer
+    // does not deduplicate after force).
+    const cal = readCalendarFile();
+    expect(cal.entries).toHaveLength(2);
+  });
+});
+
+describe('deskwork ingest — flag overrides', () => {
+  it('--slug-from frontmatter reads the slug field', () => {
+    write(
+      'src/content/posts/anything.md',
+      '---\ntitle: Whatever\nslug: my-real-slug\nstate: drafting\n---\n',
+    );
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--slug-from',
+      'frontmatter',
+      'src/content/posts/anything.md',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries[0].slug).toBe('my-real-slug');
+  });
+
+  it('--slug overrides for single-file ingest', () => {
+    write(
+      'src/content/posts/x.md',
+      '---\ntitle: X\nstate: drafting\n---\n',
+    );
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--slug',
+      'manual-override',
+      'src/content/posts/x.md',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries[0].slug).toBe('manual-override');
+  });
+
+  it('rejects --slug with multiple matched files', () => {
+    write('src/content/posts/a.md', '---\ntitle: A\nstate: drafting\n---\n');
+    write('src/content/posts/b.md', '---\ntitle: B\nstate: drafting\n---\n');
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--slug',
+      'foo',
+      'src/content/posts',
+    ]);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toMatch(/exactly one matched file/);
+  });
+
+  it('--state-field reads a custom frontmatter field', () => {
+    write(
+      'src/content/posts/p.md',
+      '---\ntitle: P\nstatus: draft\n---\n',
+    );
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--state-field',
+      'status',
+      'src/content/posts/p.md',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries[0].stage).toBe('Drafting');
+  });
+
+  it('--date-field reads a custom frontmatter field', () => {
+    write(
+      'src/content/posts/p.md',
+      '---\ntitle: P\nstate: published\nshippedOn: 2018-03-03\n---\n',
+    );
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--date-field',
+      'shippedOn',
+      'src/content/posts/p.md',
+    ]);
+    expect(res.code).toBe(0);
+
+    const cal = readCalendarFile();
+    expect(cal.entries[0].datePublished).toBe('2018-03-03');
+  });
+
+  it('--site routes to a non-default site', () => {
+    // Re-bootstrap with a multi-site config.
+    rmSync(project, { recursive: true, force: true });
+    project = mkdtempSync(join(tmpdir(), 'deskwork-ingest-int-'));
+    const cfg = {
+      version: 1,
+      sites: {
+        main: {
+          host: 'main.example.com',
+          contentDir: 'src/sites/main/content',
+          calendarPath: 'docs/calendar-main.md',
+        },
+        secondary: {
+          host: 'second.example.com',
+          contentDir: 'src/sites/secondary/content',
+          calendarPath: 'docs/calendar-secondary.md',
+        },
+      },
+      defaultSite: 'main',
+    };
+    const cfgFile = join(project, 'config.tmp.json');
+    writeFileSync(cfgFile, JSON.stringify(cfg), 'utf-8');
+    run('install', [project, cfgFile]);
+    rmSync(cfgFile);
+
+    write(
+      'src/sites/secondary/content/posts/foo.md',
+      '---\ntitle: Foo\nstate: published\ndatePublished: 2020-01-01\n---\n',
+    );
+    const res = run('ingest', [
+      project,
+      '--apply',
+      '--site',
+      'secondary',
+      'src/sites/secondary/content/posts/foo.md',
+    ]);
+    expect(res.code).toBe(0);
+
+    const secondCal = parseCalendar(
+      readFileSync(join(project, 'docs/calendar-secondary.md'), 'utf-8'),
+    );
+    expect(secondCal.entries.map((e) => e.slug)).toEqual(['foo']);
+
+    const mainCal = parseCalendar(
+      readFileSync(join(project, 'docs/calendar-main.md'), 'utf-8'),
+    );
+    expect(mainCal.entries).toHaveLength(0);
+  });
+});
+
+describe('deskwork ingest — error handling', () => {
+  it('refuses unknown flags', () => {
+    const res = run('ingest', [project, '--bogus', 'value', 'src']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toMatch(/Unknown flag/);
+  });
+
+  it('refuses an invalid --state', () => {
+    write('src/content/posts/p.md', '---\ntitle: P\n---\n');
+    const res = run('ingest', [
+      project,
+      '--state',
+      'Bogus',
+      'src/content/posts/p.md',
+    ]);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toMatch(/--state must be one of/);
+  });
+
+  it('refuses an invalid --date', () => {
+    write('src/content/posts/p.md', '---\ntitle: P\n---\n');
+    const res = run('ingest', [
+      project,
+      '--date',
+      '2024/01/15',
+      'src/content/posts/p.md',
+    ]);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toMatch(/--date must match/);
+  });
+
+  it('errors on a nonexistent path', () => {
+    const res = run('ingest', [project, 'no-such-dir']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toMatch(/does not exist/);
+  });
+});
+
+describe('deskwork ingest — scrapbook is skipped by default', () => {
+  it('files under <contentDir>/scrapbook/ are reported as skipped', () => {
+    write(
+      'src/content/posts/x.md',
+      '---\ntitle: X\nstate: published\ndatePublished: 2020-01-01\n---\n',
+    );
+    write(
+      'src/content/scrapbook/sketches/y.md',
+      '---\ntitle: Y\nstate: published\ndatePublished: 2020-01-01\n---\n',
+    );
+
+    const res = run('ingest', [project, 'src/content']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toMatch(/Plan: 1 add, 1 skip/);
+    expect(res.stdout).toMatch(/scrapbook/);
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
+    // CLI integration tests spawn subprocesses; 5s default is tight on
+    // slower CI runners (one full lifecycle test took 29s in release.yml).
+    testTimeout: 60_000,
   },
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "./cli-args": "./src/cli.ts",
     "./config": "./src/config.ts",
     "./frontmatter": "./src/frontmatter.ts",
+    "./ingest": "./src/ingest.ts",
     "./journal": "./src/journal.ts",
     "./paths": "./src/paths.ts",
     "./rename-slug": "./src/rename-slug.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Editorial calendar + review pipeline library — shared by @deskwork/cli and @deskwork/studio",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,8 @@
     "./config": "./src/config.ts",
     "./frontmatter": "./src/frontmatter.ts",
     "./ingest": "./src/ingest.ts",
+    "./ingest-derive": "./src/ingest-derive.ts",
+    "./ingest-paths": "./src/ingest-paths.ts",
     "./journal": "./src/journal.ts",
     "./paths": "./src/paths.ts",
     "./rename-slug": "./src/rename-slug.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Editorial calendar + review pipeline library — shared by @deskwork/cli and @deskwork/studio",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from './frontmatter.ts';
 export * from './journal.ts';
 export * from './scaffold.ts';
 export * from './body-state.ts';
+export * from './ingest.ts';
 export * as scrapbook from './scrapbook.ts';
 export * as renameSlug from './rename-slug.ts';
 export * as review from './review/index.ts';

--- a/packages/core/src/ingest-derive.ts
+++ b/packages/core/src/ingest-derive.ts
@@ -1,0 +1,383 @@
+/**
+ * ingest-derive.ts — slug / state / date / title derivation for ingest.
+ *
+ * Each `derive*` function takes the file's absolute path, its discovery
+ * root (for path-based slug derivation), the parsed frontmatter, the
+ * effective field-name table, and the operator's options. It returns a
+ * `<thing>Derivation` record that records both the derived value AND
+ * where it came from — the dry-run plan surfaces these sources so the
+ * operator can sanity-check before committing.
+ */
+
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { isStage, type Stage } from './types.ts';
+import type { FrontmatterData } from './frontmatter.ts';
+import { MARKDOWN_EXTENSIONS } from './ingest-paths.ts';
+
+export type DerivationSource =
+  | 'frontmatter'
+  | 'path'
+  | 'mtime'
+  | 'today'
+  | 'explicit';
+
+export interface SlugDerivation {
+  value: string;
+  source: DerivationSource;
+  reason?: string;
+}
+
+export interface StateDerivation {
+  value: Stage | null;
+  source: DerivationSource;
+  rawValue?: string;
+}
+
+export interface DateDerivation {
+  value: string;
+  source: DerivationSource;
+}
+
+const JEKYLL_RE = /^(\d{4})-(\d{2})-(\d{2})-(.+)$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Canonical state-string normalization. Maps frontmatter values that
+ * editorial projects commonly use onto our six lanes. Anything outside
+ * this table comes back ambiguous — the operator must pass `--state`.
+ */
+export const STATE_ALIASES: Record<string, Stage> = {
+  ideas: 'Ideas',
+  idea: 'Ideas',
+  ideas_lane: 'Ideas',
+  planned: 'Planned',
+  outlining: 'Outlining',
+  outline: 'Outlining',
+  drafting: 'Drafting',
+  draft: 'Drafting',
+  review: 'Review',
+  reviewing: 'Review',
+  'in-review': 'Review',
+  in_review: 'Review',
+  published: 'Published',
+  publish: 'Published',
+};
+
+// ---------------------------------------------------------------------------
+// Slug
+// ---------------------------------------------------------------------------
+
+export interface SlugDeriveInput {
+  filePath: string;
+  root: string;
+  frontmatter: FrontmatterData;
+  fieldName: string;
+  slugFrom: 'frontmatter' | 'path';
+  explicitSlug?: string;
+}
+
+/**
+ * Derive a slug for a discovered file. Order:
+ *
+ *   1. `explicitSlug` (operator's `--slug`) — wins, marked 'explicit'.
+ *   2. When `slugFrom === 'frontmatter'`, the named frontmatter field
+ *      (default `slug:`) when set; otherwise falls through to path.
+ *   3. Path-based derivation — see `slugFromPath`.
+ */
+export function deriveSlug(input: SlugDeriveInput): SlugDerivation {
+  if (input.explicitSlug !== undefined) {
+    return { value: input.explicitSlug, source: 'explicit' };
+  }
+  if (input.slugFrom === 'frontmatter') {
+    const fmSlug = readStringField(input.frontmatter, input.fieldName);
+    if (fmSlug !== undefined) {
+      return { value: fmSlug, source: 'frontmatter' };
+    }
+    // Fall through to path when frontmatter slug is missing.
+  }
+  return slugFromPath(input.filePath, input.root);
+}
+
+/**
+ * Path-based slug derivation. Computes the slug from the file's path
+ * relative to its discovery root, with hierarchical-bundle detection.
+ *
+ * Filename rules (first match wins):
+ *   1. `<dir>/index.md` or `<dir>/README.md` (case-insensitive) →
+ *      drop the suffix; the dir name becomes the slug leaf.
+ *   2. Filename matches `YYYY-MM-DD-<slug>.<ext>` → strip date prefix
+ *      and extension. Jekyll posts.
+ *   3. Otherwise → filename minus extension.
+ *
+ * Hierarchy: a directory between root and the file prefixes the slug
+ * if and only if it has its own `index.md` or `README.md`. Such a
+ * directory is itself a content node with a slug, and its children
+ * nest under it. Plain directories (no own leaf bundle) are
+ * "collection containers" — their names do NOT prefix child slugs.
+ */
+function slugFromPath(filePath: string, root: string): SlugDerivation {
+  const rel = relative(root, filePath);
+  const segments = rel.split(sep).filter((s) => s.length > 0);
+  if (segments.length === 0) {
+    return { value: '', source: 'path', reason: 'file path equals root' };
+  }
+
+  const filename = segments[segments.length - 1];
+  const dot = filename.lastIndexOf('.');
+  const base = dot > 0 ? filename.slice(0, dot) : filename;
+  const baseLower = base.toLowerCase();
+
+  let leafSegments: string[];
+  let dirSegments: string[];
+
+  if (baseLower === 'index' || baseLower === 'readme') {
+    if (segments.length < 2) {
+      // Leaf-bundle file at the discovery root — root's basename
+      // becomes the slug (the case for a single-file argument like
+      // `<...>/strivers/index.md` where root = `<...>/strivers`).
+      const rootSegments = root.split(sep).filter((s) => s.length > 0);
+      const rootLeaf = rootSegments[rootSegments.length - 1];
+      if (!rootLeaf) {
+        return {
+          value: '',
+          source: 'path',
+          reason: `${filename} at the filesystem root has no directory name to derive a slug from`,
+        };
+      }
+      leafSegments = [rootLeaf];
+      dirSegments = [];
+    } else {
+      leafSegments = [segments[segments.length - 2]];
+      dirSegments = segments.slice(0, -2);
+    }
+  } else {
+    const jekyll = base.match(JEKYLL_RE);
+    leafSegments = [jekyll ? jekyll[4] : base];
+    dirSegments = segments.slice(0, -1);
+  }
+
+  // Walk directory ancestors from root → leaf. Each ancestor
+  // contributes to the slug only if it has its own index.md or
+  // README.md (i.e. it's itself a content node, not just a folder).
+  const prefix: string[] = [];
+
+  // Special case: when the discovery root itself is a content node
+  // (has its own index.md/README.md), its basename prefixes child
+  // slugs. Skip when leafSegments already equals the root's basename
+  // (the case when the discovered file IS the root's own index.md —
+  // handled above by setting leafSegments to the root's name).
+  if (directoryIsHierarchicalNode(root)) {
+    const rootSegments = root.split(sep).filter((s) => s.length > 0);
+    const rootLeaf = rootSegments[rootSegments.length - 1];
+    if (rootLeaf && leafSegments[0] !== rootLeaf) {
+      prefix.push(rootLeaf);
+    }
+  }
+
+  let cursor = root;
+  for (const dir of dirSegments) {
+    cursor = join(cursor, dir);
+    if (directoryIsHierarchicalNode(cursor)) {
+      prefix.push(dir);
+    } else {
+      // Once an ancestor isn't itself a content node, the chain
+      // ends — the operator put a non-tracked folder between
+      // content nodes, so that folder's name shouldn't bleed in.
+      prefix.length = 0;
+    }
+  }
+
+  return { value: [...prefix, ...leafSegments].join('/'), source: 'path' };
+}
+
+/**
+ * True if `dir` itself has a leaf bundle (index.md / README.md /
+ * index.mdx / README.mdx / etc.) — i.e. it's a content node whose
+ * name should prefix its children's slugs.
+ */
+function directoryIsHierarchicalNode(dir: string): boolean {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const lower = entry.name.toLowerCase();
+    for (const ext of MARKDOWN_EXTENSIONS) {
+      if (lower === `index${ext}` || lower === `readme${ext}`) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export interface StateDeriveInput {
+  frontmatter: FrontmatterData;
+  stateField: string;
+  dateField: string;
+  stateFrom: 'frontmatter' | 'datePublished';
+  explicitState?: Stage;
+  now?: Date;
+}
+
+export function deriveState(input: StateDeriveInput): StateDerivation {
+  if (input.explicitState !== undefined) {
+    return { value: input.explicitState, source: 'explicit' };
+  }
+  if (input.stateFrom === 'frontmatter') {
+    const raw = readStringField(input.frontmatter, input.stateField);
+    if (raw === undefined) {
+      // No state field — default to Ideas as the safest lane.
+      return { value: 'Ideas', source: 'frontmatter' };
+    }
+    const normalized = normalizeStateString(raw);
+    if (normalized === null) {
+      return { value: null, source: 'frontmatter', rawValue: raw };
+    }
+    return { value: normalized, source: 'frontmatter' };
+  }
+
+  // stateFrom === 'datePublished'
+  const dateRaw = readDateField(input.frontmatter, input.dateField);
+  if (dateRaw === undefined) {
+    return { value: 'Ideas', source: 'frontmatter' };
+  }
+  const today = (input.now ?? new Date()).toISOString().slice(0, 10);
+  if (dateRaw <= today) {
+    return { value: 'Published', source: 'frontmatter' };
+  }
+  return { value: 'Drafting', source: 'frontmatter' };
+}
+
+function normalizeStateString(raw: string): Stage | null {
+  const key = raw.trim().toLowerCase();
+  if (key.length === 0) return null;
+  const direct = STATE_ALIASES[key];
+  if (direct) return direct;
+  // Stage names verbatim (Title-cased) — accept them too.
+  const titled = key.charAt(0).toUpperCase() + key.slice(1);
+  if (isStage(titled)) return titled;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Date
+// ---------------------------------------------------------------------------
+
+export interface DateDeriveInput {
+  filePath: string;
+  frontmatter: FrontmatterData;
+  dateField: string;
+  explicitDate?: string;
+  now?: Date;
+}
+
+export function deriveDate(input: DateDeriveInput): DateDerivation {
+  if (input.explicitDate !== undefined) {
+    return { value: input.explicitDate, source: 'explicit' };
+  }
+
+  const fmDate = readDateField(input.frontmatter, input.dateField);
+  if (fmDate !== undefined) {
+    return { value: fmDate, source: 'frontmatter' };
+  }
+  // Try the secondary `date` field too, when the primary one was
+  // overridden — `--date-field datePublished` should still find a
+  // generic `date:` as a backstop.
+  if (input.dateField !== 'date') {
+    const generic = readDateField(input.frontmatter, 'date');
+    if (generic !== undefined) {
+      return { value: generic, source: 'frontmatter' };
+    }
+  }
+
+  // mtime fallback — accurate enough for "approximately when the
+  // operator wrote this", but the operator can override with --date.
+  try {
+    const stat = statSync(input.filePath);
+    return { value: stat.mtime.toISOString().slice(0, 10), source: 'mtime' };
+  } catch {
+    // Should never happen — we just read the file. Fall through.
+  }
+
+  const today = (input.now ?? new Date()).toISOString().slice(0, 10);
+  return { value: today, source: 'today' };
+}
+
+// ---------------------------------------------------------------------------
+// Title / description
+// ---------------------------------------------------------------------------
+
+export function deriveTitle(
+  frontmatter: FrontmatterData,
+  fieldName: string,
+  slug: string,
+): string {
+  const raw = readStringField(frontmatter, fieldName);
+  if (raw !== undefined && raw.length > 0) return raw;
+  // Humanize the slug as a last resort. Strip leading hierarchy
+  // segments — title for `the-outbound/characters/strivers` should
+  // be "Strivers", not "The Outbound Characters Strivers".
+  const leaf = slug.split('/').pop() ?? slug;
+  return leaf
+    .split('-')
+    .map((w) => (w.length > 0 ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+export function deriveDescription(
+  frontmatter: FrontmatterData,
+  fieldName: string,
+): string {
+  return readStringField(frontmatter, fieldName) ?? '';
+}
+
+// ---------------------------------------------------------------------------
+// Field readers
+// ---------------------------------------------------------------------------
+
+function readStringField(
+  frontmatter: FrontmatterData,
+  field: string,
+): string | undefined {
+  const value = frontmatter[field];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Read a date-like field. YAML may parse `2024-01-15` as a Date or as
+ * a string depending on quoting. Both shapes resolve to YYYY-MM-DD.
+ * Anything else returns undefined.
+ */
+function readDateField(
+  frontmatter: FrontmatterData,
+  field: string,
+): string | undefined {
+  const value = frontmatter[field];
+  if (value === undefined || value === null) return undefined;
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (ISO_DATE_RE.test(trimmed)) return trimmed;
+    // Try Date.parse for non-ISO formats — the operator's frontmatter
+    // might be `date: 2024/01/15` or `date: January 15, 2024`. Parse
+    // leniently and serialize as ISO.
+    const parsed = Date.parse(trimmed);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString().slice(0, 10);
+    }
+  }
+  return undefined;
+}

--- a/packages/core/src/ingest-paths.ts
+++ b/packages/core/src/ingest-paths.ts
@@ -1,0 +1,210 @@
+/**
+ * ingest-paths.ts — markdown file collection for ingest discovery.
+ *
+ * Walks a list of operator-supplied paths (file / directory / glob)
+ * and produces a deduplicated, deterministically-ordered list of
+ * `CollectedFile` records — each one a markdown file paired with the
+ * "discovery root" it was found under. The root is what slug derivation
+ * uses to compute the file's path-relative slug.
+ *
+ * Glob expansion is hand-rolled to avoid pulling a dep onto the
+ * discovery hot path. The supported pattern surface — `*`, `**`, `?`,
+ * `[...]` — covers every operator pattern surfaced in the issue (e.g.
+ * `src/content/essays/​**​/*.md`).
+ */
+
+import {
+  existsSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { isAbsolute, join, resolve, sep } from 'node:path';
+
+const MARKDOWN_EXTENSIONS = ['.md', '.mdx', '.markdown'] as const;
+
+/**
+ * A discovered markdown file paired with its discovery root — the
+ * directory the operator's path argument resolved to (or the deepest
+ * static prefix for a glob). Slug derivation computes the slug as
+ * the file's path relative to this root, so siblings of a flat
+ * collection ("essays/foo/index.md", "essays/bar/index.md") get
+ * unprefixed slugs while deeper nesting produces hierarchical slugs.
+ */
+export interface CollectedFile {
+  filePath: string;
+  root: string;
+}
+
+/**
+ * Walk every supplied path and return a deduplicated, sorted list of
+ * `CollectedFile` records. First-seen wins for root attribution: if
+ * the same file is reachable from two paths the operator passed, the
+ * first path's discovery root is canonical.
+ */
+export function collectMarkdownFiles(paths: string[]): CollectedFile[] {
+  const seen = new Map<string, CollectedFile>();
+  for (const p of paths) {
+    for (const file of expandPath(p)) {
+      if (!seen.has(file.filePath)) {
+        seen.set(file.filePath, file);
+      }
+    }
+  }
+  return [...seen.values()].sort((a, b) =>
+    a.filePath.localeCompare(b.filePath),
+  );
+}
+
+function expandPath(input: string): CollectedFile[] {
+  const absolute = isAbsolute(input) ? input : resolve(process.cwd(), input);
+
+  if (containsGlob(input)) {
+    return expandGlob(absolute);
+  }
+
+  if (!existsSync(absolute)) {
+    throw new Error(`Path does not exist: ${input}`);
+  }
+
+  const stat = statSync(absolute);
+  if (stat.isFile()) {
+    if (!hasMarkdownExtension(absolute)) {
+      throw new Error(
+        `Path is not a markdown file: ${input} (expected one of ${MARKDOWN_EXTENSIONS.join(', ')})`,
+      );
+    }
+    // For a single-file argument the discovery root is the file's
+    // parent — no hierarchical prefix.
+    return [{ filePath: absolute, root: dirnameOf(absolute) }];
+  }
+  if (stat.isDirectory()) {
+    return walkDirectory(absolute, absolute);
+  }
+  return [];
+}
+
+function dirnameOf(filePath: string): string {
+  const idx = filePath.lastIndexOf(sep);
+  if (idx <= 0) return sep;
+  return filePath.slice(0, idx);
+}
+
+function walkDirectory(dir: string, root: string): CollectedFile[] {
+  const out: CollectedFile[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const child = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkDirectory(child, root));
+    } else if (entry.isFile() && hasMarkdownExtension(entry.name)) {
+      out.push({ filePath: child, root });
+    }
+  }
+  return out;
+}
+
+function containsGlob(input: string): boolean {
+  return /[*?[]/.test(input);
+}
+
+/**
+ * Minimal glob expansion supporting `*`, `**`, `?`, and `[...]`.
+ *
+ * The deepest static prefix becomes the discovery root so slugs are
+ * computed relative to it (e.g. `src/posts/​**​/*.md` uses `src/posts`
+ * as the slug-derivation root).
+ */
+function expandGlob(absolutePattern: string): CollectedFile[] {
+  const segments = absolutePattern.split(sep);
+  let rootEnd = 0;
+  for (let i = 0; i < segments.length; i++) {
+    if (containsGlob(segments[i])) break;
+    rootEnd = i;
+  }
+  const root = segments.slice(0, rootEnd + 1).join(sep) || sep;
+  const remainder = segments.slice(rootEnd + 1);
+
+  if (!existsSync(root)) {
+    return [];
+  }
+
+  return matchPattern(root, remainder, root);
+}
+
+function matchPattern(
+  currentDir: string,
+  remaining: string[],
+  root: string,
+): CollectedFile[] {
+  if (remaining.length === 0) {
+    if (statSync(currentDir).isFile() && hasMarkdownExtension(currentDir)) {
+      return [{ filePath: currentDir, root }];
+    }
+    return [];
+  }
+  const [head, ...rest] = remaining;
+  const out: CollectedFile[] = [];
+
+  let entries;
+  try {
+    entries = readdirSync(currentDir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+
+  if (head === '**') {
+    // Match zero or more directories, then continue with `rest`.
+    out.push(...matchPattern(currentDir, rest, root));
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        out.push(
+          ...matchPattern(join(currentDir, entry.name), remaining, root),
+        );
+      }
+    }
+    return out;
+  }
+
+  const matcher = globSegmentMatcher(head);
+  for (const entry of entries) {
+    if (!matcher(entry.name)) continue;
+    const child = join(currentDir, entry.name);
+    if (rest.length === 0) {
+      if (entry.isFile() && hasMarkdownExtension(entry.name)) {
+        out.push({ filePath: child, root });
+      }
+    } else if (entry.isDirectory()) {
+      out.push(...matchPattern(child, rest, root));
+    }
+  }
+  return out;
+}
+
+function globSegmentMatcher(pattern: string): (name: string) => boolean {
+  let re = '^';
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === '*') re += '[^/]*';
+    else if (ch === '?') re += '[^/]';
+    else if (ch === '[') {
+      const close = pattern.indexOf(']', i);
+      if (close === -1) {
+        re += '\\[';
+      } else {
+        re += pattern.slice(i, close + 1);
+        i = close;
+      }
+    } else if (/[\\^$+().{}|]/.test(ch)) re += `\\${ch}`;
+    else re += ch;
+  }
+  re += '$';
+  const compiled = new RegExp(re);
+  return (name) => compiled.test(name);
+}
+
+export function hasMarkdownExtension(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return MARKDOWN_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+export { MARKDOWN_EXTENSIONS };

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1,54 +1,54 @@
 /**
- * ingest.ts — discovery primitive for backfilling existing markdown content
- * into the editorial calendar.
+ * ingest.ts — discovery primitive for backfilling existing markdown
+ * content into the editorial calendar.
  *
- * The ingest flow turns "files on disk" into "calendar candidates" without
- * touching the calendar itself. The CLI layer wires this output into a
- * dry-run plan or an `--apply` write; this module is purely descriptive.
+ * Turns "files on disk" into "calendar candidates" without touching
+ * the calendar itself. The CLI layer wires this output into a
+ * dry-run plan or an `--apply` write; this module is purely
+ * descriptive.
  *
- * ## Responsibilities
+ * Responsibilities split across three files:
  *
- *   1. Walk a list of paths (file / directory / glob) and collect markdown
- *      files (`.md`, `.mdx`, `.markdown`).
- *   2. For each file, parse frontmatter (best-effort — files without
- *      frontmatter still produce a candidate; files with malformed
- *      frontmatter surface as errors).
- *   3. Derive `slug`, `state`, and `date` from a configurable mix of
- *      sources (frontmatter / path / mtime / today). Each derivation
- *      records its source so the operator can verify provenance in the
- *      dry-run output.
- *   4. Filter against an existing calendar — duplicates produce
- *      `IngestSkip` records with a reason, never silent drops.
+ *   - `ingest.ts` (this file) — orchestrates discovery, applies
+ *     idempotency filtering against an existing calendar, and shapes
+ *     candidates into `IngestCandidate` records ready for the apply
+ *     layer.
+ *   - `ingest-paths.ts` — walks file / directory / glob inputs and
+ *     produces `(filePath, root)` tuples.
+ *   - `ingest-derive.ts` — slug / state / date / title derivation
+ *     with provenance recording.
  *
- * ## What's intentionally out of scope
+ * What's intentionally out of scope:
  *
- *   - Mutations: `discoverIngestCandidates` never writes to disk, never
- *     mutates the calendar. The CLI command turns a candidate list into
- *     an apply plan.
+ *   - Mutations: `discoverIngestCandidates` never writes to disk,
+ *     never mutates the calendar.
  *   - Auto-detection of the content tree: the operator passes paths
- *     explicitly. Walking the entire repo to "discover" content would
- *     scoop up node_modules / vendored docs / unrelated markdown.
- *   - Migrations from other calendar formats: source is markdown files +
- *     their frontmatter. Importing from Notion / Airtable / a different
- *     calendar markdown shape is a separate concern (PRD extension).
+ *     explicitly. Walking the entire repo would scoop up
+ *     node_modules / vendored docs / unrelated markdown.
+ *   - Migrations from other calendar formats: source is markdown
+ *     files + their frontmatter. Importing from Notion / Airtable
+ *     is a separate concern (PRD extension).
  */
 
-import {
-  existsSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-} from 'node:fs';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { isAbsolute, relative, sep } from 'node:path';
+import { readFileSync } from 'node:fs';
 import { parseFrontmatter, type FrontmatterData } from './frontmatter.ts';
-import { isStage, type CalendarEntry, type EditorialCalendar, type Stage } from './types.ts';
+import type { CalendarEntry, EditorialCalendar, Stage } from './types.ts';
+import { collectMarkdownFiles } from './ingest-paths.ts';
+import {
+  deriveDate,
+  deriveDescription,
+  deriveSlug,
+  deriveState,
+  deriveTitle,
+  type DerivationSource,
+} from './ingest-derive.ts';
+
+export type { DerivationSource } from './ingest-derive.ts';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-/** Where a derived value came from. Surfaces in the dry-run plan. */
-export type DerivationSource = 'frontmatter' | 'path' | 'mtime' | 'today' | 'explicit';
 
 /** A markdown file resolved to a (slug, state, date) triple ready to commit. */
 export interface IngestCandidate {
@@ -65,9 +65,9 @@ export interface IngestCandidate {
   /** Where `derivedSlug` came from. */
   slugSource: DerivationSource;
   /**
-   * Derived stage. `null` when the source produced an unrecognized state
-   * value — the operator must pass `--state` to commit. Surfaces in the
-   * plan as `state: ambiguous`.
+   * Derived stage. `null` when the source produced an unrecognized
+   * state value — the operator must pass `--state` to commit.
+   * Surfaces in the plan as `state: ambiguous`.
    */
   derivedState: Stage | null;
   /** Where `derivedState` came from. */
@@ -75,8 +75,7 @@ export interface IngestCandidate {
   /**
    * Raw state string the source produced (e.g. `'published-elsewhere'`)
    * when normalization failed. `undefined` when state was derived
-   * unambiguously. Surfaces in the plan to make the failure mode
-   * actionable.
+   * unambiguously.
    */
   rawState?: string;
   /** Derived date in ISO YYYY-MM-DD form. */
@@ -84,8 +83,8 @@ export interface IngestCandidate {
   /** Where `derivedDate` came from. */
   dateSource: DerivationSource;
   /**
-   * Title pulled from frontmatter — falls back to a humanized slug when
-   * absent. The CLI emits this onto the new calendar row.
+   * Title pulled from frontmatter — falls back to a humanized slug
+   * when absent. The CLI emits this onto the new calendar row.
    */
   title: string;
   /** Description pulled from frontmatter — empty string when absent. */
@@ -126,15 +125,15 @@ export interface IngestOptions {
   /** Where to derive states from. Default `'frontmatter'`. */
   stateFrom?: StateFrom;
   /**
-   * Explicit slug. Only honored when discovery resolves to exactly one
-   * candidate file — the CLI enforces this before calling.
+   * Explicit slug. Only honored when discovery resolves to exactly
+   * one candidate file — the CLI enforces this before calling.
    */
   explicitSlug?: string;
   /** Explicit stage. Wins over derivation when set. */
   explicitState?: Stage;
   /** Explicit ISO date (YYYY-MM-DD). Wins over derivation when set. */
   explicitDate?: string;
-  /** Frontmatter field name overrides — match the operator's project schema. */
+  /** Frontmatter field-name overrides — match the operator's project schema. */
   fieldNames?: {
     title?: string;
     description?: string;
@@ -156,10 +155,10 @@ export interface IngestOptions {
    */
   force?: boolean;
   /**
-   * Skip files under `<contentDir>/scrapbook/` — host projects use
-   * scrapbook for sketches that aren't on the editorial calendar.
-   * The CLI threads `<contentDir>/scrapbook` (one per site) into this
-   * list. Default `[]` (no skipping).
+   * Skip files under any of these absolute paths — host projects use
+   * a scrapbook directory for sketches that aren't on the editorial
+   * calendar. The CLI threads `<contentDir>/scrapbook` (one per site)
+   * into this list. Default `[]` (no skipping).
    */
   scrapbookRoots?: string[];
   /** Today's date for date-derivation fallback. Test seam; defaults to now(). */
@@ -170,10 +169,7 @@ export interface IngestOptions {
 // Constants
 // ---------------------------------------------------------------------------
 
-const MARKDOWN_EXTENSIONS = ['.md', '.mdx', '.markdown'] as const;
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
-const JEKYLL_RE = /^(\d{4})-(\d{2})-(\d{2})-(.+)$/;
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 const DEFAULT_FIELDS = {
   title: 'title',
@@ -182,28 +178,6 @@ const DEFAULT_FIELDS = {
   state: 'state',
   date: 'datePublished',
 } as const;
-
-/**
- * Canonical state-string normalization. Maps frontmatter values that
- * editorial projects commonly use onto our six lanes. Anything outside
- * this table comes back ambiguous — the operator must pass `--state`.
- */
-const STATE_ALIASES: Record<string, Stage> = {
-  ideas: 'Ideas',
-  idea: 'Ideas',
-  planned: 'Planned',
-  outlining: 'Outlining',
-  outline: 'Outlining',
-  drafting: 'Drafting',
-  draft: 'Drafting',
-  review: 'Review',
-  reviewing: 'Review',
-  'in-review': 'Review',
-  in_review: 'Review',
-  published: 'Published',
-  publish: 'Published',
-  ideas_lane: 'Ideas',
-};
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -249,10 +223,12 @@ export function discoverIngestCandidates(
   const fields = { ...DEFAULT_FIELDS, ...(options.fieldNames ?? {}) };
 
   for (const { filePath, root } of collected) {
+    const relPath = relativeTo(options.projectRoot, filePath);
+
     if (isUnderScrapbook(filePath, options.scrapbookRoots)) {
       skips.push({
         filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
+        relativePath: relPath,
         reason: 'file is under scrapbook/ (skipped by default)',
       });
       continue;
@@ -264,7 +240,7 @@ export function discoverIngestCandidates(
     } catch (err) {
       skips.push({
         filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
+        relativePath: relPath,
         reason: `unreadable: ${err instanceof Error ? err.message : String(err)}`,
       });
       continue;
@@ -276,17 +252,26 @@ export function discoverIngestCandidates(
     } catch (err) {
       skips.push({
         filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
+        relativePath: relPath,
         reason: `frontmatter parse failed: ${err instanceof Error ? err.message : String(err)}`,
       });
       continue;
     }
 
-    const slug = deriveSlug(filePath, root, parsed.data, fields, options);
+    const slug = deriveSlug({
+      filePath,
+      root,
+      frontmatter: parsed.data,
+      fieldName: fields.slug,
+      slugFrom: options.slugFrom ?? 'path',
+      ...(options.explicitSlug !== undefined
+        ? { explicitSlug: options.explicitSlug }
+        : {}),
+    });
     if (!slug.value) {
       skips.push({
         filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
+        relativePath: relPath,
         reason: slug.reason ?? 'could not derive slug',
       });
       continue;
@@ -294,7 +279,7 @@ export function discoverIngestCandidates(
     if (!SLUG_RE.test(slug.value)) {
       skips.push({
         filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
+        relativePath: relPath,
         slug: slug.value,
         reason:
           `derived slug "${slug.value}" is not valid kebab-case ` +
@@ -310,21 +295,38 @@ export function discoverIngestCandidates(
     ) {
       skips.push({
         filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
+        relativePath: relPath,
         slug: slug.value,
         reason: `calendar already has an entry with slug "${slug.value}" (use --force to override)`,
       });
       continue;
     }
 
-    const state = deriveState(parsed.data, fields, options);
-    const date = deriveDate(filePath, parsed.data, fields, options);
+    const state = deriveState({
+      frontmatter: parsed.data,
+      stateField: fields.state,
+      dateField: fields.date,
+      stateFrom: options.stateFrom ?? 'frontmatter',
+      ...(options.explicitState !== undefined
+        ? { explicitState: options.explicitState }
+        : {}),
+      ...(options.now !== undefined ? { now: options.now } : {}),
+    });
+    const date = deriveDate({
+      filePath,
+      frontmatter: parsed.data,
+      dateField: fields.date,
+      ...(options.explicitDate !== undefined
+        ? { explicitDate: options.explicitDate }
+        : {}),
+      ...(options.now !== undefined ? { now: options.now } : {}),
+    });
     const title = deriveTitle(parsed.data, fields.title, slug.value);
     const description = deriveDescription(parsed.data, fields.description);
 
     candidates.push({
       filePath,
-      relativePath: relativeTo(options.projectRoot, filePath),
+      relativePath: relPath,
       frontmatter: parsed.data,
       body: parsed.body,
       derivedSlug: slug.value,
@@ -340,562 +342,6 @@ export function discoverIngestCandidates(
   }
 
   return { candidates, skips };
-}
-
-// ---------------------------------------------------------------------------
-// Slug derivation
-// ---------------------------------------------------------------------------
-
-interface SlugDerivation {
-  value: string;
-  source: DerivationSource;
-  reason?: string;
-}
-
-function deriveSlug(
-  filePath: string,
-  root: string,
-  frontmatter: FrontmatterData,
-  fields: { slug: string },
-  options: IngestOptions,
-): SlugDerivation {
-  if (options.explicitSlug !== undefined) {
-    return { value: options.explicitSlug, source: 'explicit' };
-  }
-
-  const slugFrom = options.slugFrom ?? 'path';
-
-  if (slugFrom === 'frontmatter') {
-    const fmSlug = readStringField(frontmatter, fields.slug);
-    if (fmSlug !== undefined) {
-      return { value: fmSlug, source: 'frontmatter' };
-    }
-    // Fall through to path when frontmatter slug is missing.
-  }
-
-  return slugFromPath(filePath, root);
-}
-
-/**
- * Path-based slug derivation. Computes the slug from the file's path
- * relative to its discovery root, with hierarchical-bundle detection.
- *
- * The "discovery root" is the path the operator passed:
- *   - For a file argument: root is the file's parent directory.
- *   - For a directory argument: root is that directory itself.
- *   - For a glob: root is the deepest static prefix.
- *
- * Filename rules (first match wins):
- *   1. `<dir>/index.md` or `<dir>/README.md` (case-insensitive) →
- *      drop the suffix; the dir name becomes the slug leaf. Astro /
- *      Hugo leaf-bundle layout.
- *   2. Filename matches `YYYY-MM-DD-<slug>.<ext>` → strip date prefix
- *      and extension. Jekyll posts.
- *   3. Otherwise → filename minus extension.
- *
- * Hierarchy: a directory between root and the file prefixes the slug
- * if and only if it has its own `index.md` or `README.md`. Such a
- * directory is itself a content node with a slug, and its children
- * nest under it. Plain directories (no own leaf bundle) are
- * "collection containers" — their names do NOT prefix child slugs.
- *
- * Examples (with root = `src/content/`):
- *
- *   essays/whats-in-a-name/index.md
- *     essays/ has no own index.md → slug = `whats-in-a-name`.
- *
- *   the-outbound/characters/strivers/index.md
- *     If the-outbound/index.md and the-outbound/characters/index.md
- *     both exist → slug = `the-outbound/characters/strivers`.
- *     If only the-outbound/index.md exists → slug = `the-outbound/strivers`.
- *     If neither exists → slug = `strivers`.
- */
-function slugFromPath(filePath: string, root: string): SlugDerivation {
-  const rel = relative(root, filePath);
-  const segments = rel.split(sep).filter((s) => s.length > 0);
-  if (segments.length === 0) {
-    return { value: '', source: 'path', reason: 'file path equals root' };
-  }
-
-  const filename = segments[segments.length - 1];
-  const dot = filename.lastIndexOf('.');
-  const base = dot > 0 ? filename.slice(0, dot) : filename;
-  const baseLower = base.toLowerCase();
-
-  let leafSegments: string[];
-  let dirSegments: string[];
-
-  if (baseLower === 'index' || baseLower === 'readme') {
-    // Leaf-bundle: drop the index/README; the dir IS the slug leaf.
-    // When the leaf-bundle file is AT the discovery root (single
-    // segment, just `index.md`), the root's basename becomes the
-    // slug — that's the case for a single-file argument like
-    // `<...>/strivers/index.md` (root = `<...>/strivers/`).
-    if (segments.length < 2) {
-      const rootSegments = root.split(sep).filter((s) => s.length > 0);
-      const rootLeaf = rootSegments[rootSegments.length - 1];
-      if (!rootLeaf) {
-        return {
-          value: '',
-          source: 'path',
-          reason: `${filename} at the filesystem root has no directory name to derive a slug from`,
-        };
-      }
-      leafSegments = [rootLeaf];
-      dirSegments = [];
-    } else {
-      leafSegments = [segments[segments.length - 2]];
-      dirSegments = segments.slice(0, -2);
-    }
-  } else {
-    const jekyll = base.match(JEKYLL_RE);
-    leafSegments = [jekyll ? jekyll[4] : base];
-    dirSegments = segments.slice(0, -1);
-  }
-
-  // Walk directory ancestors from root → leaf. Each ancestor
-  // contributes to the slug only if it has its own index.md or
-  // README.md (i.e. it's itself a content node, not just a folder).
-  const prefix: string[] = [];
-
-  // Special case: when the discovery root itself is a content node
-  // (has its own index.md/README.md), its basename prefixes child
-  // slugs. This handles `deskwork ingest src/content/the-outbound/`
-  // when the-outbound/index.md exists.
-  if (dirSegments.length > 0 || leafSegments.length > 0) {
-    if (directoryIsHierarchicalNode(root)) {
-      const rootSegments = root.split(sep).filter((s) => s.length > 0);
-      const rootLeaf = rootSegments[rootSegments.length - 1];
-      // Avoid double-prefix when leafSegments already equals the
-      // root's basename (the case when the discovered file is the
-      // root's own index.md — handled by the leaf-bundle branch
-      // above, which set leafSegments to the root's name).
-      if (rootLeaf && leafSegments[0] !== rootLeaf) {
-        prefix.push(rootLeaf);
-      }
-    }
-  }
-
-  let cursor = root;
-  for (const dir of dirSegments) {
-    cursor = join(cursor, dir);
-    if (directoryIsHierarchicalNode(cursor)) {
-      prefix.push(dir);
-    } else {
-      // Once an ancestor isn't itself a content node, the chain ends.
-      // Anything below that point doesn't get prefixed — the
-      // operator put a non-tracked folder between content nodes,
-      // and that folder's name shouldn't bleed into the slug.
-      prefix.length = 0;
-    }
-  }
-
-  const slug = [...prefix, ...leafSegments].join('/');
-  return { value: slug, source: 'path' };
-}
-
-/**
- * True if `dir` itself has a leaf bundle (index.md / README.md /
- * index.mdx / README.mdx / etc.) — i.e. it's a content node whose
- * name should prefix its children's slugs.
- */
-function directoryIsHierarchicalNode(dir: string): boolean {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return false;
-  }
-  for (const entry of entries) {
-    if (!entry.isFile()) continue;
-    const lower = entry.name.toLowerCase();
-    for (const ext of MARKDOWN_EXTENSIONS) {
-      if (lower === `index${ext}` || lower === `readme${ext}`) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-// ---------------------------------------------------------------------------
-// State derivation
-// ---------------------------------------------------------------------------
-
-interface StateDerivation {
-  value: Stage | null;
-  source: DerivationSource;
-  rawValue?: string;
-}
-
-function deriveState(
-  frontmatter: FrontmatterData,
-  fields: { state: string; date: string },
-  options: IngestOptions,
-): StateDerivation {
-  if (options.explicitState !== undefined) {
-    return { value: options.explicitState, source: 'explicit' };
-  }
-  const stateFrom = options.stateFrom ?? 'frontmatter';
-
-  if (stateFrom === 'frontmatter') {
-    const raw = readStringField(frontmatter, fields.state);
-    if (raw === undefined) {
-      // No state field — default to Ideas as the safest lane.
-      return { value: 'Ideas', source: 'frontmatter' };
-    }
-    const normalized = normalizeStateString(raw);
-    if (normalized === null) {
-      return { value: null, source: 'frontmatter', rawValue: raw };
-    }
-    return { value: normalized, source: 'frontmatter' };
-  }
-
-  // stateFrom === 'datePublished'
-  const dateRaw = readDateField(frontmatter, fields.date);
-  if (dateRaw === undefined) {
-    return { value: 'Ideas', source: 'frontmatter' };
-  }
-  const today = (options.now ?? new Date()).toISOString().slice(0, 10);
-  if (dateRaw <= today) {
-    return { value: 'Published', source: 'frontmatter' };
-  }
-  return { value: 'Drafting', source: 'frontmatter' };
-}
-
-function normalizeStateString(raw: string): Stage | null {
-  const key = raw.trim().toLowerCase();
-  if (key.length === 0) return null;
-  const direct = STATE_ALIASES[key];
-  if (direct) return direct;
-  // Stage names verbatim (Title-cased) — accept them too.
-  const titled = key.charAt(0).toUpperCase() + key.slice(1);
-  if (isStage(titled)) return titled;
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Date derivation
-// ---------------------------------------------------------------------------
-
-interface DateDerivation {
-  value: string;
-  source: DerivationSource;
-}
-
-function deriveDate(
-  filePath: string,
-  frontmatter: FrontmatterData,
-  fields: { date: string },
-  options: IngestOptions,
-): DateDerivation {
-  if (options.explicitDate !== undefined) {
-    return { value: options.explicitDate, source: 'explicit' };
-  }
-
-  const fmDate = readDateField(frontmatter, fields.date);
-  if (fmDate !== undefined) {
-    return { value: fmDate, source: 'frontmatter' };
-  }
-  // Try the secondary `date` field too, when the primary one was
-  // overridden — `--date-field datePublished` should still find a
-  // generic `date:` as a backstop.
-  if (fields.date !== 'date') {
-    const generic = readDateField(frontmatter, 'date');
-    if (generic !== undefined) {
-      return { value: generic, source: 'frontmatter' };
-    }
-  }
-
-  // mtime fallback — accurate enough for "approximately when the
-  // operator wrote this", but the operator can override with
-  // `--date YYYY-MM-DD`.
-  try {
-    const stat = statSync(filePath);
-    return { value: stat.mtime.toISOString().slice(0, 10), source: 'mtime' };
-  } catch {
-    // Should never happen — we just read the file. Fall through.
-  }
-
-  const today = (options.now ?? new Date()).toISOString().slice(0, 10);
-  return { value: today, source: 'today' };
-}
-
-// ---------------------------------------------------------------------------
-// Title / description / field readers
-// ---------------------------------------------------------------------------
-
-function deriveTitle(
-  frontmatter: FrontmatterData,
-  fieldName: string,
-  slug: string,
-): string {
-  const raw = readStringField(frontmatter, fieldName);
-  if (raw !== undefined && raw.length > 0) return raw;
-  // Humanize the slug as a last resort. Strip leading hierarchy
-  // segments — title for `the-outbound/characters/strivers` should
-  // be "Strivers", not "The Outbound Characters Strivers".
-  const leaf = slug.split('/').pop() ?? slug;
-  return leaf
-    .split('-')
-    .map((word) => (word.length > 0 ? word[0].toUpperCase() + word.slice(1) : word))
-    .join(' ');
-}
-
-function deriveDescription(
-  frontmatter: FrontmatterData,
-  fieldName: string,
-): string {
-  return readStringField(frontmatter, fieldName) ?? '';
-}
-
-function readStringField(
-  frontmatter: FrontmatterData,
-  field: string,
-): string | undefined {
-  const value = frontmatter[field];
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-/**
- * Read a date-like field. YAML may parse `2024-01-15` as a Date or as
- * a string depending on quoting. Both shapes resolve to YYYY-MM-DD.
- * Anything else returns undefined.
- */
-function readDateField(
-  frontmatter: FrontmatterData,
-  field: string,
-): string | undefined {
-  const value = frontmatter[field];
-  if (value === undefined || value === null) return undefined;
-  if (value instanceof Date) {
-    return value.toISOString().slice(0, 10);
-  }
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (ISO_DATE_RE.test(trimmed)) return trimmed;
-    // Try Date.parse for non-ISO formats — the operator's frontmatter
-    // might be `date: 2024/01/15` or `date: January 15, 2024`. We
-    // parse leniently and serialize as ISO.
-    const parsed = Date.parse(trimmed);
-    if (!Number.isNaN(parsed)) {
-      return new Date(parsed).toISOString().slice(0, 10);
-    }
-  }
-  return undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Path collection
-// ---------------------------------------------------------------------------
-
-/**
- * A discovered markdown file paired with its discovery root — the
- * directory the operator's path argument resolved to (or the deepest
- * static prefix for a glob). Slug derivation computes the slug as
- * the file's path relative to this root, so siblings of a flat
- * collection ("essays/foo/index.md", "essays/bar/index.md") get
- * unprefixed slugs while deeper nesting produces hierarchical slugs.
- */
-interface CollectedFile {
-  filePath: string;
-  root: string;
-}
-
-function collectMarkdownFiles(paths: string[]): CollectedFile[] {
-  const seen = new Map<string, CollectedFile>();
-
-  for (const p of paths) {
-    const expanded = expandPath(p);
-    for (const file of expanded) {
-      // First-seen wins for root attribution. If two paths discover
-      // the same file (e.g. operator passes both `essays/` and
-      // `essays/foo/index.md`), the first path's root is canonical.
-      if (!seen.has(file.filePath)) {
-        seen.set(file.filePath, file);
-      }
-    }
-  }
-
-  // Stable order so the dry-run plan is deterministic.
-  return [...seen.values()].sort((a, b) => a.filePath.localeCompare(b.filePath));
-}
-
-function expandPath(input: string): CollectedFile[] {
-  const absolute = isAbsolute(input) ? input : resolve(process.cwd(), input);
-
-  if (containsGlob(input)) {
-    return expandGlob(absolute);
-  }
-
-  if (!existsSync(absolute)) {
-    throw new Error(`Path does not exist: ${input}`);
-  }
-
-  const stat = statSync(absolute);
-  if (stat.isFile()) {
-    if (!hasMarkdownExtension(absolute)) {
-      throw new Error(
-        `Path is not a markdown file: ${input} (expected one of ${MARKDOWN_EXTENSIONS.join(', ')})`,
-      );
-    }
-    // For a single-file argument the discovery root is the file's
-    // parent — no hierarchical prefix.
-    return [{ filePath: absolute, root: dirnameOf(absolute) }];
-  }
-  if (stat.isDirectory()) {
-    return walkDirectory(absolute, absolute);
-  }
-  return [];
-}
-
-function dirnameOf(filePath: string): string {
-  const idx = filePath.lastIndexOf(sep);
-  if (idx <= 0) return sep;
-  return filePath.slice(0, idx);
-}
-
-function walkDirectory(dir: string, root: string): CollectedFile[] {
-  const out: CollectedFile[] = [];
-  const entries = readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const child = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...walkDirectory(child, root));
-    } else if (entry.isFile() && hasMarkdownExtension(entry.name)) {
-      out.push({ filePath: child, root });
-    }
-  }
-  return out;
-}
-
-function containsGlob(input: string): boolean {
-  return /[*?[]/.test(input);
-}
-
-/**
- * Minimal glob expansion supporting `*`, `**`, `?`, and `[...]` —
- * sufficient for the patterns operators reach for (e.g.
- * `src/content/essays/**\/*.md`). Avoids a runtime dep on a glob
- * library; this code is on the discovery hot path and shouldn't pull
- * in 200KB of generic matcher.
- *
- * The deepest static prefix becomes the discovery root so slugs are
- * computed relative to it (e.g. `src/posts/​**​/*.md` uses `src/posts`
- * as the slug-derivation root).
- */
-function expandGlob(absolutePattern: string): CollectedFile[] {
-  const segments = absolutePattern.split(sep);
-  // Find the deepest non-glob prefix to use as a walk root.
-  let rootEnd = 0;
-  for (let i = 0; i < segments.length; i++) {
-    if (containsGlob(segments[i])) break;
-    rootEnd = i;
-  }
-  const root = segments.slice(0, rootEnd + 1).join(sep) || sep;
-  const remainder = segments.slice(rootEnd + 1);
-
-  if (!existsSync(root)) {
-    return [];
-  }
-
-  return matchPattern(root, remainder, root);
-}
-
-function matchPattern(
-  currentDir: string,
-  remaining: string[],
-  root: string,
-): CollectedFile[] {
-  if (remaining.length === 0) {
-    if (statSync(currentDir).isFile() && hasMarkdownExtension(currentDir)) {
-      return [{ filePath: currentDir, root }];
-    }
-    return [];
-  }
-  const [head, ...rest] = remaining;
-  const out: CollectedFile[] = [];
-
-  let entries;
-  try {
-    entries = readdirSync(currentDir, { withFileTypes: true });
-  } catch {
-    return out;
-  }
-
-  if (head === '**') {
-    // Match zero or more directories, then continue with `rest`.
-    out.push(...matchPattern(currentDir, rest, root));
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        out.push(...matchPattern(join(currentDir, entry.name), remaining, root));
-      }
-    }
-    return out;
-  }
-
-  const matcher = globSegmentMatcher(head);
-  for (const entry of entries) {
-    if (!matcher(entry.name)) continue;
-    const child = join(currentDir, entry.name);
-    if (rest.length === 0) {
-      if (entry.isFile() && hasMarkdownExtension(entry.name)) {
-        out.push({ filePath: child, root });
-      }
-    } else if (entry.isDirectory()) {
-      out.push(...matchPattern(child, rest, root));
-    }
-  }
-  return out;
-}
-
-function globSegmentMatcher(pattern: string): (name: string) => boolean {
-  // Escape regex metas except our glob ones, then translate.
-  let re = '^';
-  for (let i = 0; i < pattern.length; i++) {
-    const ch = pattern[i];
-    if (ch === '*') re += '[^/]*';
-    else if (ch === '?') re += '[^/]';
-    else if (ch === '[') {
-      // copy through to ']'
-      const close = pattern.indexOf(']', i);
-      if (close === -1) {
-        re += '\\[';
-      } else {
-        re += pattern.slice(i, close + 1);
-        i = close;
-      }
-    } else if (/[\\^$+().{}|]/.test(ch)) re += `\\${ch}`;
-    else re += ch;
-  }
-  re += '$';
-  const compiled = new RegExp(re);
-  return (name) => compiled.test(name);
-}
-
-function hasMarkdownExtension(filename: string): boolean {
-  const lower = filename.toLowerCase();
-  return MARKDOWN_EXTENSIONS.some((ext) => lower.endsWith(ext));
-}
-
-// ---------------------------------------------------------------------------
-// Misc helpers
-// ---------------------------------------------------------------------------
-
-function relativeTo(projectRoot: string, filePath: string): string {
-  const rel = relative(projectRoot, filePath);
-  return rel.length > 0 ? rel : filePath;
-}
-
-function isUnderScrapbook(filePath: string, roots?: string[]): boolean {
-  if (!roots || roots.length === 0) return false;
-  for (const root of roots) {
-    const r = root.endsWith(sep) ? root : root + sep;
-    if (filePath.startsWith(r)) return true;
-  }
-  return false;
 }
 
 /**
@@ -920,4 +366,22 @@ export function candidateToEntry(
     entry.datePublished = candidate.derivedDate;
   }
   return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function relativeTo(projectRoot: string, filePath: string): string {
+  const rel = relative(projectRoot, filePath);
+  return rel.length > 0 ? rel : filePath;
+}
+
+function isUnderScrapbook(filePath: string, roots?: string[]): boolean {
+  if (!roots || roots.length === 0) return false;
+  for (const root of roots) {
+    const r = root.endsWith(sep) ? root : root + sep;
+    if (filePath.startsWith(r)) return true;
+  }
+  return false;
 }

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1,0 +1,923 @@
+/**
+ * ingest.ts — discovery primitive for backfilling existing markdown content
+ * into the editorial calendar.
+ *
+ * The ingest flow turns "files on disk" into "calendar candidates" without
+ * touching the calendar itself. The CLI layer wires this output into a
+ * dry-run plan or an `--apply` write; this module is purely descriptive.
+ *
+ * ## Responsibilities
+ *
+ *   1. Walk a list of paths (file / directory / glob) and collect markdown
+ *      files (`.md`, `.mdx`, `.markdown`).
+ *   2. For each file, parse frontmatter (best-effort — files without
+ *      frontmatter still produce a candidate; files with malformed
+ *      frontmatter surface as errors).
+ *   3. Derive `slug`, `state`, and `date` from a configurable mix of
+ *      sources (frontmatter / path / mtime / today). Each derivation
+ *      records its source so the operator can verify provenance in the
+ *      dry-run output.
+ *   4. Filter against an existing calendar — duplicates produce
+ *      `IngestSkip` records with a reason, never silent drops.
+ *
+ * ## What's intentionally out of scope
+ *
+ *   - Mutations: `discoverIngestCandidates` never writes to disk, never
+ *     mutates the calendar. The CLI command turns a candidate list into
+ *     an apply plan.
+ *   - Auto-detection of the content tree: the operator passes paths
+ *     explicitly. Walking the entire repo to "discover" content would
+ *     scoop up node_modules / vendored docs / unrelated markdown.
+ *   - Migrations from other calendar formats: source is markdown files +
+ *     their frontmatter. Importing from Notion / Airtable / a different
+ *     calendar markdown shape is a separate concern (PRD extension).
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { parseFrontmatter, type FrontmatterData } from './frontmatter.ts';
+import { isStage, type CalendarEntry, type EditorialCalendar, type Stage } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Where a derived value came from. Surfaces in the dry-run plan. */
+export type DerivationSource = 'frontmatter' | 'path' | 'mtime' | 'today' | 'explicit';
+
+/** A markdown file resolved to a (slug, state, date) triple ready to commit. */
+export interface IngestCandidate {
+  /** Absolute path to the source markdown file. */
+  filePath: string;
+  /** Path relative to the project root, when one was supplied. Display-only. */
+  relativePath: string;
+  /** Parsed YAML frontmatter (empty object when absent). */
+  frontmatter: FrontmatterData;
+  /** Body of the markdown file (everything after the closing `---`). */
+  body: string;
+  /** Derived slug; honours `--slug-from`, `--slug`, frontmatter, then path. */
+  derivedSlug: string;
+  /** Where `derivedSlug` came from. */
+  slugSource: DerivationSource;
+  /**
+   * Derived stage. `null` when the source produced an unrecognized state
+   * value — the operator must pass `--state` to commit. Surfaces in the
+   * plan as `state: ambiguous`.
+   */
+  derivedState: Stage | null;
+  /** Where `derivedState` came from. */
+  stateSource: DerivationSource;
+  /**
+   * Raw state string the source produced (e.g. `'published-elsewhere'`)
+   * when normalization failed. `undefined` when state was derived
+   * unambiguously. Surfaces in the plan to make the failure mode
+   * actionable.
+   */
+  rawState?: string;
+  /** Derived date in ISO YYYY-MM-DD form. */
+  derivedDate: string;
+  /** Where `derivedDate` came from. */
+  dateSource: DerivationSource;
+  /**
+   * Title pulled from frontmatter — falls back to a humanized slug when
+   * absent. The CLI emits this onto the new calendar row.
+   */
+  title: string;
+  /** Description pulled from frontmatter — empty string when absent. */
+  description: string;
+}
+
+/** A candidate that won't be added; carries a reason the operator can act on. */
+export interface IngestSkip {
+  filePath: string;
+  relativePath: string;
+  /** Slug we would have used; `undefined` when we couldn't derive one. */
+  slug?: string;
+  reason: string;
+}
+
+/** Result of a discovery pass — successes and skips, never mutations. */
+export interface IngestDiscoveryResult {
+  candidates: IngestCandidate[];
+  skips: IngestSkip[];
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export type SlugFrom = 'frontmatter' | 'path';
+export type StateFrom = 'frontmatter' | 'datePublished';
+
+export interface IngestOptions {
+  /**
+   * Project root for relative-path display + scrapbook detection.
+   * Required; the discovery surface always runs in the context of a
+   * deskwork-installed project.
+   */
+  projectRoot: string;
+  /** Where to derive slugs from. Default `'path'`. */
+  slugFrom?: SlugFrom;
+  /** Where to derive states from. Default `'frontmatter'`. */
+  stateFrom?: StateFrom;
+  /**
+   * Explicit slug. Only honored when discovery resolves to exactly one
+   * candidate file — the CLI enforces this before calling.
+   */
+  explicitSlug?: string;
+  /** Explicit stage. Wins over derivation when set. */
+  explicitState?: Stage;
+  /** Explicit ISO date (YYYY-MM-DD). Wins over derivation when set. */
+  explicitDate?: string;
+  /** Frontmatter field name overrides — match the operator's project schema. */
+  fieldNames?: {
+    title?: string;
+    description?: string;
+    slug?: string;
+    state?: string;
+    date?: string;
+  };
+  /**
+   * Existing calendar to filter against for idempotency. When omitted,
+   * no idempotency check runs (every candidate proceeds). The CLI
+   * always supplies this; tests omit it to exercise discovery alone.
+   */
+  calendar?: EditorialCalendar;
+  /**
+   * Bypass the duplicate-slug skip. The CLI exposes this as `--force`
+   * and warns the operator that existing rows will be left as-is —
+   * `discoverIngestCandidates` does not mutate, so "force" simply
+   * means "don't skip; pass through and let the apply layer decide".
+   */
+  force?: boolean;
+  /**
+   * Skip files under `<contentDir>/scrapbook/` — host projects use
+   * scrapbook for sketches that aren't on the editorial calendar.
+   * The CLI threads `<contentDir>/scrapbook` (one per site) into this
+   * list. Default `[]` (no skipping).
+   */
+  scrapbookRoots?: string[];
+  /** Today's date for date-derivation fallback. Test seam; defaults to now(). */
+  now?: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MARKDOWN_EXTENSIONS = ['.md', '.mdx', '.markdown'] as const;
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
+const JEKYLL_RE = /^(\d{4})-(\d{2})-(\d{2})-(.+)$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const DEFAULT_FIELDS = {
+  title: 'title',
+  description: 'description',
+  slug: 'slug',
+  state: 'state',
+  date: 'datePublished',
+} as const;
+
+/**
+ * Canonical state-string normalization. Maps frontmatter values that
+ * editorial projects commonly use onto our six lanes. Anything outside
+ * this table comes back ambiguous — the operator must pass `--state`.
+ */
+const STATE_ALIASES: Record<string, Stage> = {
+  ideas: 'Ideas',
+  idea: 'Ideas',
+  planned: 'Planned',
+  outlining: 'Outlining',
+  outline: 'Outlining',
+  drafting: 'Drafting',
+  draft: 'Drafting',
+  review: 'Review',
+  reviewing: 'Review',
+  'in-review': 'Review',
+  in_review: 'Review',
+  published: 'Published',
+  publish: 'Published',
+  ideas_lane: 'Ideas',
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the supplied paths, parse markdown files, and produce a
+ * candidate list ready to feed to the apply layer.
+ *
+ * `paths` accepts:
+ *   - a single markdown file (`.md`, `.mdx`, `.markdown`)
+ *   - a directory walked recursively
+ *   - a glob (any path containing `*` or `?`)
+ *
+ * Errors during parse (bad frontmatter, unreadable file) surface as
+ * `IngestSkip` records with a descriptive reason — discovery never
+ * throws on a per-file problem so a 100-file run isn't aborted by
+ * one corrupt source.
+ */
+export function discoverIngestCandidates(
+  paths: string[],
+  options: IngestOptions,
+): IngestDiscoveryResult {
+  if (paths.length === 0) {
+    throw new Error('discoverIngestCandidates: at least one path is required');
+  }
+  if (!options.projectRoot || !isAbsolute(options.projectRoot)) {
+    throw new Error(
+      `discoverIngestCandidates: projectRoot must be an absolute path (got "${options.projectRoot ?? ''}")`,
+    );
+  }
+
+  const collected = collectMarkdownFiles(paths);
+
+  if (options.explicitSlug !== undefined && collected.length !== 1) {
+    throw new Error(
+      `--slug requires exactly one matched file; ${collected.length} matched`,
+    );
+  }
+
+  const candidates: IngestCandidate[] = [];
+  const skips: IngestSkip[] = [];
+  const fields = { ...DEFAULT_FIELDS, ...(options.fieldNames ?? {}) };
+
+  for (const { filePath, root } of collected) {
+    if (isUnderScrapbook(filePath, options.scrapbookRoots)) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: 'file is under scrapbook/ (skipped by default)',
+      });
+      continue;
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(filePath, 'utf-8');
+    } catch (err) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: `unreadable: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    let parsed: { data: FrontmatterData; body: string };
+    try {
+      parsed = parseFrontmatter(raw);
+    } catch (err) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: `frontmatter parse failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    const slug = deriveSlug(filePath, root, parsed.data, fields, options);
+    if (!slug.value) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: slug.reason ?? 'could not derive slug',
+      });
+      continue;
+    }
+    if (!SLUG_RE.test(slug.value)) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        slug: slug.value,
+        reason:
+          `derived slug "${slug.value}" is not valid kebab-case ` +
+          `(must match [a-z0-9][a-z0-9-]* segments separated by '/')`,
+      });
+      continue;
+    }
+
+    if (
+      options.calendar &&
+      !options.force &&
+      options.calendar.entries.some((e) => e.slug === slug.value)
+    ) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        slug: slug.value,
+        reason: `calendar already has an entry with slug "${slug.value}" (use --force to override)`,
+      });
+      continue;
+    }
+
+    const state = deriveState(parsed.data, fields, options);
+    const date = deriveDate(filePath, parsed.data, fields, options);
+    const title = deriveTitle(parsed.data, fields.title, slug.value);
+    const description = deriveDescription(parsed.data, fields.description);
+
+    candidates.push({
+      filePath,
+      relativePath: relativeTo(options.projectRoot, filePath),
+      frontmatter: parsed.data,
+      body: parsed.body,
+      derivedSlug: slug.value,
+      slugSource: slug.source,
+      derivedState: state.value,
+      stateSource: state.source,
+      ...(state.rawValue !== undefined ? { rawState: state.rawValue } : {}),
+      derivedDate: date.value,
+      dateSource: date.source,
+      title,
+      description,
+    });
+  }
+
+  return { candidates, skips };
+}
+
+// ---------------------------------------------------------------------------
+// Slug derivation
+// ---------------------------------------------------------------------------
+
+interface SlugDerivation {
+  value: string;
+  source: DerivationSource;
+  reason?: string;
+}
+
+function deriveSlug(
+  filePath: string,
+  root: string,
+  frontmatter: FrontmatterData,
+  fields: { slug: string },
+  options: IngestOptions,
+): SlugDerivation {
+  if (options.explicitSlug !== undefined) {
+    return { value: options.explicitSlug, source: 'explicit' };
+  }
+
+  const slugFrom = options.slugFrom ?? 'path';
+
+  if (slugFrom === 'frontmatter') {
+    const fmSlug = readStringField(frontmatter, fields.slug);
+    if (fmSlug !== undefined) {
+      return { value: fmSlug, source: 'frontmatter' };
+    }
+    // Fall through to path when frontmatter slug is missing.
+  }
+
+  return slugFromPath(filePath, root);
+}
+
+/**
+ * Path-based slug derivation. Computes the slug from the file's path
+ * relative to its discovery root, with hierarchical-bundle detection.
+ *
+ * The "discovery root" is the path the operator passed:
+ *   - For a file argument: root is the file's parent directory.
+ *   - For a directory argument: root is that directory itself.
+ *   - For a glob: root is the deepest static prefix.
+ *
+ * Filename rules (first match wins):
+ *   1. `<dir>/index.md` or `<dir>/README.md` (case-insensitive) →
+ *      drop the suffix; the dir name becomes the slug leaf. Astro /
+ *      Hugo leaf-bundle layout.
+ *   2. Filename matches `YYYY-MM-DD-<slug>.<ext>` → strip date prefix
+ *      and extension. Jekyll posts.
+ *   3. Otherwise → filename minus extension.
+ *
+ * Hierarchy: a directory between root and the file prefixes the slug
+ * if and only if it has its own `index.md` or `README.md`. Such a
+ * directory is itself a content node with a slug, and its children
+ * nest under it. Plain directories (no own leaf bundle) are
+ * "collection containers" — their names do NOT prefix child slugs.
+ *
+ * Examples (with root = `src/content/`):
+ *
+ *   essays/whats-in-a-name/index.md
+ *     essays/ has no own index.md → slug = `whats-in-a-name`.
+ *
+ *   the-outbound/characters/strivers/index.md
+ *     If the-outbound/index.md and the-outbound/characters/index.md
+ *     both exist → slug = `the-outbound/characters/strivers`.
+ *     If only the-outbound/index.md exists → slug = `the-outbound/strivers`.
+ *     If neither exists → slug = `strivers`.
+ */
+function slugFromPath(filePath: string, root: string): SlugDerivation {
+  const rel = relative(root, filePath);
+  const segments = rel.split(sep).filter((s) => s.length > 0);
+  if (segments.length === 0) {
+    return { value: '', source: 'path', reason: 'file path equals root' };
+  }
+
+  const filename = segments[segments.length - 1];
+  const dot = filename.lastIndexOf('.');
+  const base = dot > 0 ? filename.slice(0, dot) : filename;
+  const baseLower = base.toLowerCase();
+
+  let leafSegments: string[];
+  let dirSegments: string[];
+
+  if (baseLower === 'index' || baseLower === 'readme') {
+    // Leaf-bundle: drop the index/README; the dir IS the slug leaf.
+    // When the leaf-bundle file is AT the discovery root (single
+    // segment, just `index.md`), the root's basename becomes the
+    // slug — that's the case for a single-file argument like
+    // `<...>/strivers/index.md` (root = `<...>/strivers/`).
+    if (segments.length < 2) {
+      const rootSegments = root.split(sep).filter((s) => s.length > 0);
+      const rootLeaf = rootSegments[rootSegments.length - 1];
+      if (!rootLeaf) {
+        return {
+          value: '',
+          source: 'path',
+          reason: `${filename} at the filesystem root has no directory name to derive a slug from`,
+        };
+      }
+      leafSegments = [rootLeaf];
+      dirSegments = [];
+    } else {
+      leafSegments = [segments[segments.length - 2]];
+      dirSegments = segments.slice(0, -2);
+    }
+  } else {
+    const jekyll = base.match(JEKYLL_RE);
+    leafSegments = [jekyll ? jekyll[4] : base];
+    dirSegments = segments.slice(0, -1);
+  }
+
+  // Walk directory ancestors from root → leaf. Each ancestor
+  // contributes to the slug only if it has its own index.md or
+  // README.md (i.e. it's itself a content node, not just a folder).
+  const prefix: string[] = [];
+
+  // Special case: when the discovery root itself is a content node
+  // (has its own index.md/README.md), its basename prefixes child
+  // slugs. This handles `deskwork ingest src/content/the-outbound/`
+  // when the-outbound/index.md exists.
+  if (dirSegments.length > 0 || leafSegments.length > 0) {
+    if (directoryIsHierarchicalNode(root)) {
+      const rootSegments = root.split(sep).filter((s) => s.length > 0);
+      const rootLeaf = rootSegments[rootSegments.length - 1];
+      // Avoid double-prefix when leafSegments already equals the
+      // root's basename (the case when the discovered file is the
+      // root's own index.md — handled by the leaf-bundle branch
+      // above, which set leafSegments to the root's name).
+      if (rootLeaf && leafSegments[0] !== rootLeaf) {
+        prefix.push(rootLeaf);
+      }
+    }
+  }
+
+  let cursor = root;
+  for (const dir of dirSegments) {
+    cursor = join(cursor, dir);
+    if (directoryIsHierarchicalNode(cursor)) {
+      prefix.push(dir);
+    } else {
+      // Once an ancestor isn't itself a content node, the chain ends.
+      // Anything below that point doesn't get prefixed — the
+      // operator put a non-tracked folder between content nodes,
+      // and that folder's name shouldn't bleed into the slug.
+      prefix.length = 0;
+    }
+  }
+
+  const slug = [...prefix, ...leafSegments].join('/');
+  return { value: slug, source: 'path' };
+}
+
+/**
+ * True if `dir` itself has a leaf bundle (index.md / README.md /
+ * index.mdx / README.mdx / etc.) — i.e. it's a content node whose
+ * name should prefix its children's slugs.
+ */
+function directoryIsHierarchicalNode(dir: string): boolean {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const lower = entry.name.toLowerCase();
+    for (const ext of MARKDOWN_EXTENSIONS) {
+      if (lower === `index${ext}` || lower === `readme${ext}`) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// State derivation
+// ---------------------------------------------------------------------------
+
+interface StateDerivation {
+  value: Stage | null;
+  source: DerivationSource;
+  rawValue?: string;
+}
+
+function deriveState(
+  frontmatter: FrontmatterData,
+  fields: { state: string; date: string },
+  options: IngestOptions,
+): StateDerivation {
+  if (options.explicitState !== undefined) {
+    return { value: options.explicitState, source: 'explicit' };
+  }
+  const stateFrom = options.stateFrom ?? 'frontmatter';
+
+  if (stateFrom === 'frontmatter') {
+    const raw = readStringField(frontmatter, fields.state);
+    if (raw === undefined) {
+      // No state field — default to Ideas as the safest lane.
+      return { value: 'Ideas', source: 'frontmatter' };
+    }
+    const normalized = normalizeStateString(raw);
+    if (normalized === null) {
+      return { value: null, source: 'frontmatter', rawValue: raw };
+    }
+    return { value: normalized, source: 'frontmatter' };
+  }
+
+  // stateFrom === 'datePublished'
+  const dateRaw = readDateField(frontmatter, fields.date);
+  if (dateRaw === undefined) {
+    return { value: 'Ideas', source: 'frontmatter' };
+  }
+  const today = (options.now ?? new Date()).toISOString().slice(0, 10);
+  if (dateRaw <= today) {
+    return { value: 'Published', source: 'frontmatter' };
+  }
+  return { value: 'Drafting', source: 'frontmatter' };
+}
+
+function normalizeStateString(raw: string): Stage | null {
+  const key = raw.trim().toLowerCase();
+  if (key.length === 0) return null;
+  const direct = STATE_ALIASES[key];
+  if (direct) return direct;
+  // Stage names verbatim (Title-cased) — accept them too.
+  const titled = key.charAt(0).toUpperCase() + key.slice(1);
+  if (isStage(titled)) return titled;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Date derivation
+// ---------------------------------------------------------------------------
+
+interface DateDerivation {
+  value: string;
+  source: DerivationSource;
+}
+
+function deriveDate(
+  filePath: string,
+  frontmatter: FrontmatterData,
+  fields: { date: string },
+  options: IngestOptions,
+): DateDerivation {
+  if (options.explicitDate !== undefined) {
+    return { value: options.explicitDate, source: 'explicit' };
+  }
+
+  const fmDate = readDateField(frontmatter, fields.date);
+  if (fmDate !== undefined) {
+    return { value: fmDate, source: 'frontmatter' };
+  }
+  // Try the secondary `date` field too, when the primary one was
+  // overridden — `--date-field datePublished` should still find a
+  // generic `date:` as a backstop.
+  if (fields.date !== 'date') {
+    const generic = readDateField(frontmatter, 'date');
+    if (generic !== undefined) {
+      return { value: generic, source: 'frontmatter' };
+    }
+  }
+
+  // mtime fallback — accurate enough for "approximately when the
+  // operator wrote this", but the operator can override with
+  // `--date YYYY-MM-DD`.
+  try {
+    const stat = statSync(filePath);
+    return { value: stat.mtime.toISOString().slice(0, 10), source: 'mtime' };
+  } catch {
+    // Should never happen — we just read the file. Fall through.
+  }
+
+  const today = (options.now ?? new Date()).toISOString().slice(0, 10);
+  return { value: today, source: 'today' };
+}
+
+// ---------------------------------------------------------------------------
+// Title / description / field readers
+// ---------------------------------------------------------------------------
+
+function deriveTitle(
+  frontmatter: FrontmatterData,
+  fieldName: string,
+  slug: string,
+): string {
+  const raw = readStringField(frontmatter, fieldName);
+  if (raw !== undefined && raw.length > 0) return raw;
+  // Humanize the slug as a last resort. Strip leading hierarchy
+  // segments — title for `the-outbound/characters/strivers` should
+  // be "Strivers", not "The Outbound Characters Strivers".
+  const leaf = slug.split('/').pop() ?? slug;
+  return leaf
+    .split('-')
+    .map((word) => (word.length > 0 ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(' ');
+}
+
+function deriveDescription(
+  frontmatter: FrontmatterData,
+  fieldName: string,
+): string {
+  return readStringField(frontmatter, fieldName) ?? '';
+}
+
+function readStringField(
+  frontmatter: FrontmatterData,
+  field: string,
+): string | undefined {
+  const value = frontmatter[field];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Read a date-like field. YAML may parse `2024-01-15` as a Date or as
+ * a string depending on quoting. Both shapes resolve to YYYY-MM-DD.
+ * Anything else returns undefined.
+ */
+function readDateField(
+  frontmatter: FrontmatterData,
+  field: string,
+): string | undefined {
+  const value = frontmatter[field];
+  if (value === undefined || value === null) return undefined;
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (ISO_DATE_RE.test(trimmed)) return trimmed;
+    // Try Date.parse for non-ISO formats — the operator's frontmatter
+    // might be `date: 2024/01/15` or `date: January 15, 2024`. We
+    // parse leniently and serialize as ISO.
+    const parsed = Date.parse(trimmed);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString().slice(0, 10);
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Path collection
+// ---------------------------------------------------------------------------
+
+/**
+ * A discovered markdown file paired with its discovery root — the
+ * directory the operator's path argument resolved to (or the deepest
+ * static prefix for a glob). Slug derivation computes the slug as
+ * the file's path relative to this root, so siblings of a flat
+ * collection ("essays/foo/index.md", "essays/bar/index.md") get
+ * unprefixed slugs while deeper nesting produces hierarchical slugs.
+ */
+interface CollectedFile {
+  filePath: string;
+  root: string;
+}
+
+function collectMarkdownFiles(paths: string[]): CollectedFile[] {
+  const seen = new Map<string, CollectedFile>();
+
+  for (const p of paths) {
+    const expanded = expandPath(p);
+    for (const file of expanded) {
+      // First-seen wins for root attribution. If two paths discover
+      // the same file (e.g. operator passes both `essays/` and
+      // `essays/foo/index.md`), the first path's root is canonical.
+      if (!seen.has(file.filePath)) {
+        seen.set(file.filePath, file);
+      }
+    }
+  }
+
+  // Stable order so the dry-run plan is deterministic.
+  return [...seen.values()].sort((a, b) => a.filePath.localeCompare(b.filePath));
+}
+
+function expandPath(input: string): CollectedFile[] {
+  const absolute = isAbsolute(input) ? input : resolve(process.cwd(), input);
+
+  if (containsGlob(input)) {
+    return expandGlob(absolute);
+  }
+
+  if (!existsSync(absolute)) {
+    throw new Error(`Path does not exist: ${input}`);
+  }
+
+  const stat = statSync(absolute);
+  if (stat.isFile()) {
+    if (!hasMarkdownExtension(absolute)) {
+      throw new Error(
+        `Path is not a markdown file: ${input} (expected one of ${MARKDOWN_EXTENSIONS.join(', ')})`,
+      );
+    }
+    // For a single-file argument the discovery root is the file's
+    // parent — no hierarchical prefix.
+    return [{ filePath: absolute, root: dirnameOf(absolute) }];
+  }
+  if (stat.isDirectory()) {
+    return walkDirectory(absolute, absolute);
+  }
+  return [];
+}
+
+function dirnameOf(filePath: string): string {
+  const idx = filePath.lastIndexOf(sep);
+  if (idx <= 0) return sep;
+  return filePath.slice(0, idx);
+}
+
+function walkDirectory(dir: string, root: string): CollectedFile[] {
+  const out: CollectedFile[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const child = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkDirectory(child, root));
+    } else if (entry.isFile() && hasMarkdownExtension(entry.name)) {
+      out.push({ filePath: child, root });
+    }
+  }
+  return out;
+}
+
+function containsGlob(input: string): boolean {
+  return /[*?[]/.test(input);
+}
+
+/**
+ * Minimal glob expansion supporting `*`, `**`, `?`, and `[...]` —
+ * sufficient for the patterns operators reach for (e.g.
+ * `src/content/essays/**\/*.md`). Avoids a runtime dep on a glob
+ * library; this code is on the discovery hot path and shouldn't pull
+ * in 200KB of generic matcher.
+ *
+ * The deepest static prefix becomes the discovery root so slugs are
+ * computed relative to it (e.g. `src/posts/​**​/*.md` uses `src/posts`
+ * as the slug-derivation root).
+ */
+function expandGlob(absolutePattern: string): CollectedFile[] {
+  const segments = absolutePattern.split(sep);
+  // Find the deepest non-glob prefix to use as a walk root.
+  let rootEnd = 0;
+  for (let i = 0; i < segments.length; i++) {
+    if (containsGlob(segments[i])) break;
+    rootEnd = i;
+  }
+  const root = segments.slice(0, rootEnd + 1).join(sep) || sep;
+  const remainder = segments.slice(rootEnd + 1);
+
+  if (!existsSync(root)) {
+    return [];
+  }
+
+  return matchPattern(root, remainder, root);
+}
+
+function matchPattern(
+  currentDir: string,
+  remaining: string[],
+  root: string,
+): CollectedFile[] {
+  if (remaining.length === 0) {
+    if (statSync(currentDir).isFile() && hasMarkdownExtension(currentDir)) {
+      return [{ filePath: currentDir, root }];
+    }
+    return [];
+  }
+  const [head, ...rest] = remaining;
+  const out: CollectedFile[] = [];
+
+  let entries;
+  try {
+    entries = readdirSync(currentDir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+
+  if (head === '**') {
+    // Match zero or more directories, then continue with `rest`.
+    out.push(...matchPattern(currentDir, rest, root));
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        out.push(...matchPattern(join(currentDir, entry.name), remaining, root));
+      }
+    }
+    return out;
+  }
+
+  const matcher = globSegmentMatcher(head);
+  for (const entry of entries) {
+    if (!matcher(entry.name)) continue;
+    const child = join(currentDir, entry.name);
+    if (rest.length === 0) {
+      if (entry.isFile() && hasMarkdownExtension(entry.name)) {
+        out.push({ filePath: child, root });
+      }
+    } else if (entry.isDirectory()) {
+      out.push(...matchPattern(child, rest, root));
+    }
+  }
+  return out;
+}
+
+function globSegmentMatcher(pattern: string): (name: string) => boolean {
+  // Escape regex metas except our glob ones, then translate.
+  let re = '^';
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === '*') re += '[^/]*';
+    else if (ch === '?') re += '[^/]';
+    else if (ch === '[') {
+      // copy through to ']'
+      const close = pattern.indexOf(']', i);
+      if (close === -1) {
+        re += '\\[';
+      } else {
+        re += pattern.slice(i, close + 1);
+        i = close;
+      }
+    } else if (/[\\^$+().{}|]/.test(ch)) re += `\\${ch}`;
+    else re += ch;
+  }
+  re += '$';
+  const compiled = new RegExp(re);
+  return (name) => compiled.test(name);
+}
+
+function hasMarkdownExtension(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return MARKDOWN_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers
+// ---------------------------------------------------------------------------
+
+function relativeTo(projectRoot: string, filePath: string): string {
+  const rel = relative(projectRoot, filePath);
+  return rel.length > 0 ? rel : filePath;
+}
+
+function isUnderScrapbook(filePath: string, roots?: string[]): boolean {
+  if (!roots || roots.length === 0) return false;
+  for (const root of roots) {
+    const r = root.endsWith(sep) ? root : root + sep;
+    if (filePath.startsWith(r)) return true;
+  }
+  return false;
+}
+
+/**
+ * Build the CalendarEntry that the apply layer will append for a
+ * given candidate. Pure shaping — does not touch the calendar.
+ */
+export function candidateToEntry(
+  candidate: IngestCandidate,
+  stage: Stage,
+): Omit<CalendarEntry, 'id'> {
+  const entry: Omit<CalendarEntry, 'id'> = {
+    slug: candidate.derivedSlug,
+    title: candidate.title,
+    description: candidate.description,
+    stage,
+    targetKeywords: [],
+    source: 'manual',
+  };
+  // Published entries carry datePublished; other lanes don't (the
+  // calendar renderer only emits the column for Published).
+  if (stage === 'Published') {
+    entry.datePublished = candidate.derivedDate;
+  }
+  return entry;
+}

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -1,0 +1,568 @@
+/**
+ * Unit coverage for the ingest discovery primitive.
+ *
+ * Each test builds a real on-disk fixture under tmpdir() (no fs mocks)
+ * and exercises a single derivation rule or filter behavior. Tests run
+ * sequentially per project to avoid stomping on shared cwd.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  utimesSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  discoverIngestCandidates,
+  candidateToEntry,
+  type IngestOptions,
+} from '../src/ingest.ts';
+import type { EditorialCalendar } from '../src/types.ts';
+
+let project: string;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'deskwork-ingest-'));
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+});
+
+function write(path: string, contents: string): string {
+  const abs = join(project, path);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, contents, 'utf-8');
+  return abs;
+}
+
+function setMtime(abs: string, iso: string): void {
+  const t = new Date(iso);
+  utimesSync(abs, t, t);
+}
+
+function baseOpts(overrides?: Partial<IngestOptions>): IngestOptions {
+  return {
+    projectRoot: project,
+    ...overrides,
+  };
+}
+
+describe('discoverIngestCandidates — slug derivation', () => {
+  it('uses parent dir name for <slug>/index.md', () => {
+    write(
+      'src/content/essays/whats-in-a-name/index.md',
+      '---\ntitle: Whats In A Name\nstate: published\ndatePublished: 2020-10-01\n---\n\nbody',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'src/content/essays/whats-in-a-name/index.md')],
+      baseOpts(),
+    );
+    expect(r.skips).toEqual([]);
+    expect(r.candidates).toHaveLength(1);
+    expect(r.candidates[0].derivedSlug).toBe('whats-in-a-name');
+    expect(r.candidates[0].slugSource).toBe('path');
+  });
+
+  it('uses parent dir name for <slug>/README.md', () => {
+    write(
+      'content/posts/hello/README.md',
+      '---\ntitle: Hello\n---\n\nhi',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'content/posts/hello/README.md')],
+      baseOpts(),
+    );
+    expect(r.candidates[0].derivedSlug).toBe('hello');
+  });
+
+  it('recognizes Jekyll YYYY-MM-DD-<slug>.md', () => {
+    write(
+      '_posts/2024-01-15-hello-world.md',
+      '---\ntitle: Hello World\n---\n\nbody',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, '_posts/2024-01-15-hello-world.md')],
+      baseOpts(),
+    );
+    expect(r.candidates[0].derivedSlug).toBe('hello-world');
+    expect(r.candidates[0].slugSource).toBe('path');
+  });
+
+  it('uses filename minus extension for flat <slug>.md', () => {
+    write('posts/foo.md', '---\ntitle: Foo\n---\n\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'posts/foo.md')],
+      baseOpts(),
+    );
+    expect(r.candidates[0].derivedSlug).toBe('foo');
+  });
+
+  it('produces hierarchical slugs only when ancestors are content nodes (have own index.md)', () => {
+    // the-outbound and characters both have their own index.md — they're
+    // tracked content nodes, so their names prefix child slugs.
+    write(
+      'src/content/the-outbound/index.md',
+      '---\ntitle: The Outbound\n---\nbody',
+    );
+    write(
+      'src/content/the-outbound/characters/index.md',
+      '---\ntitle: Characters\n---\nbody',
+    );
+    write(
+      'src/content/the-outbound/characters/strivers/index.md',
+      '---\ntitle: Strivers\n---\nbody',
+    );
+    write(
+      'src/content/the-outbound/characters/dreamers/index.md',
+      '---\ntitle: Dreamers\n---\nbody',
+    );
+    write(
+      'src/content/the-outbound/structure/index.md',
+      '---\ntitle: Structure\n---\nbody',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'src/content/the-outbound')],
+      baseOpts(),
+    );
+    expect(r.skips).toEqual([]);
+    const slugs = r.candidates.map((c) => c.derivedSlug).sort();
+    // the-outbound/index.md → slug "the-outbound" (relative to root, just leaf)
+    // characters/index.md → "characters" (parent the-outbound has own index, prefixes)
+    // strivers → prefixed via characters → "the-outbound/characters/strivers"
+    expect(slugs).toEqual([
+      'the-outbound',
+      'the-outbound/characters',
+      'the-outbound/characters/dreamers',
+      'the-outbound/characters/strivers',
+      'the-outbound/structure',
+    ]);
+  });
+
+  it('does NOT prefix collection root onto child slugs when root has no own index.md', () => {
+    // essays/ has no essays/index.md → it's a collection container,
+    // not a content node. Children get unprefixed slugs.
+    write(
+      'src/content/essays/foo/index.md',
+      '---\ntitle: Foo\n---\nbody',
+    );
+    write(
+      'src/content/essays/bar/index.md',
+      '---\ntitle: Bar\n---\nbody',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'src/content/essays')],
+      baseOpts(),
+    );
+    const slugs = r.candidates.map((c) => c.derivedSlug).sort();
+    expect(slugs).toEqual(['bar', 'foo']);
+  });
+
+  it('honors --slug-from frontmatter', () => {
+    write(
+      'src/content/posts/anything.md',
+      '---\nslug: my-real-slug\ntitle: Whatever\n---\nbody',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'src/content/posts/anything.md')],
+      baseOpts({ slugFrom: 'frontmatter' }),
+    );
+    expect(r.candidates[0].derivedSlug).toBe('my-real-slug');
+    expect(r.candidates[0].slugSource).toBe('frontmatter');
+  });
+
+  it('falls back to path when --slug-from frontmatter has no slug field', () => {
+    write(
+      'src/content/posts/file-name-here.md',
+      '---\ntitle: Whatever\n---\nbody',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'src/content/posts/file-name-here.md')],
+      baseOpts({ slugFrom: 'frontmatter' }),
+    );
+    expect(r.candidates[0].derivedSlug).toBe('file-name-here');
+    expect(r.candidates[0].slugSource).toBe('path');
+  });
+
+  it('supports custom slug-field name', () => {
+    write(
+      'src/posts/x.md',
+      '---\npermalink: special-slug\ntitle: X\n---\n',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'src/posts/x.md')],
+      baseOpts({
+        slugFrom: 'frontmatter',
+        fieldNames: { slug: 'permalink' },
+      }),
+    );
+    expect(r.candidates[0].derivedSlug).toBe('special-slug');
+  });
+
+  it('explicit slug overrides everything for single-file ingest', () => {
+    write('src/posts/x.md', '---\nslug: ignored\ntitle: X\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'src/posts/x.md')],
+      baseOpts({ explicitSlug: 'manual-override' }),
+    );
+    expect(r.candidates[0].derivedSlug).toBe('manual-override');
+    expect(r.candidates[0].slugSource).toBe('explicit');
+  });
+
+  it('rejects --slug when more than one file matches', () => {
+    write('a/x.md', '---\ntitle: x\n---\n');
+    write('a/y.md', '---\ntitle: y\n---\n');
+    expect(() =>
+      discoverIngestCandidates([join(project, 'a')], baseOpts({ explicitSlug: 'foo' })),
+    ).toThrow(/exactly one matched file/);
+  });
+
+  it('skips files with malformed kebab-case derived slug', () => {
+    write('posts/Bad_Name!.md', '---\ntitle: Bad\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'posts/Bad_Name!.md')],
+      baseOpts(),
+    );
+    expect(r.candidates).toEqual([]);
+    expect(r.skips).toHaveLength(1);
+    expect(r.skips[0].reason).toMatch(/not valid kebab-case/);
+  });
+});
+
+describe('discoverIngestCandidates — state derivation', () => {
+  it('reads `state: published` from frontmatter', () => {
+    write(
+      'p.md',
+      '---\ntitle: P\nstate: published\n---\n',
+    );
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedState).toBe('Published');
+    expect(r.candidates[0].stateSource).toBe('frontmatter');
+  });
+
+  it('maps `state: draft` → Drafting', () => {
+    write('p.md', '---\ntitle: P\nstate: draft\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedState).toBe('Drafting');
+  });
+
+  it('maps `state: outline` → Outlining', () => {
+    write('p.md', '---\ntitle: P\nstate: outline\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedState).toBe('Outlining');
+  });
+
+  it('maps `state: planned` → Planned', () => {
+    write('p.md', '---\ntitle: P\nstate: planned\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedState).toBe('Planned');
+  });
+
+  it('reports ambiguous state for unrecognized values', () => {
+    write('p.md', '---\ntitle: P\nstate: published-elsewhere\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedState).toBeNull();
+    expect(r.candidates[0].rawState).toBe('published-elsewhere');
+  });
+
+  it('defaults to Ideas when no state field is present', () => {
+    write('p.md', '---\ntitle: P\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedState).toBe('Ideas');
+  });
+
+  it('--state-from datePublished + past date → Published', () => {
+    write(
+      'p.md',
+      '---\ntitle: P\ndatePublished: 2020-01-15\n---\n',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'p.md')],
+      baseOpts({ stateFrom: 'datePublished', now: new Date('2026-04-01') }),
+    );
+    expect(r.candidates[0].derivedState).toBe('Published');
+  });
+
+  it('--state-from datePublished + future date → Drafting', () => {
+    write(
+      'p.md',
+      '---\ntitle: P\ndatePublished: 2099-01-15\n---\n',
+    );
+    const r = discoverIngestCandidates(
+      [join(project, 'p.md')],
+      baseOpts({ stateFrom: 'datePublished', now: new Date('2026-04-01') }),
+    );
+    expect(r.candidates[0].derivedState).toBe('Drafting');
+  });
+
+  it('explicit --state wins over derivation', () => {
+    write('p.md', '---\ntitle: P\nstate: published\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'p.md')],
+      baseOpts({ explicitState: 'Drafting' }),
+    );
+    expect(r.candidates[0].derivedState).toBe('Drafting');
+    expect(r.candidates[0].stateSource).toBe('explicit');
+  });
+
+  it('honors custom state-field name', () => {
+    write('p.md', '---\ntitle: P\nstatus: draft\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'p.md')],
+      baseOpts({ fieldNames: { state: 'status' } }),
+    );
+    expect(r.candidates[0].derivedState).toBe('Drafting');
+  });
+});
+
+describe('discoverIngestCandidates — date derivation', () => {
+  it('reads ISO datePublished from frontmatter', () => {
+    write(
+      'p.md',
+      '---\ntitle: P\ndatePublished: 2020-10-01\n---\n',
+    );
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedDate).toBe('2020-10-01');
+    expect(r.candidates[0].dateSource).toBe('frontmatter');
+  });
+
+  it('falls back to `date` field when datePublished is absent', () => {
+    write('p.md', '---\ntitle: P\ndate: 2019-05-04\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedDate).toBe('2019-05-04');
+  });
+
+  it('honors custom date-field name', () => {
+    write('p.md', '---\ntitle: P\nshippedOn: 2018-03-03\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'p.md')],
+      baseOpts({ fieldNames: { date: 'shippedOn' } }),
+    );
+    expect(r.candidates[0].derivedDate).toBe('2018-03-03');
+  });
+
+  it('falls back to mtime when no date in frontmatter', () => {
+    const abs = write('p.md', '---\ntitle: P\n---\n');
+    setMtime(abs, '2017-07-07T00:00:00Z');
+    const r = discoverIngestCandidates([abs], baseOpts());
+    expect(r.candidates[0].derivedDate).toBe('2017-07-07');
+    expect(r.candidates[0].dateSource).toBe('mtime');
+  });
+
+  it('explicit --date wins', () => {
+    write('p.md', '---\ntitle: P\ndatePublished: 2020-01-01\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'p.md')],
+      baseOpts({ explicitDate: '1999-12-31' }),
+    );
+    expect(r.candidates[0].derivedDate).toBe('1999-12-31');
+    expect(r.candidates[0].dateSource).toBe('explicit');
+  });
+
+  it('parses YAML-native Date values (unquoted YYYY-MM-DD)', () => {
+    // unquoted YYYY-MM-DD parses to a JS Date in `yaml`; verify the
+    // reader normalizes that back to ISO string form.
+    write(
+      'p.md',
+      '---\ntitle: P\ndatePublished: 2021-06-15\n---\n',
+    );
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].derivedDate).toBe('2021-06-15');
+  });
+});
+
+describe('discoverIngestCandidates — idempotency', () => {
+  function calendarWith(slug: string): EditorialCalendar {
+    return {
+      entries: [
+        {
+          id: 'fake-id',
+          slug,
+          title: 'existing',
+          description: '',
+          stage: 'Published',
+          targetKeywords: [],
+          source: 'manual',
+        },
+      ],
+      distributions: [],
+    };
+  }
+
+  it('skips candidates whose slug already exists', () => {
+    write('posts/foo.md', '---\ntitle: Foo\nstate: published\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'posts/foo.md')],
+      baseOpts({ calendar: calendarWith('foo') }),
+    );
+    expect(r.candidates).toEqual([]);
+    expect(r.skips).toHaveLength(1);
+    expect(r.skips[0].slug).toBe('foo');
+    expect(r.skips[0].reason).toMatch(/already has an entry/);
+  });
+
+  it('--force bypasses the duplicate skip', () => {
+    write('posts/foo.md', '---\ntitle: Foo\nstate: published\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'posts/foo.md')],
+      baseOpts({ calendar: calendarWith('foo'), force: true }),
+    );
+    expect(r.skips).toEqual([]);
+    expect(r.candidates).toHaveLength(1);
+  });
+});
+
+describe('discoverIngestCandidates — discovery', () => {
+  it('walks a directory recursively for markdown files', () => {
+    write('a/x.md', '---\ntitle: x\n---\n');
+    write('a/b/y.md', '---\ntitle: y\n---\n');
+    write('a/b/c/z.md', '---\ntitle: z\n---\n');
+    write('a/ignore.txt', 'not markdown');
+    const r = discoverIngestCandidates([join(project, 'a')], baseOpts());
+    // Directories (a/, b/, c/) have no own index.md → slugs aren't
+    // prefixed by their names.
+    const slugs = r.candidates.map((c) => c.derivedSlug).sort();
+    expect(slugs).toEqual(['x', 'y', 'z']);
+  });
+
+  it('expands glob patterns', () => {
+    write('content/posts/2024/a.md', '---\ntitle: a\n---\n');
+    write('content/posts/2025/b.md', '---\ntitle: b\n---\n');
+    write('content/notes/c.md', '---\ntitle: c\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'content/posts/**/*.md')],
+      baseOpts(),
+    );
+    // Glob's static prefix is `content/posts/`. 2024/ and 2025/ have
+    // no own index.md, so they don't prefix slugs.
+    const slugs = r.candidates.map((c) => c.derivedSlug).sort();
+    expect(slugs).toEqual(['a', 'b']);
+  });
+
+  it('accepts a single file directly', () => {
+    write('p.md', '---\ntitle: Pee\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates).toHaveLength(1);
+  });
+
+  it('throws on nonexistent paths', () => {
+    expect(() =>
+      discoverIngestCandidates([join(project, 'nope.md')], baseOpts()),
+    ).toThrow(/does not exist/);
+  });
+
+  it('throws on a non-markdown file path', () => {
+    write('foo.txt', 'hello');
+    expect(() =>
+      discoverIngestCandidates([join(project, 'foo.txt')], baseOpts()),
+    ).toThrow(/not a markdown file/);
+  });
+
+  it('skips files under scrapbook roots', () => {
+    write('content/posts/x.md', '---\ntitle: x\n---\n');
+    write('content/scrapbook/secret/y.md', '---\ntitle: y\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'content')],
+      baseOpts({ scrapbookRoots: [join(project, 'content/scrapbook')] }),
+    );
+    expect(r.candidates.map((c) => c.derivedSlug)).toEqual(['x']);
+    expect(r.skips).toHaveLength(1);
+    expect(r.skips[0].reason).toMatch(/scrapbook/);
+  });
+
+  it('handles a malformed-frontmatter file as a skip, not a throw', () => {
+    write('bad.md', '---\nthis is: not: parseable: YAML:\n---\nbody');
+    write('good.md', '---\ntitle: Good\n---\nbody');
+    const r = discoverIngestCandidates(
+      [join(project, 'bad.md'), join(project, 'good.md')],
+      baseOpts(),
+    );
+    expect(r.candidates.map((c) => c.derivedSlug)).toEqual(['good']);
+    expect(r.skips).toHaveLength(1);
+    expect(r.skips[0].reason).toMatch(/frontmatter parse failed/);
+  });
+
+  it('deduplicates files matched by multiple paths', () => {
+    write('a/x.md', '---\ntitle: x\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'a/x.md'), join(project, 'a')],
+      baseOpts(),
+    );
+    expect(r.candidates).toHaveLength(1);
+  });
+
+  it('throws when no paths supplied', () => {
+    expect(() => discoverIngestCandidates([], baseOpts())).toThrow(/at least one path/);
+  });
+
+  it('requires absolute projectRoot', () => {
+    write('p.md', '---\ntitle: p\n---\n');
+    expect(() =>
+      discoverIngestCandidates([join(project, 'p.md')], { projectRoot: 'rel/path' }),
+    ).toThrow(/absolute path/);
+  });
+});
+
+describe('discoverIngestCandidates — title and description', () => {
+  it('reads title from frontmatter', () => {
+    write('p.md', '---\ntitle: My Real Title\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].title).toBe('My Real Title');
+  });
+
+  it('humanizes the slug leaf when no title field is set', () => {
+    write('the-outbound/characters/strivers/index.md', '---\nstate: planned\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'the-outbound/characters/strivers/index.md')],
+      baseOpts(),
+    );
+    // Single-file argument → root is the file's parent
+    // (`.../strivers`) → slug is `strivers`. Title humanizes to "Strivers".
+    expect(r.candidates[0].title).toBe('Strivers');
+  });
+
+  it('reads description from frontmatter', () => {
+    write('p.md', '---\ntitle: P\ndescription: a great post\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    expect(r.candidates[0].description).toBe('a great post');
+  });
+
+  it('honors custom title-field name', () => {
+    write('p.md', '---\nheading: Heading As Title\n---\n');
+    const r = discoverIngestCandidates(
+      [join(project, 'p.md')],
+      baseOpts({ fieldNames: { title: 'heading' } }),
+    );
+    expect(r.candidates[0].title).toBe('Heading As Title');
+  });
+});
+
+describe('candidateToEntry', () => {
+  it('builds a CalendarEntry shape from a candidate', () => {
+    write(
+      'p.md',
+      '---\ntitle: T\ndescription: D\nstate: published\ndatePublished: 2020-01-01\n---\n',
+    );
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    const entry = candidateToEntry(r.candidates[0], 'Published');
+    expect(entry).toMatchObject({
+      slug: 'p',
+      title: 'T',
+      description: 'D',
+      stage: 'Published',
+      datePublished: '2020-01-01',
+      source: 'manual',
+    });
+  });
+
+  it('omits datePublished for non-Published lanes', () => {
+    write('p.md', '---\ntitle: T\ndatePublished: 2020-01-01\n---\n');
+    const r = discoverIngestCandidates([join(project, 'p.md')], baseOpts());
+    const entry = candidateToEntry(r.candidates[0], 'Drafting');
+    expect(entry.datePublished).toBeUndefined();
+  });
+});

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/studio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Editorial review studio — local web UI for the deskwork plugin",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/studio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Editorial review studio — local web UI for the deskwork plugin",

--- a/plugins/deskwork-studio/.claude-plugin/plugin.json
+++ b/plugins/deskwork-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork-studio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Web studio for the deskwork editorial calendar — dashboard, longform review, scrapbook, and a manual at /dev/editorial-help",
   "homepage": "https://github.com/audiocontrol-org/deskwork",
   "repository": "https://github.com/audiocontrol-org/deskwork",

--- a/plugins/deskwork-studio/.claude-plugin/plugin.json
+++ b/plugins/deskwork-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork-studio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Web studio for the deskwork editorial calendar — dashboard, longform review, scrapbook, and a manual at /dev/editorial-help",
   "homepage": "https://github.com/audiocontrol-org/deskwork",
   "repository": "https://github.com/audiocontrol-org/deskwork",

--- a/plugins/deskwork-studio/package.json
+++ b/plugins/deskwork-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/plugin-studio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Web studio plugin for Claude Code — thin shell pointing at @deskwork/studio",
   "license": "GPL-3.0-or-later",

--- a/plugins/deskwork-studio/package.json
+++ b/plugins/deskwork-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/plugin-studio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Web studio plugin for Claude Code — thin shell pointing at @deskwork/studio",
   "license": "GPL-3.0-or-later",

--- a/plugins/deskwork/.claude-plugin/plugin.json
+++ b/plugins/deskwork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Editorial calendar lifecycle for Claude Code — capture, plan, draft, publish, and distribute content through an agent-driven workflow",
   "homepage": "https://github.com/audiocontrol-org/deskwork",
   "repository": "https://github.com/audiocontrol-org/deskwork",

--- a/plugins/deskwork/.claude-plugin/plugin.json
+++ b/plugins/deskwork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deskwork",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Editorial calendar lifecycle for Claude Code — capture, plan, draft, publish, and distribute content through an agent-driven workflow",
   "homepage": "https://github.com/audiocontrol-org/deskwork",
   "repository": "https://github.com/audiocontrol-org/deskwork",

--- a/plugins/deskwork/bundle/cli.mjs
+++ b/plugins/deskwork/bundle/cli.mjs
@@ -5439,10 +5439,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep: sep2, value } = collItem;
+        const { start, key, sep: sep4, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep2?.[0],
+          next: key ?? sep4?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -5456,7 +5456,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep2) {
+          if (!keyProps.anchor && !keyProps.tag && !sep4) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -5480,7 +5480,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep2 ?? [], {
+        const valueProps = resolveProps.resolveProps(sep4 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -5496,7 +5496,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep2, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep4, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -5587,7 +5587,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep2 = "";
+        let sep4 = "";
         for (const token of end) {
           const { source, type } = token;
           switch (type) {
@@ -5601,13 +5601,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep2 + cb;
-              sep2 = "";
+                comment += sep4 + cb;
+              sep4 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep2 += source;
+                sep4 += source;
               hasSpace = true;
               break;
             default:
@@ -5650,18 +5650,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep: sep2, value } = collItem;
+        const { start, key, sep: sep4, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep2?.[0],
+          next: key ?? sep4?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep2 && !value) {
+          if (!props.anchor && !props.tag && !sep4 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -5715,8 +5715,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep2 && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep2, null, props, onError);
+        if (!isMap && !sep4 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep4, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -5728,7 +5728,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep2 ?? [], {
+          const valueProps = resolveProps.resolveProps(sep4 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -5739,8 +5739,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep2)
-                for (const st of sep2) {
+              if (sep4)
+                for (const st of sep4) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -5757,7 +5757,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep2, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep4, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -5937,7 +5937,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep2 = "";
+      let sep4 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -5954,24 +5954,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep2 + indent.slice(trimIndent) + content;
-          sep2 = "\n";
+          value += sep4 + indent.slice(trimIndent) + content;
+          sep4 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep2 === " ")
-            sep2 = "\n";
-          else if (!prevMoreIndented && sep2 === "\n")
-            sep2 = "\n\n";
-          value += sep2 + indent.slice(trimIndent) + content;
-          sep2 = "\n";
+          if (sep4 === " ")
+            sep4 = "\n";
+          else if (!prevMoreIndented && sep4 === "\n")
+            sep4 = "\n\n";
+          value += sep4 + indent.slice(trimIndent) + content;
+          sep4 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep2 === "\n")
+          if (sep4 === "\n")
             value += "\n";
           else
-            sep2 = "\n";
+            sep4 = "\n";
         } else {
-          value += sep2 + content;
-          sep2 = " ";
+          value += sep4 + content;
+          sep4 = " ";
           prevMoreIndented = false;
         }
       }
@@ -6153,25 +6153,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep2 = " ";
+      let sep4 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep2 === "\n")
-            res += sep2;
+          if (sep4 === "\n")
+            res += sep4;
           else
-            sep2 = "\n";
+            sep4 = "\n";
         } else {
-          res += sep2 + match[1];
-          sep2 = " ";
+          res += sep4 + match[1];
+          sep4 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep2 + (match?.[1] ?? "");
+      return res + sep4 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -6978,14 +6978,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep: sep2, value }) {
+    function stringifyItem({ start, key, sep: sep4, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep2)
-        for (const st of sep2)
+      if (sep4)
+        for (const st of sep4)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -8135,18 +8135,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep2;
+          let sep4;
           if (scalar.end) {
-            sep2 = scalar.end;
-            sep2.push(this.sourceToken);
+            sep4 = scalar.end;
+            sep4.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep2 = [this.sourceToken];
+            sep4 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep: sep2 }]
+            items: [{ start, key: scalar, sep: sep4 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -8299,15 +8299,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep2 = it.sep;
-                  sep2.push(this.sourceToken);
+                  const sep4 = it.sep;
+                  sep4.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep: sep2 }]
+                    items: [{ start: start2, key, sep: sep4 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -8501,13 +8501,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep2 = fc.end.splice(1, fc.end.length);
-            sep2.push(this.sourceToken);
+            const sep4 = fc.end.splice(1, fc.end.length);
+            sep4.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep: sep2 }]
+              items: [{ start, key: fc, sep: sep4 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -8829,298 +8829,25 @@ var init_frontmatter = __esm({
   }
 });
 
-// ../core/src/ingest.ts
+// ../core/src/ingest-paths.ts
 import {
   existsSync as existsSync3,
-  readFileSync as readFileSync5,
   readdirSync as readdirSync2,
   statSync
 } from "node:fs";
-import { isAbsolute as isAbsolute2, join as join5, relative, resolve as resolve2, sep } from "node:path";
-function discoverIngestCandidates(paths, options) {
-  if (paths.length === 0) {
-    throw new Error("discoverIngestCandidates: at least one path is required");
-  }
-  if (!options.projectRoot || !isAbsolute2(options.projectRoot)) {
-    throw new Error(
-      `discoverIngestCandidates: projectRoot must be an absolute path (got "${options.projectRoot ?? ""}")`
-    );
-  }
-  const collected = collectMarkdownFiles(paths);
-  if (options.explicitSlug !== void 0 && collected.length !== 1) {
-    throw new Error(
-      `--slug requires exactly one matched file; ${collected.length} matched`
-    );
-  }
-  const candidates = [];
-  const skips = [];
-  const fields = { ...DEFAULT_FIELDS, ...options.fieldNames ?? {} };
-  for (const { filePath, root } of collected) {
-    if (isUnderScrapbook(filePath, options.scrapbookRoots)) {
-      skips.push({
-        filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
-        reason: "file is under scrapbook/ (skipped by default)"
-      });
-      continue;
-    }
-    let raw;
-    try {
-      raw = readFileSync5(filePath, "utf-8");
-    } catch (err2) {
-      skips.push({
-        filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
-        reason: `unreadable: ${err2 instanceof Error ? err2.message : String(err2)}`
-      });
-      continue;
-    }
-    let parsed;
-    try {
-      parsed = parseFrontmatter(raw);
-    } catch (err2) {
-      skips.push({
-        filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
-        reason: `frontmatter parse failed: ${err2 instanceof Error ? err2.message : String(err2)}`
-      });
-      continue;
-    }
-    const slug = deriveSlug(filePath, root, parsed.data, fields, options);
-    if (!slug.value) {
-      skips.push({
-        filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
-        reason: slug.reason ?? "could not derive slug"
-      });
-      continue;
-    }
-    if (!SLUG_RE.test(slug.value)) {
-      skips.push({
-        filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
-        slug: slug.value,
-        reason: `derived slug "${slug.value}" is not valid kebab-case (must match [a-z0-9][a-z0-9-]* segments separated by '/')`
-      });
-      continue;
-    }
-    if (options.calendar && !options.force && options.calendar.entries.some((e) => e.slug === slug.value)) {
-      skips.push({
-        filePath,
-        relativePath: relativeTo(options.projectRoot, filePath),
-        slug: slug.value,
-        reason: `calendar already has an entry with slug "${slug.value}" (use --force to override)`
-      });
-      continue;
-    }
-    const state = deriveState(parsed.data, fields, options);
-    const date = deriveDate(filePath, parsed.data, fields, options);
-    const title = deriveTitle(parsed.data, fields.title, slug.value);
-    const description = deriveDescription(parsed.data, fields.description);
-    candidates.push({
-      filePath,
-      relativePath: relativeTo(options.projectRoot, filePath),
-      frontmatter: parsed.data,
-      body: parsed.body,
-      derivedSlug: slug.value,
-      slugSource: slug.source,
-      derivedState: state.value,
-      stateSource: state.source,
-      ...state.rawValue !== void 0 ? { rawState: state.rawValue } : {},
-      derivedDate: date.value,
-      dateSource: date.source,
-      title,
-      description
-    });
-  }
-  return { candidates, skips };
-}
-function deriveSlug(filePath, root, frontmatter, fields, options) {
-  if (options.explicitSlug !== void 0) {
-    return { value: options.explicitSlug, source: "explicit" };
-  }
-  const slugFrom = options.slugFrom ?? "path";
-  if (slugFrom === "frontmatter") {
-    const fmSlug = readStringField(frontmatter, fields.slug);
-    if (fmSlug !== void 0) {
-      return { value: fmSlug, source: "frontmatter" };
-    }
-  }
-  return slugFromPath(filePath, root);
-}
-function slugFromPath(filePath, root) {
-  const rel = relative(root, filePath);
-  const segments = rel.split(sep).filter((s) => s.length > 0);
-  if (segments.length === 0) {
-    return { value: "", source: "path", reason: "file path equals root" };
-  }
-  const filename = segments[segments.length - 1];
-  const dot = filename.lastIndexOf(".");
-  const base = dot > 0 ? filename.slice(0, dot) : filename;
-  const baseLower = base.toLowerCase();
-  let leafSegments;
-  let dirSegments;
-  if (baseLower === "index" || baseLower === "readme") {
-    if (segments.length < 2) {
-      const rootSegments = root.split(sep).filter((s) => s.length > 0);
-      const rootLeaf = rootSegments[rootSegments.length - 1];
-      if (!rootLeaf) {
-        return {
-          value: "",
-          source: "path",
-          reason: `${filename} at the filesystem root has no directory name to derive a slug from`
-        };
-      }
-      leafSegments = [rootLeaf];
-      dirSegments = [];
-    } else {
-      leafSegments = [segments[segments.length - 2]];
-      dirSegments = segments.slice(0, -2);
-    }
-  } else {
-    const jekyll = base.match(JEKYLL_RE);
-    leafSegments = [jekyll ? jekyll[4] : base];
-    dirSegments = segments.slice(0, -1);
-  }
-  const prefix = [];
-  if (dirSegments.length > 0 || leafSegments.length > 0) {
-    if (directoryIsHierarchicalNode(root)) {
-      const rootSegments = root.split(sep).filter((s) => s.length > 0);
-      const rootLeaf = rootSegments[rootSegments.length - 1];
-      if (rootLeaf && leafSegments[0] !== rootLeaf) {
-        prefix.push(rootLeaf);
-      }
-    }
-  }
-  let cursor = root;
-  for (const dir of dirSegments) {
-    cursor = join5(cursor, dir);
-    if (directoryIsHierarchicalNode(cursor)) {
-      prefix.push(dir);
-    } else {
-      prefix.length = 0;
-    }
-  }
-  const slug = [...prefix, ...leafSegments].join("/");
-  return { value: slug, source: "path" };
-}
-function directoryIsHierarchicalNode(dir) {
-  let entries;
-  try {
-    entries = readdirSync2(dir, { withFileTypes: true });
-  } catch {
-    return false;
-  }
-  for (const entry of entries) {
-    if (!entry.isFile()) continue;
-    const lower = entry.name.toLowerCase();
-    for (const ext of MARKDOWN_EXTENSIONS) {
-      if (lower === `index${ext}` || lower === `readme${ext}`) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-function deriveState(frontmatter, fields, options) {
-  if (options.explicitState !== void 0) {
-    return { value: options.explicitState, source: "explicit" };
-  }
-  const stateFrom = options.stateFrom ?? "frontmatter";
-  if (stateFrom === "frontmatter") {
-    const raw = readStringField(frontmatter, fields.state);
-    if (raw === void 0) {
-      return { value: "Ideas", source: "frontmatter" };
-    }
-    const normalized = normalizeStateString(raw);
-    if (normalized === null) {
-      return { value: null, source: "frontmatter", rawValue: raw };
-    }
-    return { value: normalized, source: "frontmatter" };
-  }
-  const dateRaw = readDateField(frontmatter, fields.date);
-  if (dateRaw === void 0) {
-    return { value: "Ideas", source: "frontmatter" };
-  }
-  const today = (options.now ?? /* @__PURE__ */ new Date()).toISOString().slice(0, 10);
-  if (dateRaw <= today) {
-    return { value: "Published", source: "frontmatter" };
-  }
-  return { value: "Drafting", source: "frontmatter" };
-}
-function normalizeStateString(raw) {
-  const key = raw.trim().toLowerCase();
-  if (key.length === 0) return null;
-  const direct = STATE_ALIASES[key];
-  if (direct) return direct;
-  const titled = key.charAt(0).toUpperCase() + key.slice(1);
-  if (isStage(titled)) return titled;
-  return null;
-}
-function deriveDate(filePath, frontmatter, fields, options) {
-  if (options.explicitDate !== void 0) {
-    return { value: options.explicitDate, source: "explicit" };
-  }
-  const fmDate = readDateField(frontmatter, fields.date);
-  if (fmDate !== void 0) {
-    return { value: fmDate, source: "frontmatter" };
-  }
-  if (fields.date !== "date") {
-    const generic = readDateField(frontmatter, "date");
-    if (generic !== void 0) {
-      return { value: generic, source: "frontmatter" };
-    }
-  }
-  try {
-    const stat = statSync(filePath);
-    return { value: stat.mtime.toISOString().slice(0, 10), source: "mtime" };
-  } catch {
-  }
-  const today = (options.now ?? /* @__PURE__ */ new Date()).toISOString().slice(0, 10);
-  return { value: today, source: "today" };
-}
-function deriveTitle(frontmatter, fieldName, slug) {
-  const raw = readStringField(frontmatter, fieldName);
-  if (raw !== void 0 && raw.length > 0) return raw;
-  const leaf = slug.split("/").pop() ?? slug;
-  return leaf.split("-").map((word) => word.length > 0 ? word[0].toUpperCase() + word.slice(1) : word).join(" ");
-}
-function deriveDescription(frontmatter, fieldName) {
-  return readStringField(frontmatter, fieldName) ?? "";
-}
-function readStringField(frontmatter, field) {
-  const value = frontmatter[field];
-  if (typeof value !== "string") return void 0;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : void 0;
-}
-function readDateField(frontmatter, field) {
-  const value = frontmatter[field];
-  if (value === void 0 || value === null) return void 0;
-  if (value instanceof Date) {
-    return value.toISOString().slice(0, 10);
-  }
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (ISO_DATE_RE.test(trimmed)) return trimmed;
-    const parsed = Date.parse(trimmed);
-    if (!Number.isNaN(parsed)) {
-      return new Date(parsed).toISOString().slice(0, 10);
-    }
-  }
-  return void 0;
-}
+import { isAbsolute as isAbsolute2, join as join5, resolve as resolve2, sep } from "node:path";
 function collectMarkdownFiles(paths) {
   const seen = /* @__PURE__ */ new Map();
   for (const p of paths) {
-    const expanded = expandPath(p);
-    for (const file of expanded) {
+    for (const file of expandPath(p)) {
       if (!seen.has(file.filePath)) {
         seen.set(file.filePath, file);
       }
     }
   }
-  return [...seen.values()].sort((a, b) => a.filePath.localeCompare(b.filePath));
+  return [...seen.values()].sort(
+    (a, b) => a.filePath.localeCompare(b.filePath)
+  );
 }
 function expandPath(input) {
   const absolute = isAbsolute2(input) ? input : resolve2(process.cwd(), input);
@@ -9198,7 +8925,9 @@ function matchPattern(currentDir, remaining, root) {
     out.push(...matchPattern(currentDir, rest, root));
     for (const entry of entries) {
       if (entry.isDirectory()) {
-        out.push(...matchPattern(join5(currentDir, entry.name), remaining, root));
+        out.push(
+          ...matchPattern(join5(currentDir, entry.name), remaining, root)
+        );
       }
     }
     return out;
@@ -9242,17 +8971,335 @@ function hasMarkdownExtension(filename) {
   const lower = filename.toLowerCase();
   return MARKDOWN_EXTENSIONS.some((ext) => lower.endsWith(ext));
 }
-function relativeTo(projectRoot, filePath) {
-  const rel = relative(projectRoot, filePath);
-  return rel.length > 0 ? rel : filePath;
+var MARKDOWN_EXTENSIONS;
+var init_ingest_paths = __esm({
+  "../core/src/ingest-paths.ts"() {
+    "use strict";
+    MARKDOWN_EXTENSIONS = [".md", ".mdx", ".markdown"];
+  }
+});
+
+// ../core/src/ingest-derive.ts
+import { readdirSync as readdirSync3, statSync as statSync2 } from "node:fs";
+import { join as join6, relative, sep as sep2 } from "node:path";
+function deriveSlug(input) {
+  if (input.explicitSlug !== void 0) {
+    return { value: input.explicitSlug, source: "explicit" };
+  }
+  if (input.slugFrom === "frontmatter") {
+    const fmSlug = readStringField(input.frontmatter, input.fieldName);
+    if (fmSlug !== void 0) {
+      return { value: fmSlug, source: "frontmatter" };
+    }
+  }
+  return slugFromPath(input.filePath, input.root);
 }
-function isUnderScrapbook(filePath, roots) {
-  if (!roots || roots.length === 0) return false;
-  for (const root of roots) {
-    const r = root.endsWith(sep) ? root : root + sep;
-    if (filePath.startsWith(r)) return true;
+function slugFromPath(filePath, root) {
+  const rel = relative(root, filePath);
+  const segments = rel.split(sep2).filter((s) => s.length > 0);
+  if (segments.length === 0) {
+    return { value: "", source: "path", reason: "file path equals root" };
+  }
+  const filename = segments[segments.length - 1];
+  const dot = filename.lastIndexOf(".");
+  const base = dot > 0 ? filename.slice(0, dot) : filename;
+  const baseLower = base.toLowerCase();
+  let leafSegments;
+  let dirSegments;
+  if (baseLower === "index" || baseLower === "readme") {
+    if (segments.length < 2) {
+      const rootSegments = root.split(sep2).filter((s) => s.length > 0);
+      const rootLeaf = rootSegments[rootSegments.length - 1];
+      if (!rootLeaf) {
+        return {
+          value: "",
+          source: "path",
+          reason: `${filename} at the filesystem root has no directory name to derive a slug from`
+        };
+      }
+      leafSegments = [rootLeaf];
+      dirSegments = [];
+    } else {
+      leafSegments = [segments[segments.length - 2]];
+      dirSegments = segments.slice(0, -2);
+    }
+  } else {
+    const jekyll = base.match(JEKYLL_RE);
+    leafSegments = [jekyll ? jekyll[4] : base];
+    dirSegments = segments.slice(0, -1);
+  }
+  const prefix = [];
+  if (directoryIsHierarchicalNode(root)) {
+    const rootSegments = root.split(sep2).filter((s) => s.length > 0);
+    const rootLeaf = rootSegments[rootSegments.length - 1];
+    if (rootLeaf && leafSegments[0] !== rootLeaf) {
+      prefix.push(rootLeaf);
+    }
+  }
+  let cursor = root;
+  for (const dir of dirSegments) {
+    cursor = join6(cursor, dir);
+    if (directoryIsHierarchicalNode(cursor)) {
+      prefix.push(dir);
+    } else {
+      prefix.length = 0;
+    }
+  }
+  return { value: [...prefix, ...leafSegments].join("/"), source: "path" };
+}
+function directoryIsHierarchicalNode(dir) {
+  let entries;
+  try {
+    entries = readdirSync3(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const lower = entry.name.toLowerCase();
+    for (const ext of MARKDOWN_EXTENSIONS) {
+      if (lower === `index${ext}` || lower === `readme${ext}`) {
+        return true;
+      }
+    }
   }
   return false;
+}
+function deriveState(input) {
+  if (input.explicitState !== void 0) {
+    return { value: input.explicitState, source: "explicit" };
+  }
+  if (input.stateFrom === "frontmatter") {
+    const raw = readStringField(input.frontmatter, input.stateField);
+    if (raw === void 0) {
+      return { value: "Ideas", source: "frontmatter" };
+    }
+    const normalized = normalizeStateString(raw);
+    if (normalized === null) {
+      return { value: null, source: "frontmatter", rawValue: raw };
+    }
+    return { value: normalized, source: "frontmatter" };
+  }
+  const dateRaw = readDateField(input.frontmatter, input.dateField);
+  if (dateRaw === void 0) {
+    return { value: "Ideas", source: "frontmatter" };
+  }
+  const today = (input.now ?? /* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  if (dateRaw <= today) {
+    return { value: "Published", source: "frontmatter" };
+  }
+  return { value: "Drafting", source: "frontmatter" };
+}
+function normalizeStateString(raw) {
+  const key = raw.trim().toLowerCase();
+  if (key.length === 0) return null;
+  const direct = STATE_ALIASES[key];
+  if (direct) return direct;
+  const titled = key.charAt(0).toUpperCase() + key.slice(1);
+  if (isStage(titled)) return titled;
+  return null;
+}
+function deriveDate(input) {
+  if (input.explicitDate !== void 0) {
+    return { value: input.explicitDate, source: "explicit" };
+  }
+  const fmDate = readDateField(input.frontmatter, input.dateField);
+  if (fmDate !== void 0) {
+    return { value: fmDate, source: "frontmatter" };
+  }
+  if (input.dateField !== "date") {
+    const generic = readDateField(input.frontmatter, "date");
+    if (generic !== void 0) {
+      return { value: generic, source: "frontmatter" };
+    }
+  }
+  try {
+    const stat = statSync2(input.filePath);
+    return { value: stat.mtime.toISOString().slice(0, 10), source: "mtime" };
+  } catch {
+  }
+  const today = (input.now ?? /* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  return { value: today, source: "today" };
+}
+function deriveTitle(frontmatter, fieldName, slug) {
+  const raw = readStringField(frontmatter, fieldName);
+  if (raw !== void 0 && raw.length > 0) return raw;
+  const leaf = slug.split("/").pop() ?? slug;
+  return leaf.split("-").map((w) => w.length > 0 ? w[0].toUpperCase() + w.slice(1) : w).join(" ");
+}
+function deriveDescription(frontmatter, fieldName) {
+  return readStringField(frontmatter, fieldName) ?? "";
+}
+function readStringField(frontmatter, field) {
+  const value = frontmatter[field];
+  if (typeof value !== "string") return void 0;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : void 0;
+}
+function readDateField(frontmatter, field) {
+  const value = frontmatter[field];
+  if (value === void 0 || value === null) return void 0;
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (ISO_DATE_RE.test(trimmed)) return trimmed;
+    const parsed = Date.parse(trimmed);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString().slice(0, 10);
+    }
+  }
+  return void 0;
+}
+var JEKYLL_RE, ISO_DATE_RE, STATE_ALIASES;
+var init_ingest_derive = __esm({
+  "../core/src/ingest-derive.ts"() {
+    "use strict";
+    init_types();
+    init_ingest_paths();
+    JEKYLL_RE = /^(\d{4})-(\d{2})-(\d{2})-(.+)$/;
+    ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+    STATE_ALIASES = {
+      ideas: "Ideas",
+      idea: "Ideas",
+      ideas_lane: "Ideas",
+      planned: "Planned",
+      outlining: "Outlining",
+      outline: "Outlining",
+      drafting: "Drafting",
+      draft: "Drafting",
+      review: "Review",
+      reviewing: "Review",
+      "in-review": "Review",
+      in_review: "Review",
+      published: "Published",
+      publish: "Published"
+    };
+  }
+});
+
+// ../core/src/ingest.ts
+import { isAbsolute as isAbsolute3, relative as relative2, sep as sep3 } from "node:path";
+import { readFileSync as readFileSync5 } from "node:fs";
+function discoverIngestCandidates(paths, options) {
+  if (paths.length === 0) {
+    throw new Error("discoverIngestCandidates: at least one path is required");
+  }
+  if (!options.projectRoot || !isAbsolute3(options.projectRoot)) {
+    throw new Error(
+      `discoverIngestCandidates: projectRoot must be an absolute path (got "${options.projectRoot ?? ""}")`
+    );
+  }
+  const collected = collectMarkdownFiles(paths);
+  if (options.explicitSlug !== void 0 && collected.length !== 1) {
+    throw new Error(
+      `--slug requires exactly one matched file; ${collected.length} matched`
+    );
+  }
+  const candidates = [];
+  const skips = [];
+  const fields = { ...DEFAULT_FIELDS, ...options.fieldNames ?? {} };
+  for (const { filePath, root } of collected) {
+    const relPath = relativeTo(options.projectRoot, filePath);
+    if (isUnderScrapbook(filePath, options.scrapbookRoots)) {
+      skips.push({
+        filePath,
+        relativePath: relPath,
+        reason: "file is under scrapbook/ (skipped by default)"
+      });
+      continue;
+    }
+    let raw;
+    try {
+      raw = readFileSync5(filePath, "utf-8");
+    } catch (err2) {
+      skips.push({
+        filePath,
+        relativePath: relPath,
+        reason: `unreadable: ${err2 instanceof Error ? err2.message : String(err2)}`
+      });
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = parseFrontmatter(raw);
+    } catch (err2) {
+      skips.push({
+        filePath,
+        relativePath: relPath,
+        reason: `frontmatter parse failed: ${err2 instanceof Error ? err2.message : String(err2)}`
+      });
+      continue;
+    }
+    const slug = deriveSlug({
+      filePath,
+      root,
+      frontmatter: parsed.data,
+      fieldName: fields.slug,
+      slugFrom: options.slugFrom ?? "path",
+      ...options.explicitSlug !== void 0 ? { explicitSlug: options.explicitSlug } : {}
+    });
+    if (!slug.value) {
+      skips.push({
+        filePath,
+        relativePath: relPath,
+        reason: slug.reason ?? "could not derive slug"
+      });
+      continue;
+    }
+    if (!SLUG_RE.test(slug.value)) {
+      skips.push({
+        filePath,
+        relativePath: relPath,
+        slug: slug.value,
+        reason: `derived slug "${slug.value}" is not valid kebab-case (must match [a-z0-9][a-z0-9-]* segments separated by '/')`
+      });
+      continue;
+    }
+    if (options.calendar && !options.force && options.calendar.entries.some((e) => e.slug === slug.value)) {
+      skips.push({
+        filePath,
+        relativePath: relPath,
+        slug: slug.value,
+        reason: `calendar already has an entry with slug "${slug.value}" (use --force to override)`
+      });
+      continue;
+    }
+    const state = deriveState({
+      frontmatter: parsed.data,
+      stateField: fields.state,
+      dateField: fields.date,
+      stateFrom: options.stateFrom ?? "frontmatter",
+      ...options.explicitState !== void 0 ? { explicitState: options.explicitState } : {},
+      ...options.now !== void 0 ? { now: options.now } : {}
+    });
+    const date = deriveDate({
+      filePath,
+      frontmatter: parsed.data,
+      dateField: fields.date,
+      ...options.explicitDate !== void 0 ? { explicitDate: options.explicitDate } : {},
+      ...options.now !== void 0 ? { now: options.now } : {}
+    });
+    const title = deriveTitle(parsed.data, fields.title, slug.value);
+    const description = deriveDescription(parsed.data, fields.description);
+    candidates.push({
+      filePath,
+      relativePath: relPath,
+      frontmatter: parsed.data,
+      body: parsed.body,
+      derivedSlug: slug.value,
+      slugSource: slug.source,
+      derivedState: state.value,
+      stateSource: state.source,
+      ...state.rawValue !== void 0 ? { rawState: state.rawValue } : {},
+      derivedDate: date.value,
+      dateSource: date.source,
+      title,
+      description
+    });
+  }
+  return { candidates, skips };
 }
 function candidateToEntry(candidate, stage) {
   const entry = {
@@ -9268,38 +9315,32 @@ function candidateToEntry(candidate, stage) {
   }
   return entry;
 }
-var MARKDOWN_EXTENSIONS, SLUG_RE, JEKYLL_RE, ISO_DATE_RE, DEFAULT_FIELDS, STATE_ALIASES;
+function relativeTo(projectRoot, filePath) {
+  const rel = relative2(projectRoot, filePath);
+  return rel.length > 0 ? rel : filePath;
+}
+function isUnderScrapbook(filePath, roots) {
+  if (!roots || roots.length === 0) return false;
+  for (const root of roots) {
+    const r = root.endsWith(sep3) ? root : root + sep3;
+    if (filePath.startsWith(r)) return true;
+  }
+  return false;
+}
+var SLUG_RE, DEFAULT_FIELDS;
 var init_ingest = __esm({
   "../core/src/ingest.ts"() {
     "use strict";
     init_frontmatter();
-    init_types();
-    MARKDOWN_EXTENSIONS = [".md", ".mdx", ".markdown"];
+    init_ingest_paths();
+    init_ingest_derive();
     SLUG_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
-    JEKYLL_RE = /^(\d{4})-(\d{2})-(\d{2})-(.+)$/;
-    ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
     DEFAULT_FIELDS = {
       title: "title",
       description: "description",
       slug: "slug",
       state: "state",
       date: "datePublished"
-    };
-    STATE_ALIASES = {
-      ideas: "Ideas",
-      idea: "Ideas",
-      planned: "Planned",
-      outlining: "Outlining",
-      outline: "Outlining",
-      drafting: "Drafting",
-      draft: "Drafting",
-      review: "Review",
-      reviewing: "Review",
-      "in-review": "Review",
-      in_review: "Review",
-      published: "Published",
-      publish: "Published",
-      ideas_lane: "Ideas"
     };
   }
 });
@@ -9310,7 +9351,7 @@ __export(ingest_exports, {
   run: () => run4
 });
 import { existsSync as existsSync4, mkdirSync as mkdirSync2 } from "node:fs";
-import { isAbsolute as isAbsolute3, join as join6, resolve as resolve3 } from "node:path";
+import { isAbsolute as isAbsolute4, join as join7, resolve as resolve3 } from "node:path";
 import { randomUUID as randomUUID4 } from "node:crypto";
 async function run4(argv2) {
   const { positional, flags, booleans } = parseInput(argv2);
@@ -9336,10 +9377,10 @@ async function run4(argv2) {
   const calendarPath = resolveCalendarPath(projectRoot, config, site);
   const calendar = readCalendar(calendarPath);
   const absolutePaths = paths.map(
-    (p) => isAbsolute3(p) ? p : resolve3(projectRoot, p)
+    (p) => isAbsolute4(p) ? p : resolve3(projectRoot, p)
   );
   const contentDir = resolveContentDir(projectRoot, config, site);
-  const scrapbookRoots = [join6(contentDir, "scrapbook")];
+  const scrapbookRoots = [join7(contentDir, "scrapbook")];
   let discovery;
   try {
     discovery = discoverIngestCandidates(absolutePaths, {
@@ -9490,7 +9531,7 @@ function pad(s, n) {
   return s + " ".repeat(n - s.length);
 }
 function writeIngestJournalEntry(projectRoot, config, site, candidate, entry) {
-  const journalRoot = join6(
+  const journalRoot = join7(
     projectRoot,
     config.reviewJournalDir ?? ".deskwork/review-journal",
     "ingest"
@@ -9551,7 +9592,7 @@ __export(install_exports, {
   run: () => run5
 });
 import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, existsSync as existsSync5, mkdirSync as mkdirSync3 } from "node:fs";
-import { dirname, isAbsolute as isAbsolute4, join as join7, resolve as resolve4 } from "node:path";
+import { dirname, isAbsolute as isAbsolute5, join as join8, resolve as resolve4 } from "node:path";
 async function run5(argv2) {
   function usage() {
     console.error(
@@ -9569,8 +9610,8 @@ async function run5(argv2) {
   } else {
     usage();
   }
-  const projectRoot = isAbsolute4(projectRootArg) ? projectRootArg : resolve4(process.cwd(), projectRootArg);
-  const configFile = isAbsolute4(configFileArg) ? configFileArg : resolve4(process.cwd(), configFileArg);
+  const projectRoot = isAbsolute5(projectRootArg) ? projectRootArg : resolve4(process.cwd(), projectRootArg);
+  const configFile = isAbsolute5(configFileArg) ? configFileArg : resolve4(process.cwd(), configFileArg);
   console.log(`Installing into: ${projectRoot}`);
   if (!existsSync5(projectRoot)) {
     console.error(`Project root does not exist: ${projectRoot}`);
@@ -9606,7 +9647,7 @@ async function run5(argv2) {
   const createdCalendars = [];
   const preservedCalendars = [];
   for (const [slug, site] of Object.entries(config.sites)) {
-    const absPath = join7(projectRoot, site.calendarPath);
+    const absPath = join8(projectRoot, site.calendarPath);
     if (existsSync5(absPath)) {
       preservedCalendars.push(`${slug}: ${site.calendarPath}`);
       continue;
@@ -9779,7 +9820,7 @@ var init_iterate = __esm({
 
 // ../core/src/scaffold.ts
 import { existsSync as existsSync7, mkdirSync as mkdirSync4 } from "node:fs";
-import { dirname as dirname2, join as join8, relative as relative2 } from "node:path";
+import { dirname as dirname2, join as join9, relative as relative3 } from "node:path";
 function scaffoldBlogPost(projectRoot, config, site, entry, opts = {}) {
   const slug = resolveSite(config, site);
   const siteCfg = config.sites[slug];
@@ -9797,7 +9838,7 @@ function scaffoldBlogPost(projectRoot, config, site, entry, opts = {}) {
     entry.slug,
     contentRelativePath
   );
-  const relativePath = relative2(projectRoot, filePath);
+  const relativePath = relative3(projectRoot, filePath);
   if (existsSync7(filePath)) {
     throw new Error(`Blog post already exists at ${relativePath}`);
   }
@@ -9814,7 +9855,7 @@ function scaffoldBlogPost(projectRoot, config, site, entry, opts = {}) {
   const body = buildBody(entry.title, siteCfg.blogOutlineSection === true);
   mkdirSync4(dirname2(filePath), { recursive: true });
   writeFrontmatter(filePath, data, body);
-  const reported = contentRelativePath ?? relative2(join8(projectRoot, siteCfg.contentDir), filePath);
+  const reported = contentRelativePath ?? relative3(join9(projectRoot, siteCfg.contentDir), filePath);
   return { filePath, relativePath, contentRelativePath: reported };
 }
 function layoutToContentRelativePath(layout, slug) {
@@ -10490,7 +10531,7 @@ var review_start_exports = {};
 __export(review_start_exports, {
   run: () => run13
 });
-import { existsSync as existsSync10, readFileSync as readFileSync9, readdirSync as readdirSync3 } from "node:fs";
+import { existsSync as existsSync10, readFileSync as readFileSync9, readdirSync as readdirSync4 } from "node:fs";
 import { dirname as dirname3 } from "node:path";
 async function run13(argv2) {
   const KNOWN_FLAGS2 = ["site"];
@@ -10563,7 +10604,7 @@ Run /deskwork:outline <slug> (or /deskwork:draft) to scaffold it first.`
   function listSiblingSlugs(blogFile) {
     const dir = dirname3(blogFile);
     if (!existsSync10(dir)) return [];
-    return readdirSync3(dir).filter((name) => name.endsWith(".md")).map((name) => name.replace(/\.md$/, ""));
+    return readdirSync4(dir).filter((name) => name.endsWith(".md")).map((name) => name.replace(/\.md$/, ""));
   }
 }
 var init_review_start = __esm({

--- a/plugins/deskwork/bundle/cli.mjs
+++ b/plugins/deskwork/bundle/cli.mjs
@@ -738,6 +738,9 @@ function siteConfig(config, site) {
 function resolveCalendarPath(projectRoot, config, site) {
   return join2(projectRoot, siteConfig(config, site).calendarPath);
 }
+function resolveContentDir(projectRoot, config, site) {
+  return join2(projectRoot, siteConfig(config, site).contentDir);
+}
 function resolveBlogFilePath(projectRoot, config, site, slug, filePath) {
   const entry = siteConfig(config, site);
   if (filePath !== void 0 && filePath !== "") {
@@ -814,8 +817,8 @@ __export(add_exports, {
   run: () => run
 });
 async function run(argv2) {
-  const KNOWN_FLAGS = ["site", "type", "content-url", "source", "slug"];
-  const SLUG_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
+  const KNOWN_FLAGS2 = ["site", "type", "content-url", "source", "slug"];
+  const SLUG_RE2 = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
   const { positional, flags } = parse();
   if (positional.length < 2) {
     fail(
@@ -823,7 +826,7 @@ async function run(argv2) {
       2
     );
   }
-  if (flags.slug !== void 0 && !SLUG_RE.test(flags.slug)) {
+  if (flags.slug !== void 0 && !SLUG_RE2.test(flags.slug)) {
     fail(
       `--slug must be one or more /-separated kebab-case segments (got "${flags.slug}")`,
       2
@@ -880,7 +883,7 @@ async function run(argv2) {
   });
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -1257,8 +1260,8 @@ __export(approve_exports, {
 });
 import { existsSync as existsSync2 } from "node:fs";
 async function run2(argv2) {
-  const KNOWN_FLAGS = ["site", "platform", "channel"];
-  const SLUG_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
+  const KNOWN_FLAGS2 = ["site", "platform", "channel"];
+  const SLUG_RE2 = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
   const { positional, flags } = parse();
   if (positional.length < 2) {
     fail(
@@ -1268,8 +1271,8 @@ async function run2(argv2) {
   }
   const [rootArg, slug] = positional;
   const projectRoot = absolutize(rootArg);
-  if (!SLUG_RE.test(slug)) {
-    fail(`invalid slug: ${slug} (must match ${SLUG_RE})`);
+  if (!SLUG_RE2.test(slug)) {
+    fail(`invalid slug: ${slug} (must match ${SLUG_RE2})`);
   }
   if (flags.platform !== void 0 && !isPlatform(flags.platform)) {
     fail(`Invalid --platform "${flags.platform}".`);
@@ -1389,7 +1392,7 @@ async function run2(argv2) {
   }
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -1414,7 +1417,7 @@ __export(draft_exports, {
   run: () => run3
 });
 async function run3(argv2) {
-  const KNOWN_FLAGS = ["site", "issue"];
+  const KNOWN_FLAGS2 = ["site", "issue"];
   const { positional, flags } = parse();
   if (positional.length < 2) {
     fail(
@@ -1462,7 +1465,7 @@ async function run3(argv2) {
   });
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -1476,238 +1479,6 @@ var init_draft = __esm({
     init_calendar_mutations();
     init_types();
     init_paths();
-    init_cli();
-  }
-});
-
-// src/commands/install.ts
-var install_exports = {};
-__export(install_exports, {
-  run: () => run4
-});
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync3, mkdirSync as mkdirSync2 } from "node:fs";
-import { dirname, isAbsolute as isAbsolute2, join as join5, resolve as resolve2 } from "node:path";
-async function run4(argv2) {
-  function usage() {
-    console.error(
-      "Usage: deskwork install [<project-root>] <config-file>"
-    );
-    process.exit(2);
-  }
-  let projectRootArg;
-  let configFileArg;
-  if (argv2.length === 1) {
-    projectRootArg = process.cwd();
-    configFileArg = argv2[0];
-  } else if (argv2.length === 2) {
-    [projectRootArg, configFileArg] = argv2;
-  } else {
-    usage();
-  }
-  const projectRoot = isAbsolute2(projectRootArg) ? projectRootArg : resolve2(process.cwd(), projectRootArg);
-  const configFile = isAbsolute2(configFileArg) ? configFileArg : resolve2(process.cwd(), configFileArg);
-  console.log(`Installing into: ${projectRoot}`);
-  if (!existsSync3(projectRoot)) {
-    console.error(`Project root does not exist: ${projectRoot}`);
-    process.exit(1);
-  }
-  if (!existsSync3(configFile)) {
-    console.error(`Config file does not exist: ${configFile}`);
-    process.exit(1);
-  }
-  let rawConfig;
-  try {
-    rawConfig = JSON.parse(readFileSync4(configFile, "utf-8"));
-  } catch (err2) {
-    const reason = err2 instanceof Error ? err2.message : String(err2);
-    console.error(`Config file is not valid JSON: ${reason}`);
-    process.exit(1);
-  }
-  let config;
-  try {
-    config = parseConfig(rawConfig);
-  } catch (err2) {
-    const reason = err2 instanceof Error ? err2.message : String(err2);
-    console.error(reason);
-    process.exit(1);
-  }
-  const writtenConfigPath = configPath(projectRoot);
-  mkdirSync2(dirname(writtenConfigPath), { recursive: true });
-  writeFileSync3(
-    writtenConfigPath,
-    JSON.stringify(config, null, 2) + "\n",
-    "utf-8"
-  );
-  const createdCalendars = [];
-  const preservedCalendars = [];
-  for (const [slug, site] of Object.entries(config.sites)) {
-    const absPath = join5(projectRoot, site.calendarPath);
-    if (existsSync3(absPath)) {
-      preservedCalendars.push(`${slug}: ${site.calendarPath}`);
-      continue;
-    }
-    mkdirSync2(dirname(absPath), { recursive: true });
-    writeFileSync3(absPath, renderEmptyCalendar(), "utf-8");
-    createdCalendars.push(`${slug}: ${site.calendarPath}`);
-  }
-  console.log(`Wrote config: ${writtenConfigPath}`);
-  console.log(`Sites configured: ${Object.keys(config.sites).join(", ")}`);
-  console.log(`Default site: ${config.defaultSite}`);
-  if (createdCalendars.length > 0) {
-    console.log(`Created calendars:`);
-    for (const c of createdCalendars) console.log(`  - ${c}`);
-  }
-  if (preservedCalendars.length > 0) {
-    console.log(`Left existing calendars untouched:`);
-    for (const c of preservedCalendars) console.log(`  - ${c}`);
-  }
-}
-var init_install = __esm({
-  "src/commands/install.ts"() {
-    "use strict";
-    init_config();
-    init_calendar();
-  }
-});
-
-// src/commands/iterate.ts
-var iterate_exports = {};
-__export(iterate_exports, {
-  run: () => run5
-});
-import { existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-async function run5(argv2) {
-  const KNOWN_FLAGS = ["site", "kind", "dispositions"];
-  const DISPOSITIONS = /* @__PURE__ */ new Set(["addressed", "deferred", "wontfix"]);
-  const { positional, flags } = parse();
-  if (positional.length < 2) {
-    fail(
-      "Usage: deskwork-iterate <project-root> [--site <slug>] [--kind longform|outline] [--dispositions <path>] <slug>",
-      2
-    );
-  }
-  const [rootArg, slug] = positional;
-  const projectRoot = absolutize(rootArg);
-  const kind = flags.kind === "outline" ? "outline" : "longform";
-  if (flags.kind !== void 0 && flags.kind !== "longform" && flags.kind !== "outline") {
-    fail(`Invalid --kind "${flags.kind}". Must be 'longform' or 'outline'.`);
-  }
-  let config;
-  try {
-    config = readConfig(projectRoot);
-  } catch (err2) {
-    fail(err2 instanceof Error ? err2.message : String(err2));
-  }
-  const site = resolveSite(config, flags.site);
-  const file = resolveBlogFilePath(projectRoot, config, site, slug);
-  if (!existsSync4(file)) {
-    fail(`No blog file at ${file}.`);
-  }
-  const diskMarkdown = readFileSync5(file, "utf8");
-  const workflow = readWorkflows(projectRoot, config).find(
-    (w) => w.site === site && w.slug === slug && w.contentKind === kind && w.state !== "applied" && w.state !== "cancelled"
-  );
-  if (!workflow) {
-    fail(
-      `No active ${kind} workflow for ${site}/${slug}. Run /deskwork:review-start <slug> to enqueue one first.`
-    );
-  }
-  if (workflow.state !== "iterating") {
-    fail(
-      `Workflow state is '${workflow.state}', not 'iterating'.
-The studio must click 'Request iteration' to move the workflow to 'iterating' before this helper runs.`
-    );
-  }
-  const versions = readVersions(projectRoot, config, workflow.id);
-  const current = versions.find((v) => v.version === workflow.currentVersion);
-  if (current && current.markdown === diskMarkdown) {
-    fail(
-      `File on disk is identical to workflow v${workflow.currentVersion} \u2014 no revision to snapshot. Write the revision to disk first (the agent does this), then re-run.`
-    );
-  }
-  let dispositions = null;
-  if (flags.dispositions !== void 0) {
-    const path = absolutize(flags.dispositions);
-    if (!existsSync4(path)) {
-      fail(`--dispositions file not found: ${path}`);
-    }
-    let parsed;
-    try {
-      parsed = JSON.parse(readFileSync5(path, "utf8"));
-    } catch (err2) {
-      const reason = err2 instanceof Error ? err2.message : String(err2);
-      fail(`--dispositions: invalid JSON at ${path}: ${reason}`);
-    }
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      fail(`--dispositions: expected JSON object at ${path}`);
-    }
-    dispositions = {};
-    for (const [commentId, raw] of Object.entries(parsed)) {
-      if (typeof raw !== "object" || raw === null) {
-        fail(`--dispositions[${commentId}]: must be an object`);
-      }
-      const d = raw;
-      if (typeof d.disposition !== "string" || !DISPOSITIONS.has(d.disposition)) {
-        fail(
-          `--dispositions[${commentId}].disposition: must be 'addressed' | 'deferred' | 'wontfix'`
-        );
-      }
-      const entry = { disposition: d.disposition };
-      if (typeof d.reason === "string" && d.reason.length > 0) {
-        entry.reason = d.reason;
-      }
-      dispositions[commentId] = entry;
-    }
-  }
-  const newVersion = appendVersion(
-    projectRoot,
-    config,
-    workflow.id,
-    diskMarkdown,
-    "agent"
-  );
-  const addressed = [];
-  if (dispositions) {
-    const workflowComments = new Set(
-      readAnnotations(projectRoot, config, workflow.id).filter((a) => a.type === "comment").map((a) => a.id)
-    );
-    for (const [commentId, entry] of Object.entries(dispositions)) {
-      if (!workflowComments.has(commentId)) continue;
-      const ann = mintAnnotation({
-        type: "address",
-        workflowId: workflow.id,
-        commentId,
-        version: newVersion.version,
-        disposition: entry.disposition,
-        ...entry.reason !== void 0 ? { reason: entry.reason } : {}
-      });
-      appendAnnotation(projectRoot, config, ann);
-      addressed.push(commentId);
-    }
-  }
-  const updated = transitionState(projectRoot, config, workflow.id, "in-review");
-  emit({
-    workflowId: workflow.id,
-    site: updated.site,
-    slug: updated.slug,
-    state: updated.state,
-    version: newVersion.version,
-    addressedComments: addressed
-  });
-  function parse() {
-    try {
-      return parseArgs(argv2, KNOWN_FLAGS);
-    } catch (err2) {
-      fail(err2 instanceof Error ? err2.message : String(err2), 2);
-    }
-  }
-}
-var init_iterate = __esm({
-  "src/commands/iterate.ts"() {
-    "use strict";
-    init_config();
-    init_paths();
-    init_pipeline();
     init_cli();
   }
 });
@@ -5668,10 +5439,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep, value } = collItem;
+        const { start, key, sep: sep2, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep?.[0],
+          next: key ?? sep2?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -5685,7 +5456,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep) {
+          if (!keyProps.anchor && !keyProps.tag && !sep2) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -5709,7 +5480,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep ?? [], {
+        const valueProps = resolveProps.resolveProps(sep2 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -5725,7 +5496,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep2, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -5816,7 +5587,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep = "";
+        let sep2 = "";
         for (const token of end) {
           const { source, type } = token;
           switch (type) {
@@ -5830,13 +5601,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep + cb;
-              sep = "";
+                comment += sep2 + cb;
+              sep2 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep += source;
+                sep2 += source;
               hasSpace = true;
               break;
             default:
@@ -5879,18 +5650,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep, value } = collItem;
+        const { start, key, sep: sep2, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep?.[0],
+          next: key ?? sep2?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep && !value) {
+          if (!props.anchor && !props.tag && !sep2 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -5944,8 +5715,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep, null, props, onError);
+        if (!isMap && !sep2 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep2, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -5957,7 +5728,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep ?? [], {
+          const valueProps = resolveProps.resolveProps(sep2 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -5968,8 +5739,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep)
-                for (const st of sep) {
+              if (sep2)
+                for (const st of sep2) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -5986,7 +5757,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep2, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -6166,7 +5937,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep = "";
+      let sep2 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -6183,24 +5954,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep + indent.slice(trimIndent) + content;
-          sep = "\n";
+          value += sep2 + indent.slice(trimIndent) + content;
+          sep2 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep === " ")
-            sep = "\n";
-          else if (!prevMoreIndented && sep === "\n")
-            sep = "\n\n";
-          value += sep + indent.slice(trimIndent) + content;
-          sep = "\n";
+          if (sep2 === " ")
+            sep2 = "\n";
+          else if (!prevMoreIndented && sep2 === "\n")
+            sep2 = "\n\n";
+          value += sep2 + indent.slice(trimIndent) + content;
+          sep2 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep === "\n")
+          if (sep2 === "\n")
             value += "\n";
           else
-            sep = "\n";
+            sep2 = "\n";
         } else {
-          value += sep + content;
-          sep = " ";
+          value += sep2 + content;
+          sep2 = " ";
           prevMoreIndented = false;
         }
       }
@@ -6382,25 +6153,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep = " ";
+      let sep2 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep === "\n")
-            res += sep;
+          if (sep2 === "\n")
+            res += sep2;
           else
-            sep = "\n";
+            sep2 = "\n";
         } else {
-          res += sep + match[1];
-          sep = " ";
+          res += sep2 + match[1];
+          sep2 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep + (match?.[1] ?? "");
+      return res + sep2 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -7207,14 +6978,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep, value }) {
+    function stringifyItem({ start, key, sep: sep2, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep)
-        for (const st of sep)
+      if (sep2)
+        for (const st of sep2)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -8364,18 +8135,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep;
+          let sep2;
           if (scalar.end) {
-            sep = scalar.end;
-            sep.push(this.sourceToken);
+            sep2 = scalar.end;
+            sep2.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep = [this.sourceToken];
+            sep2 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep }]
+            items: [{ start, key: scalar, sep: sep2 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -8528,15 +8299,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep = it.sep;
-                  sep.push(this.sourceToken);
+                  const sep2 = it.sep;
+                  sep2.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep }]
+                    items: [{ start: start2, key, sep: sep2 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -8730,13 +8501,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep = fc.end.splice(1, fc.end.length);
-            sep.push(this.sourceToken);
+            const sep2 = fc.end.splice(1, fc.end.length);
+            sep2.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep }]
+              items: [{ start, key: fc, sep: sep2 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -9015,7 +8786,30 @@ var require_dist = __commonJS({
 });
 
 // ../core/src/frontmatter.ts
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4 } from "node:fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+function parseFrontmatter(markdown) {
+  const match = markdown.match(FRONTMATTER_RE);
+  if (!match) {
+    return { data: {}, body: markdown };
+  }
+  const [, yamlContent, body] = match;
+  let data;
+  try {
+    data = (0, import_yaml.parse)(yamlContent);
+  } catch (err2) {
+    const reason = err2 instanceof Error ? err2.message : String(err2);
+    throw new Error(`Invalid YAML frontmatter: ${reason}`);
+  }
+  if (data === null || data === void 0) {
+    return { data: {}, body };
+  }
+  if (typeof data !== "object" || Array.isArray(data)) {
+    throw new Error(
+      `Invalid frontmatter: expected a YAML mapping at the top level, got ${typeof data}.`
+    );
+  }
+  return { data, body };
+}
 function stringifyFrontmatter(data, body) {
   const yaml = (0, import_yaml.stringify)(data, { lineWidth: 0 }).replace(/\n$/, "");
   return `---
@@ -9024,19 +8818,968 @@ ${yaml}
 ${body}`;
 }
 function writeFrontmatter(path, data, body) {
-  writeFileSync4(path, stringifyFrontmatter(data, body), "utf-8");
+  writeFileSync3(path, stringifyFrontmatter(data, body), "utf-8");
 }
-var import_yaml;
+var import_yaml, FRONTMATTER_RE;
 var init_frontmatter = __esm({
   "../core/src/frontmatter.ts"() {
     "use strict";
     import_yaml = __toESM(require_dist(), 1);
+    FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+  }
+});
+
+// ../core/src/ingest.ts
+import {
+  existsSync as existsSync3,
+  readFileSync as readFileSync5,
+  readdirSync as readdirSync2,
+  statSync
+} from "node:fs";
+import { isAbsolute as isAbsolute2, join as join5, relative, resolve as resolve2, sep } from "node:path";
+function discoverIngestCandidates(paths, options) {
+  if (paths.length === 0) {
+    throw new Error("discoverIngestCandidates: at least one path is required");
+  }
+  if (!options.projectRoot || !isAbsolute2(options.projectRoot)) {
+    throw new Error(
+      `discoverIngestCandidates: projectRoot must be an absolute path (got "${options.projectRoot ?? ""}")`
+    );
+  }
+  const collected = collectMarkdownFiles(paths);
+  if (options.explicitSlug !== void 0 && collected.length !== 1) {
+    throw new Error(
+      `--slug requires exactly one matched file; ${collected.length} matched`
+    );
+  }
+  const candidates = [];
+  const skips = [];
+  const fields = { ...DEFAULT_FIELDS, ...options.fieldNames ?? {} };
+  for (const { filePath, root } of collected) {
+    if (isUnderScrapbook(filePath, options.scrapbookRoots)) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: "file is under scrapbook/ (skipped by default)"
+      });
+      continue;
+    }
+    let raw;
+    try {
+      raw = readFileSync5(filePath, "utf-8");
+    } catch (err2) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: `unreadable: ${err2 instanceof Error ? err2.message : String(err2)}`
+      });
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = parseFrontmatter(raw);
+    } catch (err2) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: `frontmatter parse failed: ${err2 instanceof Error ? err2.message : String(err2)}`
+      });
+      continue;
+    }
+    const slug = deriveSlug(filePath, root, parsed.data, fields, options);
+    if (!slug.value) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        reason: slug.reason ?? "could not derive slug"
+      });
+      continue;
+    }
+    if (!SLUG_RE.test(slug.value)) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        slug: slug.value,
+        reason: `derived slug "${slug.value}" is not valid kebab-case (must match [a-z0-9][a-z0-9-]* segments separated by '/')`
+      });
+      continue;
+    }
+    if (options.calendar && !options.force && options.calendar.entries.some((e) => e.slug === slug.value)) {
+      skips.push({
+        filePath,
+        relativePath: relativeTo(options.projectRoot, filePath),
+        slug: slug.value,
+        reason: `calendar already has an entry with slug "${slug.value}" (use --force to override)`
+      });
+      continue;
+    }
+    const state = deriveState(parsed.data, fields, options);
+    const date = deriveDate(filePath, parsed.data, fields, options);
+    const title = deriveTitle(parsed.data, fields.title, slug.value);
+    const description = deriveDescription(parsed.data, fields.description);
+    candidates.push({
+      filePath,
+      relativePath: relativeTo(options.projectRoot, filePath),
+      frontmatter: parsed.data,
+      body: parsed.body,
+      derivedSlug: slug.value,
+      slugSource: slug.source,
+      derivedState: state.value,
+      stateSource: state.source,
+      ...state.rawValue !== void 0 ? { rawState: state.rawValue } : {},
+      derivedDate: date.value,
+      dateSource: date.source,
+      title,
+      description
+    });
+  }
+  return { candidates, skips };
+}
+function deriveSlug(filePath, root, frontmatter, fields, options) {
+  if (options.explicitSlug !== void 0) {
+    return { value: options.explicitSlug, source: "explicit" };
+  }
+  const slugFrom = options.slugFrom ?? "path";
+  if (slugFrom === "frontmatter") {
+    const fmSlug = readStringField(frontmatter, fields.slug);
+    if (fmSlug !== void 0) {
+      return { value: fmSlug, source: "frontmatter" };
+    }
+  }
+  return slugFromPath(filePath, root);
+}
+function slugFromPath(filePath, root) {
+  const rel = relative(root, filePath);
+  const segments = rel.split(sep).filter((s) => s.length > 0);
+  if (segments.length === 0) {
+    return { value: "", source: "path", reason: "file path equals root" };
+  }
+  const filename = segments[segments.length - 1];
+  const dot = filename.lastIndexOf(".");
+  const base = dot > 0 ? filename.slice(0, dot) : filename;
+  const baseLower = base.toLowerCase();
+  let leafSegments;
+  let dirSegments;
+  if (baseLower === "index" || baseLower === "readme") {
+    if (segments.length < 2) {
+      const rootSegments = root.split(sep).filter((s) => s.length > 0);
+      const rootLeaf = rootSegments[rootSegments.length - 1];
+      if (!rootLeaf) {
+        return {
+          value: "",
+          source: "path",
+          reason: `${filename} at the filesystem root has no directory name to derive a slug from`
+        };
+      }
+      leafSegments = [rootLeaf];
+      dirSegments = [];
+    } else {
+      leafSegments = [segments[segments.length - 2]];
+      dirSegments = segments.slice(0, -2);
+    }
+  } else {
+    const jekyll = base.match(JEKYLL_RE);
+    leafSegments = [jekyll ? jekyll[4] : base];
+    dirSegments = segments.slice(0, -1);
+  }
+  const prefix = [];
+  if (dirSegments.length > 0 || leafSegments.length > 0) {
+    if (directoryIsHierarchicalNode(root)) {
+      const rootSegments = root.split(sep).filter((s) => s.length > 0);
+      const rootLeaf = rootSegments[rootSegments.length - 1];
+      if (rootLeaf && leafSegments[0] !== rootLeaf) {
+        prefix.push(rootLeaf);
+      }
+    }
+  }
+  let cursor = root;
+  for (const dir of dirSegments) {
+    cursor = join5(cursor, dir);
+    if (directoryIsHierarchicalNode(cursor)) {
+      prefix.push(dir);
+    } else {
+      prefix.length = 0;
+    }
+  }
+  const slug = [...prefix, ...leafSegments].join("/");
+  return { value: slug, source: "path" };
+}
+function directoryIsHierarchicalNode(dir) {
+  let entries;
+  try {
+    entries = readdirSync2(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const lower = entry.name.toLowerCase();
+    for (const ext of MARKDOWN_EXTENSIONS) {
+      if (lower === `index${ext}` || lower === `readme${ext}`) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+function deriveState(frontmatter, fields, options) {
+  if (options.explicitState !== void 0) {
+    return { value: options.explicitState, source: "explicit" };
+  }
+  const stateFrom = options.stateFrom ?? "frontmatter";
+  if (stateFrom === "frontmatter") {
+    const raw = readStringField(frontmatter, fields.state);
+    if (raw === void 0) {
+      return { value: "Ideas", source: "frontmatter" };
+    }
+    const normalized = normalizeStateString(raw);
+    if (normalized === null) {
+      return { value: null, source: "frontmatter", rawValue: raw };
+    }
+    return { value: normalized, source: "frontmatter" };
+  }
+  const dateRaw = readDateField(frontmatter, fields.date);
+  if (dateRaw === void 0) {
+    return { value: "Ideas", source: "frontmatter" };
+  }
+  const today = (options.now ?? /* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  if (dateRaw <= today) {
+    return { value: "Published", source: "frontmatter" };
+  }
+  return { value: "Drafting", source: "frontmatter" };
+}
+function normalizeStateString(raw) {
+  const key = raw.trim().toLowerCase();
+  if (key.length === 0) return null;
+  const direct = STATE_ALIASES[key];
+  if (direct) return direct;
+  const titled = key.charAt(0).toUpperCase() + key.slice(1);
+  if (isStage(titled)) return titled;
+  return null;
+}
+function deriveDate(filePath, frontmatter, fields, options) {
+  if (options.explicitDate !== void 0) {
+    return { value: options.explicitDate, source: "explicit" };
+  }
+  const fmDate = readDateField(frontmatter, fields.date);
+  if (fmDate !== void 0) {
+    return { value: fmDate, source: "frontmatter" };
+  }
+  if (fields.date !== "date") {
+    const generic = readDateField(frontmatter, "date");
+    if (generic !== void 0) {
+      return { value: generic, source: "frontmatter" };
+    }
+  }
+  try {
+    const stat = statSync(filePath);
+    return { value: stat.mtime.toISOString().slice(0, 10), source: "mtime" };
+  } catch {
+  }
+  const today = (options.now ?? /* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  return { value: today, source: "today" };
+}
+function deriveTitle(frontmatter, fieldName, slug) {
+  const raw = readStringField(frontmatter, fieldName);
+  if (raw !== void 0 && raw.length > 0) return raw;
+  const leaf = slug.split("/").pop() ?? slug;
+  return leaf.split("-").map((word) => word.length > 0 ? word[0].toUpperCase() + word.slice(1) : word).join(" ");
+}
+function deriveDescription(frontmatter, fieldName) {
+  return readStringField(frontmatter, fieldName) ?? "";
+}
+function readStringField(frontmatter, field) {
+  const value = frontmatter[field];
+  if (typeof value !== "string") return void 0;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : void 0;
+}
+function readDateField(frontmatter, field) {
+  const value = frontmatter[field];
+  if (value === void 0 || value === null) return void 0;
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (ISO_DATE_RE.test(trimmed)) return trimmed;
+    const parsed = Date.parse(trimmed);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString().slice(0, 10);
+    }
+  }
+  return void 0;
+}
+function collectMarkdownFiles(paths) {
+  const seen = /* @__PURE__ */ new Map();
+  for (const p of paths) {
+    const expanded = expandPath(p);
+    for (const file of expanded) {
+      if (!seen.has(file.filePath)) {
+        seen.set(file.filePath, file);
+      }
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.filePath.localeCompare(b.filePath));
+}
+function expandPath(input) {
+  const absolute = isAbsolute2(input) ? input : resolve2(process.cwd(), input);
+  if (containsGlob(input)) {
+    return expandGlob(absolute);
+  }
+  if (!existsSync3(absolute)) {
+    throw new Error(`Path does not exist: ${input}`);
+  }
+  const stat = statSync(absolute);
+  if (stat.isFile()) {
+    if (!hasMarkdownExtension(absolute)) {
+      throw new Error(
+        `Path is not a markdown file: ${input} (expected one of ${MARKDOWN_EXTENSIONS.join(", ")})`
+      );
+    }
+    return [{ filePath: absolute, root: dirnameOf(absolute) }];
+  }
+  if (stat.isDirectory()) {
+    return walkDirectory(absolute, absolute);
+  }
+  return [];
+}
+function dirnameOf(filePath) {
+  const idx = filePath.lastIndexOf(sep);
+  if (idx <= 0) return sep;
+  return filePath.slice(0, idx);
+}
+function walkDirectory(dir, root) {
+  const out = [];
+  const entries = readdirSync2(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const child = join5(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkDirectory(child, root));
+    } else if (entry.isFile() && hasMarkdownExtension(entry.name)) {
+      out.push({ filePath: child, root });
+    }
+  }
+  return out;
+}
+function containsGlob(input) {
+  return /[*?[]/.test(input);
+}
+function expandGlob(absolutePattern) {
+  const segments = absolutePattern.split(sep);
+  let rootEnd = 0;
+  for (let i = 0; i < segments.length; i++) {
+    if (containsGlob(segments[i])) break;
+    rootEnd = i;
+  }
+  const root = segments.slice(0, rootEnd + 1).join(sep) || sep;
+  const remainder = segments.slice(rootEnd + 1);
+  if (!existsSync3(root)) {
+    return [];
+  }
+  return matchPattern(root, remainder, root);
+}
+function matchPattern(currentDir, remaining, root) {
+  if (remaining.length === 0) {
+    if (statSync(currentDir).isFile() && hasMarkdownExtension(currentDir)) {
+      return [{ filePath: currentDir, root }];
+    }
+    return [];
+  }
+  const [head, ...rest] = remaining;
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync2(currentDir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  if (head === "**") {
+    out.push(...matchPattern(currentDir, rest, root));
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        out.push(...matchPattern(join5(currentDir, entry.name), remaining, root));
+      }
+    }
+    return out;
+  }
+  const matcher = globSegmentMatcher(head);
+  for (const entry of entries) {
+    if (!matcher(entry.name)) continue;
+    const child = join5(currentDir, entry.name);
+    if (rest.length === 0) {
+      if (entry.isFile() && hasMarkdownExtension(entry.name)) {
+        out.push({ filePath: child, root });
+      }
+    } else if (entry.isDirectory()) {
+      out.push(...matchPattern(child, rest, root));
+    }
+  }
+  return out;
+}
+function globSegmentMatcher(pattern) {
+  let re = "^";
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === "*") re += "[^/]*";
+    else if (ch === "?") re += "[^/]";
+    else if (ch === "[") {
+      const close = pattern.indexOf("]", i);
+      if (close === -1) {
+        re += "\\[";
+      } else {
+        re += pattern.slice(i, close + 1);
+        i = close;
+      }
+    } else if (/[\\^$+().{}|]/.test(ch)) re += `\\${ch}`;
+    else re += ch;
+  }
+  re += "$";
+  const compiled = new RegExp(re);
+  return (name) => compiled.test(name);
+}
+function hasMarkdownExtension(filename) {
+  const lower = filename.toLowerCase();
+  return MARKDOWN_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+function relativeTo(projectRoot, filePath) {
+  const rel = relative(projectRoot, filePath);
+  return rel.length > 0 ? rel : filePath;
+}
+function isUnderScrapbook(filePath, roots) {
+  if (!roots || roots.length === 0) return false;
+  for (const root of roots) {
+    const r = root.endsWith(sep) ? root : root + sep;
+    if (filePath.startsWith(r)) return true;
+  }
+  return false;
+}
+function candidateToEntry(candidate, stage) {
+  const entry = {
+    slug: candidate.derivedSlug,
+    title: candidate.title,
+    description: candidate.description,
+    stage,
+    targetKeywords: [],
+    source: "manual"
+  };
+  if (stage === "Published") {
+    entry.datePublished = candidate.derivedDate;
+  }
+  return entry;
+}
+var MARKDOWN_EXTENSIONS, SLUG_RE, JEKYLL_RE, ISO_DATE_RE, DEFAULT_FIELDS, STATE_ALIASES;
+var init_ingest = __esm({
+  "../core/src/ingest.ts"() {
+    "use strict";
+    init_frontmatter();
+    init_types();
+    MARKDOWN_EXTENSIONS = [".md", ".mdx", ".markdown"];
+    SLUG_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
+    JEKYLL_RE = /^(\d{4})-(\d{2})-(\d{2})-(.+)$/;
+    ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+    DEFAULT_FIELDS = {
+      title: "title",
+      description: "description",
+      slug: "slug",
+      state: "state",
+      date: "datePublished"
+    };
+    STATE_ALIASES = {
+      ideas: "Ideas",
+      idea: "Ideas",
+      planned: "Planned",
+      outlining: "Outlining",
+      outline: "Outlining",
+      drafting: "Drafting",
+      draft: "Drafting",
+      review: "Review",
+      reviewing: "Review",
+      "in-review": "Review",
+      in_review: "Review",
+      published: "Published",
+      publish: "Published",
+      ideas_lane: "Ideas"
+    };
+  }
+});
+
+// src/commands/ingest.ts
+var ingest_exports = {};
+__export(ingest_exports, {
+  run: () => run4
+});
+import { existsSync as existsSync4, mkdirSync as mkdirSync2 } from "node:fs";
+import { isAbsolute as isAbsolute3, join as join6, resolve as resolve3 } from "node:path";
+import { randomUUID as randomUUID4 } from "node:crypto";
+async function run4(argv2) {
+  const { positional, flags, booleans } = parseInput(argv2);
+  if (positional.length < 2) {
+    fail(
+      "Usage: deskwork ingest <project-root> [--site <slug>] [--apply] [--json] [--force] [--slug-from frontmatter|path] [--state-from frontmatter|datePublished] [--slug <s>] [--state <stage>] [--date YYYY-MM-DD] [--title-field <n>] [--description-field <n>] [--slug-field <n>] [--state-field <n>] [--date-field <n>] <path>...",
+      2
+    );
+  }
+  const [rootArg, ...paths] = positional;
+  const projectRoot = absolutize(rootArg);
+  const slugFrom = parseSlugFrom(flags["slug-from"]);
+  const stateFrom = parseStateFrom(flags["state-from"]);
+  const explicitState = parseExplicitState(flags.state);
+  const explicitDate = parseExplicitDate(flags.date);
+  let config;
+  try {
+    config = readConfig(projectRoot);
+  } catch (err2) {
+    fail(err2 instanceof Error ? err2.message : String(err2));
+  }
+  const site = resolveSite(config, flags.site);
+  const calendarPath = resolveCalendarPath(projectRoot, config, site);
+  const calendar = readCalendar(calendarPath);
+  const absolutePaths = paths.map(
+    (p) => isAbsolute3(p) ? p : resolve3(projectRoot, p)
+  );
+  const contentDir = resolveContentDir(projectRoot, config, site);
+  const scrapbookRoots = [join6(contentDir, "scrapbook")];
+  let discovery;
+  try {
+    discovery = discoverIngestCandidates(absolutePaths, {
+      projectRoot,
+      ...slugFrom !== void 0 ? { slugFrom } : {},
+      ...stateFrom !== void 0 ? { stateFrom } : {},
+      ...flags.slug !== void 0 ? { explicitSlug: flags.slug } : {},
+      ...explicitState !== void 0 ? { explicitState } : {},
+      ...explicitDate !== void 0 ? { explicitDate } : {},
+      fieldNames: buildFieldNames(flags),
+      calendar,
+      ...booleans.has("force") ? { force: true } : {},
+      scrapbookRoots
+    });
+  } catch (err2) {
+    fail(err2 instanceof Error ? err2.message : String(err2), 2);
+  }
+  const ambiguous = [];
+  const actionable = [];
+  for (const c of discovery.candidates) {
+    if (c.derivedState === null) {
+      ambiguous.push({
+        filePath: c.filePath,
+        relativePath: c.relativePath,
+        slug: c.derivedSlug,
+        reason: `state ambiguous (raw frontmatter value: "${c.rawState ?? ""}"); pass --state <stage> to commit`
+      });
+      continue;
+    }
+    actionable.push({ candidate: c, stage: c.derivedState });
+  }
+  const allSkips = [...discovery.skips, ...ambiguous];
+  if (booleans.has("json")) {
+    emitJsonPlan({
+      apply: booleans.has("apply"),
+      site,
+      calendarPath,
+      add: actionable.map((a) => candidatePlanRecord(a.candidate, a.stage)),
+      skip: allSkips
+    });
+  } else {
+    emitTextPlan({
+      apply: booleans.has("apply"),
+      add: actionable,
+      skip: allSkips
+    });
+  }
+  if (!booleans.has("apply")) return;
+  for (const { candidate, stage } of actionable) {
+    const id = randomUUID4();
+    const entry = { id, ...candidateToEntry(candidate, stage) };
+    calendar.entries.push(entry);
+    writeIngestJournalEntry(projectRoot, config, site, candidate, entry);
+  }
+  writeCalendar(calendarPath, calendar);
+}
+function parseInput(argv2) {
+  try {
+    return parseArgs(argv2, KNOWN_FLAGS, BOOLEAN_FLAGS);
+  } catch (err2) {
+    fail(err2 instanceof Error ? err2.message : String(err2), 2);
+  }
+}
+function parseSlugFrom(value) {
+  if (value === void 0) return void 0;
+  if (value !== "frontmatter" && value !== "path") {
+    fail(`--slug-from must be 'frontmatter' or 'path' (got "${value}")`, 2);
+  }
+  return value;
+}
+function parseStateFrom(value) {
+  if (value === void 0) return void 0;
+  if (value !== "frontmatter" && value !== "datePublished") {
+    fail(
+      `--state-from must be 'frontmatter' or 'datePublished' (got "${value}")`,
+      2
+    );
+  }
+  return value;
+}
+function parseExplicitState(value) {
+  if (value === void 0) return void 0;
+  const normalized = value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+  if (!isStage(normalized)) {
+    fail(
+      `--state must be one of Ideas, Planned, Outlining, Drafting, Review, Published (got "${value}")`,
+      2
+    );
+  }
+  return normalized;
+}
+function parseExplicitDate(value) {
+  if (value === void 0) return void 0;
+  if (!DATE_RE.test(value)) {
+    fail(`--date must match YYYY-MM-DD (got "${value}")`, 2);
+  }
+  return value;
+}
+function buildFieldNames(flags) {
+  const out = {};
+  if (flags["title-field"] !== void 0) out.title = flags["title-field"];
+  if (flags["description-field"] !== void 0) out.description = flags["description-field"];
+  if (flags["slug-field"] !== void 0) out.slug = flags["slug-field"];
+  if (flags["state-field"] !== void 0) out.state = flags["state-field"];
+  if (flags["date-field"] !== void 0) out.date = flags["date-field"];
+  return out;
+}
+function candidatePlanRecord(c, stage) {
+  return {
+    action: "add",
+    slug: c.derivedSlug,
+    title: c.title,
+    stage,
+    date: c.derivedDate,
+    filePath: c.filePath,
+    relativePath: c.relativePath,
+    sources: {
+      slug: c.slugSource,
+      state: c.stateSource,
+      date: c.dateSource
+    }
+  };
+}
+function emitJsonPlan(plan) {
+  process.stdout.write(`${JSON.stringify(plan, null, 2)}
+`);
+}
+function emitTextPlan(plan) {
+  const heading = plan.apply ? `Applying: ${plan.add.length} add, ${plan.skip.length} skip` : `Plan: ${plan.add.length} add, ${plan.skip.length} skip (dry-run; pass --apply to commit)`;
+  process.stdout.write(`${heading}
+
+`);
+  for (const { candidate, stage } of plan.add) {
+    const sources = `slug:${candidate.slugSource} state:${candidate.stateSource} date:${candidate.dateSource}`;
+    process.stdout.write(
+      `add  ${pad(candidate.derivedSlug, 36)}  ${pad(stage, 10)}  ${pad(candidate.derivedDate, 12)}  ${sources}
+`
+    );
+  }
+  for (const skip of plan.skip) {
+    const slug = skip.slug ?? "(no slug)";
+    process.stdout.write(`skip ${pad(slug, 36)}  ${skip.reason}
+`);
+  }
+}
+function pad(s, n) {
+  if (s.length >= n) return s;
+  return s + " ".repeat(n - s.length);
+}
+function writeIngestJournalEntry(projectRoot, config, site, candidate, entry) {
+  const journalRoot = join6(
+    projectRoot,
+    config.reviewJournalDir ?? ".deskwork/review-journal",
+    "ingest"
+  );
+  if (!existsSync4(journalRoot)) {
+    mkdirSync2(journalRoot, { recursive: true });
+  }
+  const record = {
+    id: entry.id ?? randomUUID4(),
+    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+    event: "ingest",
+    slug: entry.slug,
+    entryId: entry.id ?? "",
+    site,
+    stage: entry.stage,
+    sourceFile: candidate.relativePath,
+    frontmatterSnapshot: candidate.frontmatter,
+    derivation: {
+      slug: candidate.slugSource,
+      state: candidate.stateSource,
+      date: candidate.dateSource
+    }
+  };
+  appendJournal(journalRoot, record);
+}
+var KNOWN_FLAGS, BOOLEAN_FLAGS, DATE_RE;
+var init_ingest2 = __esm({
+  "src/commands/ingest.ts"() {
+    "use strict";
+    init_config();
+    init_calendar();
+    init_paths();
+    init_types();
+    init_cli();
+    init_journal();
+    init_ingest();
+    KNOWN_FLAGS = [
+      "site",
+      "slug-from",
+      "state-from",
+      "slug",
+      "state",
+      "date",
+      "title-field",
+      "description-field",
+      "slug-field",
+      "state-field",
+      "date-field"
+    ];
+    BOOLEAN_FLAGS = ["apply", "json", "force"];
+    DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+  }
+});
+
+// src/commands/install.ts
+var install_exports = {};
+__export(install_exports, {
+  run: () => run5
+});
+import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, existsSync as existsSync5, mkdirSync as mkdirSync3 } from "node:fs";
+import { dirname, isAbsolute as isAbsolute4, join as join7, resolve as resolve4 } from "node:path";
+async function run5(argv2) {
+  function usage() {
+    console.error(
+      "Usage: deskwork install [<project-root>] <config-file>"
+    );
+    process.exit(2);
+  }
+  let projectRootArg;
+  let configFileArg;
+  if (argv2.length === 1) {
+    projectRootArg = process.cwd();
+    configFileArg = argv2[0];
+  } else if (argv2.length === 2) {
+    [projectRootArg, configFileArg] = argv2;
+  } else {
+    usage();
+  }
+  const projectRoot = isAbsolute4(projectRootArg) ? projectRootArg : resolve4(process.cwd(), projectRootArg);
+  const configFile = isAbsolute4(configFileArg) ? configFileArg : resolve4(process.cwd(), configFileArg);
+  console.log(`Installing into: ${projectRoot}`);
+  if (!existsSync5(projectRoot)) {
+    console.error(`Project root does not exist: ${projectRoot}`);
+    process.exit(1);
+  }
+  if (!existsSync5(configFile)) {
+    console.error(`Config file does not exist: ${configFile}`);
+    process.exit(1);
+  }
+  let rawConfig;
+  try {
+    rawConfig = JSON.parse(readFileSync6(configFile, "utf-8"));
+  } catch (err2) {
+    const reason = err2 instanceof Error ? err2.message : String(err2);
+    console.error(`Config file is not valid JSON: ${reason}`);
+    process.exit(1);
+  }
+  let config;
+  try {
+    config = parseConfig(rawConfig);
+  } catch (err2) {
+    const reason = err2 instanceof Error ? err2.message : String(err2);
+    console.error(reason);
+    process.exit(1);
+  }
+  const writtenConfigPath = configPath(projectRoot);
+  mkdirSync3(dirname(writtenConfigPath), { recursive: true });
+  writeFileSync4(
+    writtenConfigPath,
+    JSON.stringify(config, null, 2) + "\n",
+    "utf-8"
+  );
+  const createdCalendars = [];
+  const preservedCalendars = [];
+  for (const [slug, site] of Object.entries(config.sites)) {
+    const absPath = join7(projectRoot, site.calendarPath);
+    if (existsSync5(absPath)) {
+      preservedCalendars.push(`${slug}: ${site.calendarPath}`);
+      continue;
+    }
+    mkdirSync3(dirname(absPath), { recursive: true });
+    writeFileSync4(absPath, renderEmptyCalendar(), "utf-8");
+    createdCalendars.push(`${slug}: ${site.calendarPath}`);
+  }
+  console.log(`Wrote config: ${writtenConfigPath}`);
+  console.log(`Sites configured: ${Object.keys(config.sites).join(", ")}`);
+  console.log(`Default site: ${config.defaultSite}`);
+  if (createdCalendars.length > 0) {
+    console.log(`Created calendars:`);
+    for (const c of createdCalendars) console.log(`  - ${c}`);
+  }
+  if (preservedCalendars.length > 0) {
+    console.log(`Left existing calendars untouched:`);
+    for (const c of preservedCalendars) console.log(`  - ${c}`);
+  }
+}
+var init_install = __esm({
+  "src/commands/install.ts"() {
+    "use strict";
+    init_config();
+    init_calendar();
+  }
+});
+
+// src/commands/iterate.ts
+var iterate_exports = {};
+__export(iterate_exports, {
+  run: () => run6
+});
+import { existsSync as existsSync6, readFileSync as readFileSync7 } from "node:fs";
+async function run6(argv2) {
+  const KNOWN_FLAGS2 = ["site", "kind", "dispositions"];
+  const DISPOSITIONS = /* @__PURE__ */ new Set(["addressed", "deferred", "wontfix"]);
+  const { positional, flags } = parse();
+  if (positional.length < 2) {
+    fail(
+      "Usage: deskwork-iterate <project-root> [--site <slug>] [--kind longform|outline] [--dispositions <path>] <slug>",
+      2
+    );
+  }
+  const [rootArg, slug] = positional;
+  const projectRoot = absolutize(rootArg);
+  const kind = flags.kind === "outline" ? "outline" : "longform";
+  if (flags.kind !== void 0 && flags.kind !== "longform" && flags.kind !== "outline") {
+    fail(`Invalid --kind "${flags.kind}". Must be 'longform' or 'outline'.`);
+  }
+  let config;
+  try {
+    config = readConfig(projectRoot);
+  } catch (err2) {
+    fail(err2 instanceof Error ? err2.message : String(err2));
+  }
+  const site = resolveSite(config, flags.site);
+  const file = resolveBlogFilePath(projectRoot, config, site, slug);
+  if (!existsSync6(file)) {
+    fail(`No blog file at ${file}.`);
+  }
+  const diskMarkdown = readFileSync7(file, "utf8");
+  const workflow = readWorkflows(projectRoot, config).find(
+    (w) => w.site === site && w.slug === slug && w.contentKind === kind && w.state !== "applied" && w.state !== "cancelled"
+  );
+  if (!workflow) {
+    fail(
+      `No active ${kind} workflow for ${site}/${slug}. Run /deskwork:review-start <slug> to enqueue one first.`
+    );
+  }
+  if (workflow.state !== "iterating") {
+    fail(
+      `Workflow state is '${workflow.state}', not 'iterating'.
+The studio must click 'Request iteration' to move the workflow to 'iterating' before this helper runs.`
+    );
+  }
+  const versions = readVersions(projectRoot, config, workflow.id);
+  const current = versions.find((v) => v.version === workflow.currentVersion);
+  if (current && current.markdown === diskMarkdown) {
+    fail(
+      `File on disk is identical to workflow v${workflow.currentVersion} \u2014 no revision to snapshot. Write the revision to disk first (the agent does this), then re-run.`
+    );
+  }
+  let dispositions = null;
+  if (flags.dispositions !== void 0) {
+    const path = absolutize(flags.dispositions);
+    if (!existsSync6(path)) {
+      fail(`--dispositions file not found: ${path}`);
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync7(path, "utf8"));
+    } catch (err2) {
+      const reason = err2 instanceof Error ? err2.message : String(err2);
+      fail(`--dispositions: invalid JSON at ${path}: ${reason}`);
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      fail(`--dispositions: expected JSON object at ${path}`);
+    }
+    dispositions = {};
+    for (const [commentId, raw] of Object.entries(parsed)) {
+      if (typeof raw !== "object" || raw === null) {
+        fail(`--dispositions[${commentId}]: must be an object`);
+      }
+      const d = raw;
+      if (typeof d.disposition !== "string" || !DISPOSITIONS.has(d.disposition)) {
+        fail(
+          `--dispositions[${commentId}].disposition: must be 'addressed' | 'deferred' | 'wontfix'`
+        );
+      }
+      const entry = { disposition: d.disposition };
+      if (typeof d.reason === "string" && d.reason.length > 0) {
+        entry.reason = d.reason;
+      }
+      dispositions[commentId] = entry;
+    }
+  }
+  const newVersion = appendVersion(
+    projectRoot,
+    config,
+    workflow.id,
+    diskMarkdown,
+    "agent"
+  );
+  const addressed = [];
+  if (dispositions) {
+    const workflowComments = new Set(
+      readAnnotations(projectRoot, config, workflow.id).filter((a) => a.type === "comment").map((a) => a.id)
+    );
+    for (const [commentId, entry] of Object.entries(dispositions)) {
+      if (!workflowComments.has(commentId)) continue;
+      const ann = mintAnnotation({
+        type: "address",
+        workflowId: workflow.id,
+        commentId,
+        version: newVersion.version,
+        disposition: entry.disposition,
+        ...entry.reason !== void 0 ? { reason: entry.reason } : {}
+      });
+      appendAnnotation(projectRoot, config, ann);
+      addressed.push(commentId);
+    }
+  }
+  const updated = transitionState(projectRoot, config, workflow.id, "in-review");
+  emit({
+    workflowId: workflow.id,
+    site: updated.site,
+    slug: updated.slug,
+    state: updated.state,
+    version: newVersion.version,
+    addressedComments: addressed
+  });
+  function parse() {
+    try {
+      return parseArgs(argv2, KNOWN_FLAGS2);
+    } catch (err2) {
+      fail(err2 instanceof Error ? err2.message : String(err2), 2);
+    }
+  }
+}
+var init_iterate = __esm({
+  "src/commands/iterate.ts"() {
+    "use strict";
+    init_config();
+    init_paths();
+    init_pipeline();
+    init_cli();
   }
 });
 
 // ../core/src/scaffold.ts
-import { existsSync as existsSync5, mkdirSync as mkdirSync3 } from "node:fs";
-import { dirname as dirname2, join as join6, relative } from "node:path";
+import { existsSync as existsSync7, mkdirSync as mkdirSync4 } from "node:fs";
+import { dirname as dirname2, join as join8, relative as relative2 } from "node:path";
 function scaffoldBlogPost(projectRoot, config, site, entry, opts = {}) {
   const slug = resolveSite(config, site);
   const siteCfg = config.sites[slug];
@@ -9054,8 +9797,8 @@ function scaffoldBlogPost(projectRoot, config, site, entry, opts = {}) {
     entry.slug,
     contentRelativePath
   );
-  const relativePath = relative(projectRoot, filePath);
-  if (existsSync5(filePath)) {
+  const relativePath = relative2(projectRoot, filePath);
+  if (existsSync7(filePath)) {
     throw new Error(`Blog post already exists at ${relativePath}`);
   }
   const dateStr = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
@@ -9069,9 +9812,9 @@ function scaffoldBlogPost(projectRoot, config, site, entry, opts = {}) {
   data.author = author;
   if (siteCfg.blogInitialState) data.state = siteCfg.blogInitialState;
   const body = buildBody(entry.title, siteCfg.blogOutlineSection === true);
-  mkdirSync3(dirname2(filePath), { recursive: true });
+  mkdirSync4(dirname2(filePath), { recursive: true });
   writeFrontmatter(filePath, data, body);
-  const reported = contentRelativePath ?? relative(join6(projectRoot, siteCfg.contentDir), filePath);
+  const reported = contentRelativePath ?? relative2(join8(projectRoot, siteCfg.contentDir), filePath);
   return { filePath, relativePath, contentRelativePath: reported };
 }
 function layoutToContentRelativePath(layout, slug) {
@@ -9112,10 +9855,10 @@ var init_scaffold = __esm({
 // src/commands/outline.ts
 var outline_exports = {};
 __export(outline_exports, {
-  run: () => run6
+  run: () => run7
 });
-async function run6(argv2) {
-  const KNOWN_FLAGS = ["site", "author", "layout"];
+async function run7(argv2) {
+  const KNOWN_FLAGS2 = ["site", "author", "layout"];
   const VALID_LAYOUTS = ["index", "readme", "flat"];
   const { positional, flags } = parse();
   if (positional.length < 2) {
@@ -9180,7 +9923,7 @@ async function run6(argv2) {
   });
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -9202,10 +9945,10 @@ var init_outline = __esm({
 // src/commands/plan.ts
 var plan_exports = {};
 __export(plan_exports, {
-  run: () => run7
+  run: () => run8
 });
-async function run7(argv2) {
-  const KNOWN_FLAGS = ["site", "topics"];
+async function run8(argv2) {
+  const KNOWN_FLAGS2 = ["site", "topics"];
   const { positional, flags } = parse();
   if (positional.length < 2) {
     fail(
@@ -9247,7 +9990,7 @@ async function run7(argv2) {
   });
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -9267,12 +10010,12 @@ var init_plan = __esm({
 // src/commands/publish.ts
 var publish_exports = {};
 __export(publish_exports, {
-  run: () => run8
+  run: () => run9
 });
-import { existsSync as existsSync6 } from "node:fs";
-async function run8(argv2) {
-  const KNOWN_FLAGS = ["site", "date", "content-url"];
-  const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+import { existsSync as existsSync8 } from "node:fs";
+async function run9(argv2) {
+  const KNOWN_FLAGS2 = ["site", "date", "content-url"];
+  const DATE_RE2 = /^\d{4}-\d{2}-\d{2}$/;
   const { positional, flags } = parse();
   if (positional.length < 2) {
     fail(
@@ -9282,7 +10025,7 @@ async function run8(argv2) {
   }
   const [rootArg, slug] = positional;
   const projectRoot = absolutize(rootArg);
-  if (flags.date !== void 0 && !DATE_RE.test(flags.date)) {
+  if (flags.date !== void 0 && !DATE_RE2.test(flags.date)) {
     fail(`Invalid --date "${flags.date}". Must match YYYY-MM-DD.`);
   }
   let config;
@@ -9309,7 +10052,7 @@ async function run8(argv2) {
   let filePath;
   if (hasRepoContent(contentType)) {
     filePath = resolveBlogFilePath(projectRoot, config, site, slug);
-    if (!existsSync6(filePath)) {
+    if (!existsSync8(filePath)) {
       fail(
         `Cannot publish blog post "${slug}": no file at ${filePath}. Write the post before publishing.`
       );
@@ -9338,7 +10081,7 @@ async function run8(argv2) {
   });
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -9359,10 +10102,10 @@ var init_publish = __esm({
 // src/commands/review-cancel.ts
 var review_cancel_exports = {};
 __export(review_cancel_exports, {
-  run: () => run9
+  run: () => run10
 });
-async function run9(argv2) {
-  const KNOWN_FLAGS = ["site", "platform", "channel", "kind"];
+async function run10(argv2) {
+  const KNOWN_FLAGS2 = ["site", "platform", "channel", "kind"];
   const { positional, flags } = parse();
   if (positional.length < 2) {
     fail(
@@ -9426,7 +10169,7 @@ async function run9(argv2) {
   }
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -9447,10 +10190,10 @@ var init_review_cancel = __esm({
 // src/commands/review-help.ts
 var review_help_exports = {};
 __export(review_help_exports, {
-  run: () => run10
+  run: () => run11
 });
-async function run10(argv2) {
-  const KNOWN_FLAGS = ["site"];
+async function run11(argv2) {
+  const KNOWN_FLAGS2 = ["site"];
   const { positional, flags } = parse();
   if (positional.length < 1) {
     fail("Usage: deskwork-review-help <project-root> [--site <slug>]", 2);
@@ -9479,7 +10222,7 @@ async function run10(argv2) {
   });
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -9657,11 +10400,11 @@ var init_report = __esm({
 // src/commands/review-report.ts
 var review_report_exports = {};
 __export(review_report_exports, {
-  run: () => run11
+  run: () => run12
 });
-async function run11(argv2) {
-  const KNOWN_FLAGS = ["site", "format"];
-  const BOOLEAN_FLAGS = ["include-active"];
+async function run12(argv2) {
+  const KNOWN_FLAGS2 = ["site", "format"];
+  const BOOLEAN_FLAGS2 = ["include-active"];
   const { positional, flags, booleans } = parse();
   if (positional.length < 1) {
     fail(
@@ -9691,7 +10434,7 @@ async function run11(argv2) {
   }
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS, BOOLEAN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2, BOOLEAN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
@@ -9707,7 +10450,7 @@ var init_review_report = __esm({
 });
 
 // ../core/src/body-state.ts
-import { existsSync as existsSync7, readFileSync as readFileSync7 } from "node:fs";
+import { existsSync as existsSync9, readFileSync as readFileSync8 } from "node:fs";
 function stripOutlineSection(body) {
   const lines = body.split("\n");
   const startIdx = lines.findIndex((line) => /^##[ \t]+Outline\b/.test(line));
@@ -9722,8 +10465,8 @@ function stripOutlineSection(body) {
   return [...lines.slice(0, startIdx), ...lines.slice(endIdx)].join("\n");
 }
 function bodyState(filePath) {
-  if (!existsSync7(filePath)) return "missing";
-  const content = readFileSync7(filePath, "utf8");
+  if (!existsSync9(filePath)) return "missing";
+  const content = readFileSync8(filePath, "utf8");
   const fmMatch = content.match(/^---\n[\s\S]*?\n---\n?/);
   const body = fmMatch ? content.slice(fmMatch[0].length) : content;
   const withoutH1 = body.replace(/^\s*#[^\n]*\n?/, "");
@@ -9745,21 +10488,21 @@ var init_body_state = __esm({
 // src/commands/review-start.ts
 var review_start_exports = {};
 __export(review_start_exports, {
-  run: () => run12
+  run: () => run13
 });
-import { existsSync as existsSync8, readFileSync as readFileSync8, readdirSync as readdirSync2 } from "node:fs";
+import { existsSync as existsSync10, readFileSync as readFileSync9, readdirSync as readdirSync3 } from "node:fs";
 import { dirname as dirname3 } from "node:path";
-async function run12(argv2) {
-  const KNOWN_FLAGS = ["site"];
-  const SLUG_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
+async function run13(argv2) {
+  const KNOWN_FLAGS2 = ["site"];
+  const SLUG_RE2 = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/;
   const { positional, flags } = parse();
   if (positional.length < 2) {
     fail("Usage: deskwork-review-start <project-root> [--site <slug>] <slug>", 2);
   }
   const [rootArg, slug] = positional;
   const projectRoot = absolutize(rootArg);
-  if (!SLUG_RE.test(slug)) {
-    fail(`invalid slug: ${slug} (must match ${SLUG_RE})`);
+  if (!SLUG_RE2.test(slug)) {
+    fail(`invalid slug: ${slug} (must match ${SLUG_RE2})`);
   }
   let config;
   try {
@@ -9769,7 +10512,7 @@ async function run12(argv2) {
   }
   const site = resolveSite(config, flags.site);
   const file = resolveBlogFilePath(projectRoot, config, site, slug);
-  if (!existsSync8(file)) {
+  if (!existsSync10(file)) {
     const siblings = listSiblingSlugs(file);
     const list = siblings.length > 0 ? siblings.join(", ") : "(none)";
     fail(
@@ -9778,7 +10521,7 @@ Existing slugs on ${site}: ${list}.
 Run /deskwork:outline <slug> (or /deskwork:draft) to scaffold it first.`
     );
   }
-  const initialMarkdown = readFileSync8(file, "utf8");
+  const initialMarkdown = readFileSync9(file, "utf8");
   const body = bodyState(file);
   const before = Date.now();
   const workflow = createWorkflow(projectRoot, config, {
@@ -9812,15 +10555,15 @@ Run /deskwork:outline <slug> (or /deskwork:draft) to scaffold it first.`
   });
   function parse() {
     try {
-      return parseArgs(argv2, KNOWN_FLAGS);
+      return parseArgs(argv2, KNOWN_FLAGS2);
     } catch (err2) {
       fail(err2 instanceof Error ? err2.message : String(err2), 2);
     }
   }
   function listSiblingSlugs(blogFile) {
     const dir = dirname3(blogFile);
-    if (!existsSync8(dir)) return [];
-    return readdirSync2(dir).filter((name) => name.endsWith(".md")).map((name) => name.replace(/\.md$/, ""));
+    if (!existsSync10(dir)) return [];
+    return readdirSync3(dir).filter((name) => name.endsWith(".md")).map((name) => name.replace(/\.md$/, ""));
   }
 }
 var init_review_start = __esm({
@@ -9839,6 +10582,7 @@ var SUBCOMMANDS = {
   add: () => Promise.resolve().then(() => (init_add(), add_exports)),
   approve: () => Promise.resolve().then(() => (init_approve(), approve_exports)),
   draft: () => Promise.resolve().then(() => (init_draft(), draft_exports)),
+  ingest: () => Promise.resolve().then(() => (init_ingest2(), ingest_exports)),
   install: () => Promise.resolve().then(() => (init_install(), install_exports)),
   iterate: () => Promise.resolve().then(() => (init_iterate(), iterate_exports)),
   outline: () => Promise.resolve().then(() => (init_outline(), outline_exports)),
@@ -9879,6 +10623,7 @@ function printUsage() {
   out.write("Usage: deskwork <subcommand> [args...]\n\n");
   out.write("Lifecycle:\n");
   out.write("  install         bootstrap deskwork in a project\n");
+  out.write("  ingest          backfill existing markdown into the calendar\n");
   out.write("  add             append an idea to the calendar\n");
   out.write("  plan            move Ideas \u2192 Planned with keywords\n");
   out.write("  outline         scaffold + move Planned \u2192 Outlining\n");

--- a/plugins/deskwork/package.json
+++ b/plugins/deskwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Editorial calendar lifecycle plugin for Claude Code — thin shell pointing at @deskwork/cli",
   "license": "GPL-3.0-or-later",

--- a/plugins/deskwork/package.json
+++ b/plugins/deskwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskwork/plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Editorial calendar lifecycle plugin for Claude Code — thin shell pointing at @deskwork/cli",
   "license": "GPL-3.0-or-later",

--- a/plugins/deskwork/skills/ingest/SKILL.md
+++ b/plugins/deskwork/skills/ingest/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: ingest
+description: Backfill existing markdown content into the editorial calendar. Walks files / directories / globs, parses frontmatter, derives slug + state + date with provenance, and (after a dry-run) appends calendar rows + a journal record per file. Use when adopting deskwork on a project that already has published or in-progress posts.
+---
+
+## Ingest — Backfill what you already have
+
+The lifecycle (`add → plan → outline → draft → publish`) is forward-only. Anyone adopting deskwork on a project that already has content hits this on day one: the calendar starts empty and there's no first-class way to populate it from existing posts. `ingest` is that way.
+
+**Layout-agnostic.** Works for Astro `<slug>/index.md`, Hugo leaf bundles, Jekyll `_posts/YYYY-MM-DD-<slug>.md`, flat `<slug>.md`, hierarchical content nodes, and plain markdown notes folders without per-tree configuration. The operator picks paths; deskwork honors whatever shape is on disk.
+
+### When to use ingest vs. add
+
+| Situation | Use |
+|---|---|
+| Brand-new idea, nothing on disk yet | `/deskwork:add` |
+| File already exists and reflects work in progress (drafted, published, etc.) | `/deskwork:ingest` |
+| Migrating from a different editorial calendar format | Not in scope — out of scope per PRD |
+| Pulling from Substack / RSS / Notion | Not in scope — `ingest` reads markdown on disk only |
+
+**Rule of thumb:** if the markdown file already contains body text the operator wrote, ingest. If it doesn't exist yet, add.
+
+### The dry-run-first contract
+
+`ingest` is **dry-run by default**. Without `--apply`, it walks the discovery target, prints a complete plan to stdout, and writes nothing to disk. Always run dry-run first, read the plan, then re-run with `--apply` when the plan looks right.
+
+```
+deskwork ingest src/content/essays/
+```
+
+…produces output like:
+
+```
+Plan: 3 add, 0 skip (dry-run; pass --apply to commit)
+
+add  whats-in-a-name                      Published   2020-10-01    slug:path state:frontmatter date:frontmatter
+add  the-deskwork-experiment              Published   2026-04-20    slug:path state:frontmatter date:frontmatter
+add  on-revising-in-the-open              Drafting    2026-05-15    slug:path state:frontmatter date:frontmatter
+```
+
+The trailing `slug:... state:... date:...` columns record where each derived value came from — verify them before committing. Sources:
+
+- `frontmatter` — pulled from a YAML field
+- `path` — derived from the file path
+- `mtime` — file modification time fallback
+- `today` — last-resort fallback (current date)
+- `explicit` — passed via `--slug` / `--state` / `--date`
+
+### Layout-agnostic discovery — examples
+
+The operator passes paths; deskwork walks them and derives slugs from the layout. The path argument's basename does **not** prefix child slugs unless that directory has its own `index.md`/`README.md` (i.e. it's itself a content node).
+
+#### Astro / Hugo `<slug>/index.md`
+
+```
+src/content/essays/
+├── whats-in-a-name/index.md          → slug "whats-in-a-name"
+├── the-deskwork-experiment/index.md  → slug "the-deskwork-experiment"
+└── on-revising-in-the-open/index.md  → slug "on-revising-in-the-open"
+```
+
+```
+deskwork ingest src/content/essays/
+```
+
+`essays/` has no `essays/index.md`, so it's a collection container — its name doesn't prefix slugs.
+
+#### Hierarchical content nodes (own `index.md` at each level)
+
+```
+src/content/the-outbound/
+├── index.md                              → slug "the-outbound"
+├── characters/
+│   ├── index.md                          → slug "the-outbound/characters"
+│   ├── strivers/index.md                 → slug "the-outbound/characters/strivers"
+│   └── dreamers/index.md                 → slug "the-outbound/characters/dreamers"
+└── structure/index.md                    → slug "the-outbound/structure"
+```
+
+```
+deskwork ingest src/content/the-outbound/
+```
+
+Each directory with its own `index.md` is itself a tracked content node, so its name prefixes child slugs.
+
+#### Jekyll `_posts/YYYY-MM-DD-<slug>.md`
+
+```
+_posts/
+├── 2024-01-15-hello-world.md             → slug "hello-world"
+└── 2024-02-20-second-post.md             → slug "second-post"
+```
+
+```
+deskwork ingest _posts/
+```
+
+The date prefix gets stripped; the post body remains the slug.
+
+#### Flat `<slug>.md`
+
+```
+src/content/blog/
+├── foo.md                                → slug "foo"
+└── bar.md                                → slug "bar"
+```
+
+```
+deskwork ingest src/content/blog/
+```
+
+#### Eleventy / plain notes / globs
+
+```
+deskwork ingest 'notes/2024/**/*.md'
+deskwork ingest src/posts/ another-dir/specific-file.md
+```
+
+Multiple paths in one call are supported. Glob expansion uses the deepest static prefix as the slug-derivation root (`src/posts/​**​/*.md` rooted at `src/posts/`).
+
+### State derivation
+
+By default, the helper reads the `state:` frontmatter field and normalizes it onto the calendar's six lanes:
+
+| Frontmatter value | Lane |
+|---|---|
+| `published`, `publish` | Published |
+| `review`, `reviewing`, `in-review` | Review |
+| `drafting`, `draft` | Drafting |
+| `outline`, `outlining` | Outlining |
+| `planned` | Planned |
+| `idea`, `ideas` | Ideas |
+| (anything else) | **ambiguous** — operator must pass `--state` |
+
+Files without a `state:` field default to `Ideas`.
+
+### Common flag combinations
+
+```sh
+# Dry-run — read the plan first.
+deskwork ingest src/content/essays/
+
+# Commit after the plan looks right.
+deskwork ingest src/content/essays/ --apply
+
+# Single file with explicit overrides (slug + state + date).
+deskwork ingest --slug whats-in-a-name --state Published --date 2020-10-01 \
+  src/content/essays/whats-in-a-name/index.md --apply
+
+# State the operator's project schema spells differently:
+#   their YAML uses `status:` instead of `state:`.
+deskwork ingest --state-field status src/content/posts/ --apply
+
+# Frontmatter has no state field; infer from datePublished
+# (past → Published; future → Drafting).
+deskwork ingest --state-from datePublished src/content/posts/ --apply
+
+# Glob across multiple year-bucketed directories.
+deskwork ingest 'src/posts/2023/**/*.md' 'src/posts/2024/**/*.md' --apply
+
+# Multi-site project — explicit site:
+deskwork ingest --site secondary src/sites/secondary/content/ --apply
+
+# Operator manually reconciled a duplicate; force a re-add:
+deskwork ingest --force src/content/essays/the-revised-one/index.md --apply
+```
+
+### Idempotency
+
+Re-running `ingest --apply` over the same paths is safe: candidates whose slug already exists in the calendar emit a `skip` line with the reason. The journal records the first ingest only — duplicate skips don't create new journal entries.
+
+`--force` bypasses the duplicate-slug check after the operator has manually reconciled (e.g. moved an old row to a different lane and now wants the file ingested fresh). The apply layer does **not** dedupe after `--force`; the operator owns the reconciliation.
+
+### Steps for the agent
+
+1. **Confirm the target.** Ask the operator which path(s) to ingest. If they say "everything", point them at the project's primary content directory (`src/content/`, `content/`, `_posts/`, etc.) — never auto-walk the entire repo (out of scope: `node_modules/`, `vendor/`, etc.).
+2. **Resolve `--site`** (or default).
+3. **Run a dry-run first.** Always. Read the plan with the operator before committing.
+4. **Surface ambiguities.** Files with unrecognized `state:` values land in the `skip` list with `state ambiguous`. The operator either edits the frontmatter or passes `--state <lane>` per-file (which means re-running per-file — not a bulk override).
+5. **Run with `--apply`** once the plan is correct.
+6. **Report.** Read the calendar back and tell the operator how many rows landed in each lane, plus any remaining skips.
+
+### Error handling
+
+- **Path does not exist** — surface verbatim. Don't paper over with a fallback.
+- **Unknown `state:` value** — file is skipped with `state ambiguous`. Per-file fix: `deskwork ingest --apply --state Published <file>`.
+- **Slug collision with an existing calendar row** — file is skipped with `already has an entry`. Inspect the existing row before reaching for `--force`.
+- **Malformed frontmatter** — file is skipped with `frontmatter parse failed: <reason>`. The operator fixes the YAML and re-runs.
+- **Files under `<contentDir>/scrapbook/`** — skipped by default; ingest those explicitly when the operator wants them tracked.
+
+### What this is not
+
+- **Not a migration tool for other editorial-calendar formats.** Source is markdown files on disk + their frontmatter. Importing from Notion / Airtable / a different calendar-markdown shape is out of scope.
+- **Not a publishing-platform sync.** No Substack, Ghost, RSS pulling.
+- **Not auto-detection of the content tree.** The operator passes paths explicitly.


### PR DESCRIPTION
## Summary

Adds `deskwork ingest`, a new subcommand for backfilling existing markdown content into the editorial calendar. Layout-agnostic — works for Astro `<slug>/index.md`, Hugo leaf bundles, Jekyll `_posts/YYYY-MM-DD-slug.md`, flat `<slug>.md`, and hierarchical content nodes without per-tree configuration.

Closes #15.

## What this changes

- **`packages/core/src/ingest.ts` + `ingest-derive.ts` + `ingest-paths.ts`** — discovery primitive. Walks paths (file / directory / glob), parses frontmatter, and derives slug + state + date with provenance recording (frontmatter / path / mtime / today / explicit). Layout-agnostic: the operator's path argument's basename does NOT prefix child slugs unless that directory has its own `index.md`/`README.md` (i.e. it's itself a tracked content node). Hierarchical slugs accumulate naturally up the path.
- **`packages/cli/src/commands/ingest.ts`** — CLI surface. Argv `[<project-root>] [--site <slug>] [options] <path>...`. Dry-run by default; `--apply` writes calendar rows + journal records with `event: 'ingest'`. `--json` for machine-readable plan output. Idempotent on re-run.
- **`plugins/deskwork/skills/ingest/SKILL.md`** — operator-facing prompt covering when to use ingest vs. add, the dry-run-first contract, layout-agnostic discovery examples for the four common shapes, state-derivation alias table, common flag combinations, and out-of-scope clarifications.

## Acceptance criteria (from workplan Phase 15)

- [x] `deskwork ingest <path>` (no `--apply`) prints a plan and writes nothing; exits 0 even when every file would be skipped.
- [x] `deskwork ingest <path> --apply` writes calendar rows + journal entries; re-running produces only skips (idempotent).
- [x] Discovery works against synthetic Astro / Hugo / Jekyll / flat trees — only the path argument differs.
- [x] Files under `<contentDir>/scrapbook/` are skipped by default.
- [x] Unrecognized `state:` values produce a "state ambiguous" skip; operator re-runs with `--state` to commit.
- [x] Slug collision reports `skip` with reason; `--force` bypasses.
- [x] writingcontrol.org dogfood: ingesting `src/content/essays/` lands the three known essays in the right lanes (`whats-in-a-name` + `the-deskwork-experiment` → Published with their `datePublished` values; `on-revising-in-the-open` → Drafting).

## Test plan

- [x] `npm --workspace packages/core test` — 202 tests pass (156 baseline + 46 new for ingest discovery / derivation / idempotency / flag overrides).
- [x] `npm --workspace packages/cli test` — 61 tests pass (40 baseline + 21 new integration tests covering the layout matrix, --apply, --force, ambiguous-state handling, --site routing, --slug single-file enforcement, scrapbook skipping, error cases).
- [x] `npm --workspace packages/studio test` — 39 tests still green.
- [x] `npx tsc --noEmit -p packages/core` and `-p packages/cli` — clean.
- [x] `claude plugin validate plugins/deskwork` — passes.
- [x] Manual dogfood: synthetic writingcontrol.org tree → 3 essays land in correct lanes; re-run produces 3 skips; `--force` bypasses skip and adds duplicate row.
- [x] Husky pre-commit rebuilds `plugins/deskwork/bundle/cli.mjs` and re-stages it on every commit that touched `packages/cli/src/`.

## Commits

1. `feat(core)` — discovery primitive + 46 unit tests.
2. `feat(cli)` — CLI dispatcher entry + 21 integration tests + dispatcher registration.
3. `docs(skill)` — operator-facing SKILL.md.
4. `refactor(core)` — split ingest module to keep all files under the 300-500 line guideline.
5. `docs(workplan)` — Phase 15 checkboxes flipped.
