### PR TITLE
fix(scope-discovery): TF-004 + TF-005 — close v0.24.1 canary findings

### DIFF
--- a/.dw-lifecycle/scope-discovery/clones.yaml
+++ b/.dw-lifecycle/scope-discovery/clones.yaml
@@ -1,4 +1,4 @@
-generated_at: 2026-05-27T04:21:30.812Z
+generated_at: 2026-05-28T06:35:47.333Z
 clones:
   - id: 014b49040fe1
     lines: 13
@@ -639,35 +639,6 @@ clones:
       - plugins/dw-lifecycle/src/scope-discovery/controller/controller-policies.ts:213:228
     disposition: keep-with-reason
     reason: intentional shared scaffolding from Phase 11 Wave 6 (controller library + audit-log parser + cross-surface filter scaffolds share boilerplate). Extracting hurts more than the duplication costs.
-  - id: 5b458e4fbe70
-    lines: 9
-    members:
-      - plugins/dw-lifecycle/src/scope-discovery/controller/controller-state.ts:140:148
-      - plugins/dw-lifecycle/src/scope-discovery/orchestrator-loop/loop-config.ts:52:60
-      - plugins/dw-lifecycle/src/scope-discovery/orchestrator-loop/loop-state.ts:83:91
-    disposition: pending
-    reason: null
-  - id: 9a9bc23a9689
-    lines: 12
-    members:
-      - plugins/dw-lifecycle/src/scope-discovery/controller/controller-state.ts:151:162
-      - plugins/dw-lifecycle/src/scope-discovery/escalation/escalation-parse.ts:63:74
-    disposition: pending
-    reason: null
-  - id: 3adf9dc3205a
-    lines: 10
-    members:
-      - plugins/dw-lifecycle/src/scope-discovery/controller/controller-state.ts:321:330
-      - plugins/dw-lifecycle/src/scope-discovery/recovery/trust-calibration.ts:337:346
-    disposition: pending
-    reason: null
-  - id: 901289cce185
-    lines: 11
-    members:
-      - plugins/dw-lifecycle/src/scope-discovery/controller/controller-state.ts:346:356
-      - plugins/dw-lifecycle/src/scope-discovery/recovery/trust-calibration.ts:359:369
-    disposition: pending
-    reason: null
   - id: afeee722255a
     lines: 16
     members:
@@ -717,6 +688,48 @@ clones:
       - plugins/dw-lifecycle/src/scope-discovery/discovery-agents/prd-themed-pattern-hunter.ts:181:189
     disposition: pending
     reason: null
+  - id: 9ff84b42341b
+    lines: 18
+    members:
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts:104:121
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts:196:213
+    disposition: pending
+    reason: null
+  - id: 329cba21b4ca
+    lines: 24
+    members:
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts:114:137
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts:39:62
+    disposition: keep-with-reason
+    reason: "TF-005 fix: wrap-prompt + validate-return CLI verbs share parsing + override-resolution boilerplate with dispatch-wrapper.ts by design"
+  - id: 48215ae524d5
+    lines: 8
+    members:
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts:140:147
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts:232:239
+    disposition: keep-with-reason
+    reason: "TF-005 fix: wrap-prompt + validate-return CLI verbs share parsing + override-resolution boilerplate with dispatch-wrapper.ts by design"
+  - id: a5ba00eab10c
+    lines: 21
+    members:
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts:26:46
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts:118:138
+    disposition: pending
+    reason: null
+  - id: 641aa1adda0d
+    lines: 10
+    members:
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts:59:68
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts:151:160
+    disposition: pending
+    reason: null
+  - id: 08acb5a7f406
+    lines: 11
+    members:
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts:74:84
+      - plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts:166:176
+    disposition: pending
+    reason: null
   - id: 7a91b6f37fe8
     lines: 24
     members:
@@ -750,55 +763,55 @@ clones:
     lines: 17
     members:
       - plugins/dw-lifecycle/src/scope-discovery/escalation/escalation-queue.ts:134:150
-      - plugins/dw-lifecycle/src/scope-discovery/llm/auditor.ts:109:263
+      - plugins/dw-lifecycle/src/scope-discovery/llm/auditor.ts:109:213
     disposition: pending
     reason: null
   - id: b55096bc507f
     lines: 17
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/install-agent-prompts.ts:118:134
-      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:154:170
+      - plugins/dw-lifecycle/src/scope-discovery/install-agent-prompts.ts:119:135
+      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:168:184
     disposition: pending
     reason: null
   - id: ced608f5be46
     lines: 18
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/install-agent-prompts.ts:132:149
-      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:171:188
+      - plugins/dw-lifecycle/src/scope-discovery/install-agent-prompts.ts:133:150
+      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:185:202
     disposition: pending
     reason: null
   - id: bc97e6ec2135
     lines: 7
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/install-agent-prompts.ts:304:310
+      - plugins/dw-lifecycle/src/scope-discovery/install-agent-prompts.ts:311:317
       - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery.ts:245:251
     disposition: pending
     reason: null
   - id: 3c6b6627d081
     lines: 14
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:154:167
+      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:168:181
       - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery.ts:157:112
     disposition: pending
     reason: null
   - id: 92d75db1cad2
     lines: 16
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:173:188
+      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:187:202
       - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery.ts:170:127
     disposition: pending
     reason: null
   - id: 7698568d0d6c
     lines: 9
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:327:335
-      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:347:355
+      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:341:349
+      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:361:369
     disposition: pending
     reason: null
   - id: cd6cea43f755
     lines: 9
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:465:473
+      - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery-hooks.ts:562:570
       - plugins/dw-lifecycle/src/scope-discovery/install-scope-discovery.ts:267:275
     disposition: pending
     reason: null
@@ -827,7 +840,7 @@ clones:
     lines: 10
     members:
       - plugins/dw-lifecycle/src/scope-discovery/llm/auditor.ts:111:120
-      - plugins/dw-lifecycle/src/scope-discovery/orchestrator-loop/loop-state.ts:244:253
+      - plugins/dw-lifecycle/src/scope-discovery/orchestrator-loop/loop-state.ts:202:211
     disposition: pending
     reason: null
   - id: 8f81364fec2d
@@ -868,28 +881,28 @@ clones:
   - id: 3696fa4e795e
     lines: 13
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory-cli.ts:84:96
+      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory-cli.ts:99:111
       - plugins/dw-lifecycle/src/scope-discovery/scope-widen-cli.ts:104:116
     disposition: keep-with-reason
     reason: intentional shared scaffolding across Phase 11 Wave 5 surfaces (codebase-state metrics computation + gather pattern, LLM judge/auditor library boilerplate, tooling-feedback import + doctor rule scaffolding). Extracting would create cross-surface coupling that hurts more than the duplication costs.
   - id: babc9b39137a
     lines: 10
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory.ts:269:278
+      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory.ts:285:294
       - plugins/dw-lifecycle/src/scope-discovery/scope-widen.ts:246:255
     disposition: keep-with-reason
     reason: scope-widen mirrors scope-inventory's CLI-shell boilerplate (slug-regex validation, makeRunDir, scopeWidenMain's parseCli try/catch). Extracting shared helpers would tangle two subcommands' control flow for marginal de-duplication benefit; the symmetry is desirable for operator UX consistency.
   - id: 653e6225d350
     lines: 11
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory.ts:271:281
+      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory.ts:287:297
       - plugins/dw-lifecycle/src/scope-discovery/synthesis-cli.ts:150:160
     disposition: pending
     reason: null
   - id: c86cf0b21100
     lines: 11
     members:
-      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory.ts:75:85
+      - plugins/dw-lifecycle/src/scope-discovery/scope-inventory.ts:80:90
       - plugins/dw-lifecycle/src/scope-discovery/scope-widen.ts:78:88
     disposition: keep-with-reason
     reason: scope-widen mirrors scope-inventory's CLI-shell boilerplate (slug-regex validation, makeRunDir, scopeWidenMain's parseCli try/catch). Extracting shared helpers would tangle two subcommands' control flow for marginal de-duplication benefit; the symmetry is desirable for operator UX consistency.

--- a/plugins/dw-lifecycle/bin/dw-lifecycle
+++ b/plugins/dw-lifecycle/bin/dw-lifecycle
@@ -7,13 +7,26 @@
 #   1. Workspace dev path: tsx exists in some ancestor's node_modules/.bin/
 #      via npm workspace hoist. Dispatch via that tsx.
 #   2. Adopter post-install: tsx exists at $PLUGIN_ROOT/node_modules/.bin/tsx
-#      (after first-run `npm install --omit=dev --workspaces=false`).
-#   3. First run, neither present: npm install in $PLUGIN_ROOT, then dispatch.
+#      AND all other declared runtime deps are resolvable from
+#      $PLUGIN_ROOT/node_modules/. Dispatch via the local tsx.
+#   3. First run (or partial install): npm install in $PLUGIN_ROOT, then
+#      dispatch. A sentinel file under $PLUGIN_ROOT/node_modules/ encodes
+#      the plugin manifest version so subsequent runs short-circuit the
+#      dep-probe walk. Version bumps invalidate the sentinel and force a
+#      fresh probe.
 #
 # Unlike the deskwork/deskwork-studio shells, dw-lifecycle's logic ships
 # in-tree (plugins/dw-lifecycle/src/*.ts), not as a published @deskwork/*
-# npm package. The shell needs npm install to fetch tsx + yaml + zod
-# (declared in this plugin's package.json), and nothing else.
+# npm package. The shell needs npm install to fetch the full declared
+# dependency set (tsx + yaml + zod + ajv + ajv-formats + jscpd), and
+# nothing else.
+#
+# Probing the full dep set (not just tsx) closes TF-004: prior shim
+# versions only probed for tsx, leaving the rest of the declared
+# runtime deps uninstalled when the marketplace clone arrived without
+# a node_modules/ tree (a freshly-evicted Claude Code cache, or a
+# manual `git clone` of the marketplace). Adopters hit
+# `ERR_MODULE_NOT_FOUND: ajv` on first invocation.
 
 set -euo pipefail
 
@@ -36,26 +49,145 @@ find_tsx() {
   return 1
 }
 
-TSX_BIN="$(find_tsx || true)"
+# Read the plugin manifest version from .claude-plugin/plugin.json.
+# Used to name the install-complete sentinel so version bumps force a
+# re-probe. Falls back to an empty string if the manifest is unreadable;
+# an empty version simply disables the sentinel fast-path (every run
+# probes), which is the conservative default.
+plugin_version() {
+  local manifest="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+  [ -f "${manifest}" ] || { printf ''; return 0; }
+  node -e "
+    try {
+      const m = JSON.parse(require('fs').readFileSync('${manifest}', 'utf8'));
+      if (typeof m.version === 'string' && m.version) process.stdout.write(m.version);
+    } catch (e) { /* sentinel is optional; never fail the shim over it */ }
+  " 2>/dev/null || printf ''
+}
 
-if [ -z "${TSX_BIN}" ]; then
-  echo "dw-lifecycle: first run — installing dependencies..." >&2
+# Probe whether a declared runtime dep is installed in the plugin's own
+# node_modules/. We test for the dep's package.json (rather than the
+# directory alone) so a partial-install state where the directory was
+# created but the package metadata never landed is caught.
+dep_installed() {
+  local dep=$1
+  [ -f "${PLUGIN_ROOT}/node_modules/${dep}/package.json" ]
+}
+
+# Probe every declared runtime dep. The list is the union of
+# package.json's "dependencies" keys. Update both lists together when
+# the plugin gains a new runtime dep.
+#
+# Note: we deliberately probe a representative cross-section (tsx for
+# the entry-point, ajv/ajv-formats/jscpd for the post-tsx imports the
+# CLI hits, yaml/zod for the manifest readers) rather than every
+# transitive package — npm install is atomic at the top level, so any
+# of these being missing means the whole tree needs to be installed.
+all_deps_installed() {
+  for dep in tsx yaml zod ajv ajv-formats jscpd; do
+    if ! dep_installed "${dep}"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# Run npm install in the plugin root. Used both on first install and
+# on partial-install recovery (any declared dep missing).
+run_install() {
+  echo "dw-lifecycle: installing plugin dependencies (first run for v${1:-unknown})..." >&2
   (
     cd "${PLUGIN_ROOT}"
     # --workspaces=false: when the plugin tree is sparse-cloned from a
     # workspaces-declaring monorepo, npm would otherwise walk up, treat
     # this as a workspace install, and hoist node_modules/ to the
-    # workspace root — leaving ${PLUGIN_ROOT}/node_modules/.bin/tsx
-    # empty. Disabling workspaces forces install into the plugin's own
+    # workspace root — leaving ${PLUGIN_ROOT}/node_modules/ empty.
+    # Disabling workspaces forces install into the plugin's own
     # node_modules/.
     npm install --omit=dev --workspaces=false \
       --no-audit --no-fund --loglevel=error
   ) >&2
+}
+
+# Write the install-complete sentinel keyed to the manifest version.
+# On subsequent runs the sentinel's existence short-circuits the
+# dep-probe walk. Version bumps change the sentinel filename, so a
+# stale sentinel from v0.24.1 doesn't suppress the probe when v0.25.0
+# ships with a wider declared-dep set.
+write_sentinel() {
+  local version=$1
+  [ -n "${version}" ] || return 0
+  [ -d "${PLUGIN_ROOT}/node_modules" ] || return 0
+  : > "${PLUGIN_ROOT}/node_modules/.deskwork-install-complete-${version}" 2>/dev/null || true
+}
+
+sentinel_present() {
+  local version=$1
+  [ -n "${version}" ] || return 1
+  [ -f "${PLUGIN_ROOT}/node_modules/.deskwork-install-complete-${version}" ]
+}
+
+# Decide whether the plugin needs an install run. Three states:
+#   1. Workspace dev path: tsx resolves from an ancestor's node_modules.
+#      The monorepo's install already covered every workspace package's
+#      deps, so we never run npm install here — the workspace's
+#      node_modules is the source of truth.
+#   2. Adopter mode, sentinel + tsx present: trust the sentinel; skip
+#      the per-dep probe.
+#   3. Adopter mode, no sentinel OR any dep missing: install.
+
+TSX_BIN="$(find_tsx || true)"
+VERSION="$(plugin_version)"
+
+# Detect workspace dev path: tsx resolved from an ancestor (NOT from
+# PLUGIN_ROOT/node_modules itself). In that case the monorepo owns
+# dependency resolution; we don't probe the plugin's own node_modules.
+IS_WORKSPACE_DEV=0
+if [ -n "${TSX_BIN}" ]; then
+  case "${TSX_BIN}" in
+    "${PLUGIN_ROOT}/node_modules/.bin/tsx")
+      IS_WORKSPACE_DEV=0
+      ;;
+    *)
+      IS_WORKSPACE_DEV=1
+      ;;
+  esac
+fi
+
+NEEDS_INSTALL=0
+if [ -z "${TSX_BIN}" ]; then
+  # Case 3a: no tsx anywhere — fresh sparse clone.
+  NEEDS_INSTALL=1
+elif [ "${IS_WORKSPACE_DEV}" -eq 0 ]; then
+  # Adopter mode (tsx is in PLUGIN_ROOT/node_modules). Check sentinel,
+  # fall through to per-dep probe on miss.
+  if sentinel_present "${VERSION}"; then
+    NEEDS_INSTALL=0
+  elif all_deps_installed; then
+    # Deps are all present but the sentinel is stale (or never written
+    # by an older shim). Write a fresh sentinel so subsequent runs skip
+    # the probe.
+    write_sentinel "${VERSION}"
+    NEEDS_INSTALL=0
+  else
+    NEEDS_INSTALL=1
+  fi
+fi
+# IS_WORKSPACE_DEV == 1 falls through to the dispatch — the workspace
+# install owns the dep set.
+
+if [ "${NEEDS_INSTALL}" -eq 1 ]; then
+  run_install "${VERSION}"
   TSX_BIN="$(find_tsx || true)"
   if [ -z "${TSX_BIN}" ]; then
     echo "dw-lifecycle: npm install completed but tsx is still not resolvable from ${PLUGIN_ROOT}. Aborting." >&2
     exit 1
   fi
+  if ! all_deps_installed; then
+    echo "dw-lifecycle: npm install completed but one or more declared deps are still missing under ${PLUGIN_ROOT}/node_modules. Aborting." >&2
+    exit 1
+  fi
+  write_sentinel "${VERSION}"
 fi
 
 exec "${TSX_BIN}" "${PLUGIN_ROOT}/src/cli.ts" "$@"

--- a/plugins/dw-lifecycle/skills/implement/SKILL.md
+++ b/plugins/dw-lifecycle/skills/implement/SKILL.md
@@ -43,7 +43,7 @@ Default = run scope-widen between tasks. Skipping is the exception, not the rule
 
 ## Dispatch-wrapper engagement
 
-Every sub-agent dispatch fired by this skill — implementer, reviewer, code-explorer, code-architect, parallel fan-out workers — MUST be routed through `wrap()` from `plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts` (the Phase 5 library API). The wrapper enforces three contracts on the sub-agent's return:
+Every sub-agent dispatch fired by this skill — implementer, reviewer, code-explorer, code-architect, parallel fan-out workers — MUST be routed through the dispatch wrapper. The wrapper enforces three contracts on the sub-agent's return:
 
 - **Return grammar.** Every dispatched response MUST conclude with three labelled blocks:
 
@@ -53,17 +53,39 @@ Every sub-agent dispatch fired by this skill — implementer, reviewer, code-exp
   Excluded: <file:line> — <one-line non-deferral reason>
   ```
 
-  `parseReturn()` extracts the blocks; `validateParsed()` rejects on missing blocks AND on the "skipped same-class audit" shape (Searched count > 1, Included covers exactly 1 match, Excluded empty).
+  The parser extracts the blocks; the validator rejects on missing blocks AND on the "skipped same-class audit" shape (Searched count > 1, Included covers exactly 1 match, Excluded empty).
 
 - **Forbidden-deferral phrases.** Any `Excluded` reason containing a deferral substring or matching a deferral regex (per `FORBIDDEN_DEFERRAL_PHRASES` / `FORBIDDEN_DEFERRAL_REGEXES`) is rejected. Project overrides at `.dw-lifecycle/scope-discovery/forbidden-deferral-phrases.yaml` are honored.
 
-- **Refactor-marker auto-prelude.** When the task prompt contains a refactor marker (`refactor`, `extraction`, `clones.yaml`, `canonical_side`, `tests_proof`, or any project-supplied marker from `.dw-lifecycle/scope-discovery/refactor-markers.yaml`), `wrap()` automatically appends the REFACTOR-CONTEXT PRECONDITIONS prelude to the dispatched prompt. Refactor dispatches without the Step 0 obligation are the failure mode the prelude exists to prevent; the marker set is intentionally narrow so false positives stay cheap.
+- **Refactor-marker auto-prelude.** When the task prompt contains a refactor marker (`refactor`, `extraction`, `clones.yaml`, `canonical_side`, `tests_proof`, or any project-supplied marker from `.dw-lifecycle/scope-discovery/refactor-markers.yaml`), the wrapper automatically appends the REFACTOR-CONTEXT PRECONDITIONS prelude to the dispatched prompt. Refactor dispatches without the Step 0 obligation are the failure mode the prelude exists to prevent; the marker set is intentionally narrow so false positives stay cheap.
 
-The wrapper is library-only — `wrap(agentType, taskPrompt, { dispatchFn })`. The controller (this skill's orchestrating agent) supplies the `dispatchFn` callback that drives the Agent tool. On `DispatchRejected`, the controller re-prompts the sub-agent with the violation reason in the next iteration; persistent rejection escalates to the operator with the parsed-return excerpt.
+### How the orchestrator engages the wrapper
 
-Cross-reference: `plugins/dw-lifecycle/templates/scope-discovery/dispatch-wrapper-prelude.md` documents the convention and the override files in full.
+The wrapper is engaged via two Bash invocations bracketing every Agent-tool dispatch. The orchestrator (this skill's Claude session) cannot supply a TypeScript `dispatchFn` callback to the wrapper because the Agent tool is a runtime tool-use primitive, not a callable. The CLI verbs below factor the wrapper's prompt-augmentation half and response-validation half out into separate steps the orchestrator drives.
 
-If `.dw-lifecycle/scope-discovery/` is not present in the project, the dispatch-wrapper still runs — the wrapper itself is plugin code, not project config — but it falls back to the built-in `FORBIDDEN_DEFERRAL_PHRASES` / `REFACTOR_CONTEXT_MARKERS` defaults. Project overrides are the only thing the project-side install gates.
+1. **Before dispatch — augment the operator-authored prompt.** Write the prompt to a temp file via `mktemp`, then invoke:
+
+   ```bash
+   dw-lifecycle wrap-prompt --agent-type <type> --prompt-file <path>
+   ```
+
+   Stdout is the augmented prompt (original prompt + grammar instruction + optional refactor-context prelude). Stderr is a one-line summary (suppress with `--quiet`). Paste stdout into the Agent tool's `prompt` parameter. The verb resolves project overrides under `.dw-lifecycle/scope-discovery/*.yaml` against `--repo-root` (defaults to cwd).
+
+2. **After dispatch — validate the sub-agent's response.** Write the response to a temp file, then invoke:
+
+   ```bash
+   dw-lifecycle validate-return --agent-type <type> --response-file <path>
+   ```
+
+   Stdout is a structured `ValidationResult` JSON: `{ valid, foundBlocks: {searched, included, excluded}, missingBlocks, parseError, forbiddenPhrases: [{phrase, file, line, reason}], refactorPreconditionViolations, skippedAudit, summary }`. Exit code: 0 if valid; 1 on validation failure. Pass `--json` to suppress the stderr summary in pipelines.
+
+   On exit 1, the orchestrator rejects the response and re-dispatches with the same augmented prompt + a correction note quoting the violation surfaced in the JSON. After two consecutive rejections on the same dispatch, surface the parsed-return excerpt to the operator and pause the task.
+
+Agent types recognized by both verbs: `implementer`, `reviewer`, `code-explorer`, `code-architect`, `ui-engineer`, `typescript-pro`, `documentation-engineer`, `project-orchestrator`, `feature-orchestrator`, `codebase-auditor`, `architect-reviewer`, `code-reviewer`. The augmentation profile is currently uniform across types; the flag is required so future per-type profiles ship without a CLI breaking change. The refactor-precondition cue check in `validate-return` fires only when the response itself claims a refactor (mentions `refactor` / `extraction` / `clones.yaml` / `canonical_side`) AND the agent type is refactor-eligible (`implementer`, `code-architect`, `typescript-pro`).
+
+Cross-reference: `plugins/dw-lifecycle/templates/scope-discovery/dispatch-wrapper-prelude.md` documents the convention and the override files in full. In-band TypeScript callers (e.g. the orchestrator-turn's judge step) still engage the dispatch wrapper via `wrap()` from `plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts`; the CLI verbs share the same library functions for marker detection, override loading, grammar instruction, and parser/validator.
+
+If `.dw-lifecycle/scope-discovery/` is not present in the project, the verbs still run — the dispatch grammar is plugin code, not project config — and fall back to the built-in `FORBIDDEN_DEFERRAL_PHRASES` / `REFACTOR_CONTEXT_MARKERS` defaults. Project overrides are the only thing the project-side install gates.
 
 ## Orchestrator loop (per-turn audit/judge stack)
 
@@ -123,6 +145,6 @@ Defaults at `DEFAULT_LOOP_CONFIG` in `orchestrator-loop/loop-config.ts`. Operato
 - **Test failures during TDD.** Per the TDD discipline: failing test is expected before implementation. Failing tests AFTER implementation means the impl is wrong; iterate, don't bypass the test.
 - **Auto-invocation behavior (scope-widen).** When `.dw-lifecycle/scope-discovery/` is absent, the Step 5 auto-invocation is silently skipped. When present, `scope-widen` runs with default flags (dry-run is its default; `--apply` is passed when this skill invokes it because the merged manifest must be readable by the next task's implementer brief). The widen run's resulting `scope-manifest.yaml` path AND the additive-delta summary are passed into the next task's dispatched-agent context so the implementer sees the augmented scope before starting.
 - **`scope-widen` fails.** Surface the error in the next task's brief; the task still proceeds. The operator can re-run scope-widen manually (`/dw-lifecycle:scope-widen <slug> "<complaint>"`) after addressing the cause.
-- **`DispatchRejected` from `wrap()`.** Re-prompt the sub-agent with the violation reason (missing block / forbidden phrase / skipped-audit signal). After two consecutive rejections on the same dispatch, surface the parsed-return excerpt to the operator and pause the task.
-- **Orchestrator loop — judge dispatch fails.** `dw-lifecycle orchestrator-turn` exits non-zero when the judge's `wrap()` call rejects. Surface the violation to the operator; the next turn re-runs the judge with the same input (recovery is operator-decided per the wrong-decision-recovery primitives at `recovery/`).
+- **`dw-lifecycle validate-return` exit 1.** The sub-agent's response was rejected by the dispatch grammar (missing block / forbidden phrase / skipped-audit signal / refactor-precondition violation). Re-dispatch with the same augmented prompt + a correction note that quotes the violation surfaced in the JSON. After two consecutive rejections on the same dispatch, surface the parsed-return excerpt to the operator and pause the task.
+- **Orchestrator loop — judge dispatch fails.** `dw-lifecycle orchestrator-turn` exits non-zero when the in-band judge's wrapper call rejects. Surface the violation to the operator; the next turn re-runs the judge with the same input (recovery is operator-decided per the wrong-decision-recovery primitives at `recovery/`).
 - **Orchestrator loop — wrong-decision detected but reversal proposal needs operator review.** The reversal proposal lands in `TurnReport.reversalProposals`. Auto-apply when `controllerDecision.intensity` AND the recovery library's trust-calibration both support it; otherwise enqueue an escalation via `escalation/escalation-queue.ts#enqueueEscalation`. Escalations surface in the next turn's `escalationVisibility`.

--- a/plugins/dw-lifecycle/src/__tests__/scope-discovery/validate-return.test.ts
+++ b/plugins/dw-lifecycle/src/__tests__/scope-discovery/validate-return.test.ts
@@ -1,0 +1,341 @@
+/**
+ * plugins/dw-lifecycle/src/__tests__/scope-discovery/validate-return.test.ts
+ *
+ * Tests for the `dw-lifecycle validate-return` CLI bridge that exposes
+ * the dispatch-wrapper's response-validation logic to the orchestrating
+ * Claude session. Per the project test rule "use fixture project trees
+ * on disk, never mock the filesystem", uses tmp directories for project
+ * roots when exercising overrides.
+ *
+ * Coverage:
+ *   - Happy path: all three blocks present + no forbidden phrases →
+ *     valid=true.
+ *   - Missing Searched / Included / Excluded blocks: valid=false with
+ *     missingBlocks populated.
+ *   - Forbidden-deferral phrase ("for now", "will fix"): valid=false
+ *     with forbiddenPhrases array populated.
+ *   - Skipped-audit shape (Searched count > 1, Included covers 1,
+ *     Excluded empty): valid=false with skippedAudit populated.
+ *   - Refactor-precondition cue check: response claims a refactor without
+ *     citing canonical_side / tests_proof → refactorPreconditionViolations
+ *     populated (only fires for refactor-eligible agent types).
+ *   - Project override: custom forbidden phrase REJECTS its own phrase.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { validateReturnForCli } from '../../scope-discovery/dispatch-wrapper-cli.js';
+import { parseFlags } from '../../subcommands/validate-return.js';
+
+const WELL_FORMED_RESPONSE = [
+  'Did the work.',
+  '',
+  'Searched: foo-pattern — 2 matches',
+  'Included: src/a.tsx:42, src/b.tsx:117',
+  'Excluded: src/legacy.tsx:88 — different primitive (CodeMirror)',
+  '',
+].join('\n');
+
+describe('validate-return CLI assembler', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'validate-return-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('happy path: well-formed response is valid', async () => {
+    const result = await validateReturnForCli({
+      response: WELL_FORMED_RESPONSE,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.parseError).toBeNull();
+    expect(result.forbiddenPhrases).toEqual([]);
+    expect(result.skippedAudit).toBeNull();
+    expect(result.foundBlocks.searched).toBe(true);
+    expect(result.foundBlocks.included).toBe(true);
+    expect(result.foundBlocks.excluded).toBe(true);
+    expect(result.missingBlocks).toEqual([]);
+    expect(result.refactorPreconditionViolations).toEqual([]);
+    expect(result.summary).toContain('valid');
+  });
+
+  it('missing Searched block surfaces missingBlocks', async () => {
+    const response = [
+      'Did the work.',
+      '',
+      'Included: src/a.tsx:42',
+      'Excluded: src/legacy.tsx:88 — different primitive',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.foundBlocks.searched).toBe(false);
+    expect(result.missingBlocks).toContain('Searched');
+    expect(result.parseError).not.toBeNull();
+  });
+
+  it('missing Included block surfaces missingBlocks', async () => {
+    const response = [
+      'Searched: foo — 1 matches',
+      'Excluded: src/legacy.tsx:88 — different primitive',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.foundBlocks.included).toBe(false);
+    expect(result.missingBlocks).toContain('Included');
+  });
+
+  it('missing Excluded block surfaces missingBlocks', async () => {
+    const response = [
+      'Searched: foo — 1 matches',
+      'Included: src/a.tsx:42',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.foundBlocks.excluded).toBe(false);
+    expect(result.missingBlocks).toContain('Excluded');
+  });
+
+  it('forbidden-deferral phrase "for now" surfaces in forbiddenPhrases', async () => {
+    const response = [
+      'Searched: foo — 3 matches',
+      'Included: src/a.tsx:1, src/b.tsx:2',
+      'Excluded: src/c.tsx:3 — for now this is intentional',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.forbiddenPhrases.length).toBe(1);
+    const hit = result.forbiddenPhrases[0];
+    if (hit === undefined) throw new Error('expected a hit');
+    expect(hit.phrase).toBe('for now');
+    expect(hit.file).toBe('src/c.tsx');
+    expect(hit.line).toBe(3);
+    expect(result.summary).toContain('REJECTED');
+  });
+
+  it('skipped-audit shape (multi-match + 1 included + 0 excluded) surfaces skippedAudit', async () => {
+    const response = [
+      'Searched: foo-pattern — 5 matches',
+      'Included: src/a.tsx:1',
+      'Excluded:',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.skippedAudit).not.toBeNull();
+    expect(result.skippedAudit).toContain('5 matches');
+  });
+
+  it('refactor-precondition violation: response claims refactor but cites neither canonical_side nor tests_proof', async () => {
+    const response = [
+      'I performed the refactor by extracting the shared helper to src/util.ts.',
+      'I did not run the cite-the-disposition checks because the change felt obvious.',
+      '',
+      'Searched: shared-helper-pattern — 1 matches',
+      'Included: src/util.ts:1',
+      'Excluded: src/old.ts:5 — replaced by the new helper',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.refactorPreconditionViolations.length).toBe(2);
+    expect(
+      result.refactorPreconditionViolations.some((v) => v.includes('canonical_side')),
+    ).toBe(true);
+    expect(
+      result.refactorPreconditionViolations.some((v) => v.includes('tests_proof')),
+    ).toBe(true);
+  });
+
+  it('refactor-precondition cue check does NOT fire for non-refactor-eligible agent types', async () => {
+    // Same response as above, but agent-type is reviewer (read-only,
+    // not in the refactor-eligible set). The cue check is skipped.
+    const response = [
+      'I performed the refactor by extracting the shared helper to src/util.ts.',
+      '',
+      'Searched: shared-helper-pattern — 1 matches',
+      'Included: src/util.ts:1',
+      'Excluded: src/old.ts:5 — replaced by the new helper',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'reviewer',
+      repoRoot: tmp,
+    });
+    expect(result.refactorPreconditionViolations).toEqual([]);
+  });
+
+  it('refactor-precondition cue check does NOT fire when response makes no refactor claim', async () => {
+    const result = await validateReturnForCli({
+      response: WELL_FORMED_RESPONSE,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.refactorPreconditionViolations).toEqual([]);
+  });
+
+  it('refactor response that cites canonical_side AND tests_proof passes the cue check', async () => {
+    const response = [
+      'I performed the refactor by extracting the shared helper to src/util.ts.',
+      'Per the clones.yaml entry with canonical_side: "all", I verified the',
+      'extracted code is a faithful lift; tests_proof.sha was resolved via',
+      'git rev-parse and the diff confirms a deliberate canonical-side mutation.',
+      '',
+      'Searched: shared-helper-pattern — 1 matches',
+      'Included: src/util.ts:1',
+      'Excluded: src/old.ts:5 — replaced by the new helper',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.refactorPreconditionViolations).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('project override REJECTS its own phrase', async () => {
+    await mkdir(join(tmp, '.dw-lifecycle', 'scope-discovery'), { recursive: true });
+    await writeFile(
+      join(tmp, '.dw-lifecycle', 'scope-discovery', 'forbidden-deferral-phrases.yaml'),
+      'phrases:\n  - "absolutely-not"\n',
+      'utf8',
+    );
+    const response = [
+      'Searched: foo — 3 matches',
+      'Included: src/a.tsx:1, src/b.tsx:2',
+      'Excluded: src/c.tsx:3 — absolutely-not in scope',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.forbiddenPhrases.length).toBe(1);
+    const hit = result.forbiddenPhrases[0];
+    if (hit === undefined) throw new Error('expected a hit');
+    expect(hit.phrase).toBe('absolutely-not');
+  });
+
+  it('project override no longer rejects the built-in "for now" phrase', async () => {
+    await mkdir(join(tmp, '.dw-lifecycle', 'scope-discovery'), { recursive: true });
+    await writeFile(
+      join(tmp, '.dw-lifecycle', 'scope-discovery', 'forbidden-deferral-phrases.yaml'),
+      'phrases:\n  - "absolutely-not"\n',
+      'utf8',
+    );
+    const response = [
+      'Searched: foo — 3 matches',
+      'Included: src/a.tsx:1, src/b.tsx:2',
+      'Excluded: src/c.tsx:3 — different primitive (for now this is intentional)',
+      '',
+    ].join('\n');
+    const result = await validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: tmp,
+    });
+    // Under the built-in list "for now" would reject; under override it passes.
+    expect(result.valid).toBe(true);
+    expect(result.forbiddenPhrases).toEqual([]);
+  });
+});
+
+describe('validate-return flag parser', () => {
+  it('happy path: parses --response-file + --agent-type', () => {
+    const parsed = parseFlags([
+      '--response-file', '/tmp/r.md',
+      '--agent-type', 'implementer',
+    ]);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.args?.responseFile).toBe('/tmp/r.md');
+    expect(parsed.args?.agentType).toBe('implementer');
+    expect(parsed.args?.jsonOnly).toBe(false);
+  });
+
+  it('--json flag is honored', () => {
+    const parsed = parseFlags([
+      '--response-file', '/tmp/r.md',
+      '--agent-type', 'implementer',
+      '--json',
+    ]);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.args?.jsonOnly).toBe(true);
+  });
+
+  it('missing --response-file is a usage error', () => {
+    const parsed = parseFlags(['--agent-type', 'implementer']);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('--response-file');
+  });
+
+  it('missing --agent-type is a usage error', () => {
+    const parsed = parseFlags(['--response-file', '/tmp/r.md']);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('--agent-type');
+  });
+
+  it('unknown agent-type is a usage error', () => {
+    const parsed = parseFlags([
+      '--response-file', '/tmp/r.md',
+      '--agent-type', 'malarkey-pro',
+    ]);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('malarkey-pro');
+  });
+
+  it('unknown flag is a usage error', () => {
+    const parsed = parseFlags([
+      '--response-file', '/tmp/r.md',
+      '--agent-type', 'implementer',
+      '--bogus',
+    ]);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('unknown arg');
+  });
+
+  it('--help short-circuits with help=true', () => {
+    const parsed = parseFlags(['--help']);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.help).toBe(true);
+  });
+});

--- a/plugins/dw-lifecycle/src/__tests__/scope-discovery/wrap-prompt.test.ts
+++ b/plugins/dw-lifecycle/src/__tests__/scope-discovery/wrap-prompt.test.ts
@@ -1,0 +1,201 @@
+/**
+ * plugins/dw-lifecycle/src/__tests__/scope-discovery/wrap-prompt.test.ts
+ *
+ * Tests for the `dw-lifecycle wrap-prompt` CLI bridge that exposes the
+ * dispatch-wrapper's prompt-augmentation logic to the orchestrating
+ * Claude session. Per the project test rule "use fixture project trees
+ * on disk, never mock the filesystem", uses tmp directories for project
+ * roots + prompt files.
+ *
+ * Coverage:
+ *   - Happy path: augmented prompt contains the grammar instruction.
+ *   - Refactor marker detection: prompt with `refactor` carries the
+ *     REFACTOR-CONTEXT prelude; non-refactor prompts do not.
+ *   - Project override: forbidden-deferral-phrases.yaml on disk REPLACES
+ *     the default phrase list in the augmented prompt.
+ *   - Flag parsing: missing flags / unknown args / unknown agent-type
+ *     produce usage errors (parseFlags result, not exit).
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { wrapPromptForCli } from '../../scope-discovery/dispatch-wrapper-cli.js';
+import { parseFlags } from '../../subcommands/wrap-prompt.js';
+
+describe('wrap-prompt CLI assembler', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'wrap-prompt-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('happy path: emits augmented prompt with grammar instruction appended', async () => {
+    const result = await wrapPromptForCli({
+      agentType: 'implementer',
+      taskPrompt: 'Build the foo widget.',
+      repoRoot: tmp,
+    });
+    expect(result.augmentedPrompt).toContain('Build the foo widget.');
+    expect(result.augmentedPrompt).toContain('REQUIRED RETURN GRAMMAR');
+    expect(result.augmentedPrompt).toContain('Searched: <pattern>');
+    expect(result.augmentedPrompt).toContain('Included: <file:line>');
+    expect(result.augmentedPrompt).toContain('Excluded: <file:line>');
+    expect(result.refactorMarkerMatched).toBe(false);
+    expect(result.projectOverrideForbiddenLoaded).toBe(false);
+    expect(result.projectOverrideMarkersLoaded).toBe(false);
+    expect(result.summary).toContain('agent-type=implementer');
+    expect(result.summary).toContain('refactor-marker: no');
+    expect(result.summary).toContain('project override: no');
+  });
+
+  it('refactor marker triggers REFACTOR-CONTEXT prelude', async () => {
+    const result = await wrapPromptForCli({
+      agentType: 'typescript-pro',
+      taskPrompt: 'Please refactor the duplicated helper in src/util.ts.',
+      repoRoot: tmp,
+    });
+    expect(result.augmentedPrompt).toContain('REFACTOR-CONTEXT PRECONDITIONS');
+    expect(result.augmentedPrompt).toContain('canonical_side');
+    expect(result.refactorMarkerMatched).toBe(true);
+    expect(result.summary).toContain('refactor-marker: yes');
+  });
+
+  it('non-refactor prompt does NOT carry the REFACTOR-CONTEXT prelude', async () => {
+    const result = await wrapPromptForCli({
+      agentType: 'reviewer',
+      taskPrompt: 'Review the PR diff for style + correctness.',
+      repoRoot: tmp,
+    });
+    expect(result.augmentedPrompt).not.toContain('REFACTOR-CONTEXT PRECONDITIONS');
+    expect(result.refactorMarkerMatched).toBe(false);
+  });
+
+  it('forbidden-deferral-phrases.yaml override REPLACES the built-in list in the prompt', async () => {
+    await mkdir(join(tmp, '.dw-lifecycle', 'scope-discovery'), { recursive: true });
+    await writeFile(
+      join(tmp, '.dw-lifecycle', 'scope-discovery', 'forbidden-deferral-phrases.yaml'),
+      'phrases:\n  - "absolutely-not"\n',
+      'utf8',
+    );
+    const result = await wrapPromptForCli({
+      agentType: 'implementer',
+      taskPrompt: 'Carry out the fix.',
+      repoRoot: tmp,
+    });
+    // The override's only phrase appears in the prompt; built-in "for now"
+    // is gone from the active list.
+    expect(result.augmentedPrompt).toContain('absolutely-not');
+    expect(result.projectOverrideForbiddenLoaded).toBe(true);
+    expect(result.summary).toContain('project override: yes');
+  });
+
+  it('refactor-markers.yaml override REPLACES built-in markers', async () => {
+    await mkdir(join(tmp, '.dw-lifecycle', 'scope-discovery'), { recursive: true });
+    await writeFile(
+      join(tmp, '.dw-lifecycle', 'scope-discovery', 'refactor-markers.yaml'),
+      'markers:\n  - "custom-marker-xyz"\n',
+      'utf8',
+    );
+    // A prompt with "refactor" should NOT receive the prelude under override.
+    const noPrelude = await wrapPromptForCli({
+      agentType: 'typescript-pro',
+      taskPrompt: 'Please refactor the duplicated helper.',
+      repoRoot: tmp,
+    });
+    expect(noPrelude.refactorMarkerMatched).toBe(false);
+    expect(noPrelude.augmentedPrompt).not.toContain('REFACTOR-CONTEXT PRECONDITIONS');
+
+    // A prompt with the custom marker SHOULD receive the prelude.
+    const withPrelude = await wrapPromptForCli({
+      agentType: 'typescript-pro',
+      taskPrompt: 'This dispatch contains custom-marker-xyz.',
+      repoRoot: tmp,
+    });
+    expect(withPrelude.refactorMarkerMatched).toBe(true);
+    expect(withPrelude.augmentedPrompt).toContain('REFACTOR-CONTEXT PRECONDITIONS');
+    expect(withPrelude.projectOverrideMarkersLoaded).toBe(true);
+  });
+
+  it('malformed forbidden override surfaces a clear error', async () => {
+    await mkdir(join(tmp, '.dw-lifecycle', 'scope-discovery'), { recursive: true });
+    await writeFile(
+      join(tmp, '.dw-lifecycle', 'scope-discovery', 'forbidden-deferral-phrases.yaml'),
+      'other_field: oops\n',
+      'utf8',
+    );
+    await expect(
+      wrapPromptForCli({
+        agentType: 'implementer',
+        taskPrompt: 'noop',
+        repoRoot: tmp,
+      }),
+    ).rejects.toThrow(/produced zero phrases/);
+  });
+});
+
+describe('wrap-prompt flag parser', () => {
+  it('happy path: parses --agent-type + --prompt-file', () => {
+    const parsed = parseFlags([
+      '--agent-type', 'implementer',
+      '--prompt-file', '/tmp/p.md',
+    ]);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.args?.agentType).toBe('implementer');
+    expect(parsed.args?.promptFile).toBe('/tmp/p.md');
+    expect(parsed.args?.quiet).toBe(false);
+  });
+
+  it('missing --agent-type is a usage error', () => {
+    const parsed = parseFlags(['--prompt-file', '/tmp/p.md']);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('--agent-type');
+  });
+
+  it('missing --prompt-file is a usage error', () => {
+    const parsed = parseFlags(['--agent-type', 'implementer']);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('--prompt-file');
+  });
+
+  it('unknown agent-type is a usage error', () => {
+    const parsed = parseFlags([
+      '--agent-type', 'malarkey-pro',
+      '--prompt-file', '/tmp/p.md',
+    ]);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('malarkey-pro');
+    expect(parsed.error).toContain('recognized agent type');
+  });
+
+  it('unknown flag is a usage error', () => {
+    const parsed = parseFlags([
+      '--agent-type', 'implementer',
+      '--prompt-file', '/tmp/p.md',
+      '--bogus',
+    ]);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('unknown arg');
+  });
+
+  it('--quiet flag is honored', () => {
+    const parsed = parseFlags([
+      '--agent-type', 'implementer',
+      '--prompt-file', '/tmp/p.md',
+      '--quiet',
+    ]);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.args?.quiet).toBe(true);
+  });
+
+  it('--help short-circuits with help=true', () => {
+    const parsed = parseFlags(['--help']);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.help).toBe(true);
+  });
+});

--- a/plugins/dw-lifecycle/src/cli.ts
+++ b/plugins/dw-lifecycle/src/cli.ts
@@ -28,6 +28,8 @@ import { installAgentPrompts } from './subcommands/install-agent-prompts.js';
 import { migrateFromPilot } from './subcommands/migrate-from-pilot.js';
 import { uninstallScopeDiscoveryHooks } from './subcommands/uninstall-scope-discovery-hooks.js';
 import { orchestratorTurn } from './subcommands/orchestrator-turn.js';
+import { wrapPrompt } from './subcommands/wrap-prompt.js';
+import { validateReturn } from './subcommands/validate-return.js';
 
 const subcommand = process.argv[2];
 const args = process.argv.slice(3);
@@ -70,6 +72,8 @@ const SUBCOMMANDS: Record<string, (args: string[]) => Promise<void>> = {
   'migrate-from-pilot': migrateFromPilot,
   'uninstall-scope-discovery-hooks': uninstallScopeDiscoveryHooks,
   'orchestrator-turn': orchestratorTurn,
+  'wrap-prompt': wrapPrompt,
+  'validate-return': validateReturn,
 };
 
 // Deprecation hints printed alongside the subcommand list in `--help`.

--- a/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-cli.ts
+++ b/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-cli.ts
@@ -1,0 +1,336 @@
+/**
+ * plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-cli.ts
+ *
+ * CLI bridge between the orchestrating Claude session and the
+ * dispatch-wrapper engine. The TF-005 friction (logged in the
+ * scope-discovery canary's tooling-feedback.md) named the failure:
+ * `wrap()` takes a `dispatchFn` callback, but the orchestrator's only
+ * dispatch primitive is Claude Code's Agent tool — a runtime tool-use,
+ * not a TypeScript callable. There is no way for the orchestrator to
+ * "supply a real `dispatchFn`" from inside `wrap()`.
+ *
+ * This module factors the prompt-augmentation half (refactor-marker
+ * detection, project-override loading, GRAMMAR_INSTRUCTION append,
+ * REFACTOR_PRECONDITIONS_CHECKLIST prelude) and the response-validation
+ * half (parseReturn + validateParsed) out of the in-band `wrap()` flow,
+ * so the orchestrator can engage them in two Bash invocations:
+ *
+ *   1. `dw-lifecycle wrap-prompt --agent-type <t> --prompt-file <p>`
+ *      — stdout is the augmented prompt the agent pastes into the Agent
+ *      tool's prompt parameter.
+ *
+ *   2. `dw-lifecycle validate-return --agent-type <t> --response-file <r>`
+ *      — exit 0 on valid; 1 on rejection. Stdout is JSON; stderr a
+ *      one-line summary.
+ *
+ * The in-band `wrap()` API in `dispatch-wrapper.ts` stays functional for
+ * any internal TS callers — both paths share the same library functions
+ * for marker detection, override loading, grammar instruction, and
+ * parser/validator. YAML override loaders live in
+ * `dispatch-wrapper-overrides.ts` to keep this module under the file cap.
+ */
+
+import {
+  DispatchRejected,
+  FORBIDDEN_DEFERRAL_PHRASES,
+  FORBIDDEN_DEFERRAL_REGEXES,
+  findForbiddenPhraseIn,
+  parseReturn,
+  validateParsed,
+  type MissingBlock,
+} from './dispatch-grammar.js';
+import {
+  REFACTOR_PRECONDITIONS_CHECKLIST,
+  isRefactorContextPromptWith,
+} from './refactor-preconditions-prompt.js';
+import {
+  GRAMMAR_INSTRUCTION,
+  buildGrammarInstruction,
+} from './dispatch-wrapper.js';
+import { resolveCliConfig } from './dispatch-wrapper-overrides.js';
+
+// ---------------------------------------------------------------------------
+// wrapPromptForCli — emit the augmented prompt as plain text
+// ---------------------------------------------------------------------------
+
+export interface WrapPromptCliArgs {
+  readonly agentType: string;
+  readonly taskPrompt: string;
+  readonly repoRoot: string;
+}
+
+export interface WrapPromptCliResult {
+  readonly augmentedPrompt: string;
+  readonly refactorMarkerMatched: boolean;
+  readonly projectOverrideForbiddenLoaded: boolean;
+  readonly projectOverrideMarkersLoaded: boolean;
+  readonly summary: string;
+}
+
+export async function wrapPromptForCli(
+  args: WrapPromptCliArgs,
+): Promise<WrapPromptCliResult> {
+  const config = await resolveCliConfig(args.repoRoot);
+  const refactorMatched = isRefactorContextPromptWith(
+    args.taskPrompt,
+    config.markers,
+  );
+  // Mirror dispatch-wrapper.ts wrap(): use the cached GRAMMAR_INSTRUCTION
+  // constant when the active lists are the defaults; otherwise rebuild
+  // so the prompt names the override-active phrase/regex lists.
+  const grammarInstruction =
+    config.phrases === FORBIDDEN_DEFERRAL_PHRASES &&
+    config.regexes === FORBIDDEN_DEFERRAL_REGEXES
+      ? GRAMMAR_INSTRUCTION
+      : buildGrammarInstruction(config.phrases, config.regexes);
+  const refactorPrelude = refactorMatched ? REFACTOR_PRECONDITIONS_CHECKLIST : '';
+  const augmentedPrompt = args.taskPrompt + grammarInstruction + refactorPrelude;
+
+  const lineCount = augmentedPrompt.split(/\r?\n/).length;
+  const summary =
+    `wrap-prompt: augmented ${lineCount}-line prompt for agent-type=${args.agentType} ` +
+    `(refactor-marker: ${refactorMatched ? 'yes' : 'no'}; ` +
+    `project override: ${config.phrasesFromOverride || config.markersFromOverride ? 'yes' : 'no'})`;
+
+  return {
+    augmentedPrompt,
+    refactorMarkerMatched: refactorMatched,
+    projectOverrideForbiddenLoaded: config.phrasesFromOverride,
+    projectOverrideMarkersLoaded: config.markersFromOverride,
+    summary,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateReturnForCli — parse + validate; emit structured ValidationResult
+// ---------------------------------------------------------------------------
+
+export interface ForbiddenPhraseHit {
+  readonly phrase: string;
+  readonly file: string;
+  readonly line: number;
+  readonly reason: string;
+}
+
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly foundBlocks: {
+    readonly searched: boolean;
+    readonly included: boolean;
+    readonly excluded: boolean;
+  };
+  readonly missingBlocks: ReadonlyArray<MissingBlock>;
+  readonly parseError: string | null;
+  readonly forbiddenPhrases: ReadonlyArray<ForbiddenPhraseHit>;
+  readonly refactorPreconditionViolations: ReadonlyArray<string>;
+  readonly skippedAudit: string | null;
+  readonly summary: string;
+}
+
+export interface ValidateReturnCliArgs {
+  readonly response: string;
+  readonly agentType: string;
+  readonly repoRoot: string;
+}
+
+/**
+ * Refactor-eligible agent types — the subset that actually carries
+ * refactor dispatches. ui-engineer does design work and doesn't
+ * currently receive refactor markers; reviewer + code-explorer are
+ * read-only. The set mirrors the dispatch-wrapper engagement profile.
+ */
+const REFACTOR_ELIGIBLE_TYPES: ReadonlySet<string> = new Set([
+  'implementer',
+  'code-architect',
+  'typescript-pro',
+]);
+
+/**
+ * Check refactor preconditions on a sub-agent response. The dispatch
+ * grammar's parser/validator covers grammar + forbidden phrases + the
+ * skipped-audit shape. The refactor branch checks that the response
+ * either (a) cites a canonical_side disposition AND tests_proof.sha, or
+ * (b) makes no refactor claim at all. Returns a list of violation
+ * descriptions; empty means no violation.
+ *
+ * Heuristic-based — the response is the sub-agent's prose, which may not
+ * have machine-grade structure. We look for the canonical_side and
+ * tests_proof cues in the response text; missing one or both when the
+ * response itself claims a refactor (and the agent type is refactor-
+ * eligible) triggers a violation surface.
+ */
+function refactorPreconditionViolations(
+  response: string,
+  agentType: string,
+): ReadonlyArray<string> {
+  const lower = response.toLowerCase();
+  const claimsRefactor =
+    lower.includes('refactor') ||
+    lower.includes('extraction') ||
+    lower.includes('clones.yaml') ||
+    lower.includes('canonical_side');
+  if (!claimsRefactor) return [];
+  if (!REFACTOR_ELIGIBLE_TYPES.has(agentType)) return [];
+
+  const violations: string[] = [];
+  if (!lower.includes('canonical_side')) {
+    violations.push(
+      'response describes a refactor but does not cite `canonical_side` ' +
+        '(per refactor-preconditions, the disposition entry must declare the ' +
+        'canonical_side branch and the response must reflect which branch was verified)',
+    );
+  }
+  if (!lower.includes('tests_proof')) {
+    violations.push(
+      'response describes a refactor but does not cite `tests_proof.sha` ' +
+        '(per refactor-preconditions, the response must verify that the ' +
+        'failing-test commit genuinely shows test failure on broken code)',
+    );
+  }
+  return violations;
+}
+
+export async function validateReturnForCli(
+  args: ValidateReturnCliArgs,
+): Promise<ValidationResult> {
+  const config = await resolveCliConfig(args.repoRoot);
+
+  // Run the parser. parseReturn() throws DispatchRejected with the
+  // missingBlocks list when one or more required blocks is absent.
+  let parsed: ReturnType<typeof parseReturn> | null = null;
+  let parseError: string | null = null;
+  let missingBlocks: ReadonlyArray<MissingBlock> = [];
+  try {
+    parsed = parseReturn(args.response);
+  } catch (err) {
+    if (err instanceof DispatchRejected) {
+      parseError = err.message;
+      missingBlocks = err.missingBlocks;
+    } else {
+      throw err;
+    }
+  }
+
+  const searchedFound =
+    parsed !== null ||
+    (parseError !== null && !missingBlocks.includes('Searched'));
+  const includedFound =
+    parsed !== null ||
+    (parseError !== null && !missingBlocks.includes('Included'));
+  const excludedFound =
+    parsed !== null ||
+    (parseError !== null && !missingBlocks.includes('Excluded'));
+
+  const forbiddenHits: ForbiddenPhraseHit[] = [];
+  let skippedAudit: string | null = null;
+
+  if (parsed !== null) {
+    // Validator (validateParsed) throws on the FIRST violation; we walk
+    // each excluded entry ourselves so the result surfaces ALL hits
+    // (the orchestrator's correction note benefits from seeing every
+    // problem at once instead of round-tripping one at a time).
+    for (const entry of parsed.excluded) {
+      const hit = findForbiddenPhraseIn(
+        entry.reason,
+        config.phrases,
+        config.regexes,
+      );
+      if (hit !== null) {
+        forbiddenHits.push({
+          phrase: hit.phrase,
+          file: entry.file,
+          line: entry.line,
+          reason: entry.reason,
+        });
+      }
+    }
+    // Skipped-audit detector (Rule 1 of validateParsed).
+    if (
+      parsed.searched.count > 1 &&
+      parsed.included.length === 1 &&
+      parsed.excluded.length === 0
+    ) {
+      skippedAudit =
+        `Searched reported ${parsed.searched.count} matches for ` +
+        `"${parsed.searched.pattern}" but Included covers only 1 file:line ` +
+        `and Excluded is empty — same-class audit skipped.`;
+    }
+    // Run validateParsed too as a teeth-check on the in-band validator
+    // (any path we miss here should still trip via validateParsed). Catch
+    // the throw — the structured result is the authoritative output.
+    try {
+      validateParsed(parsed, {
+        forbiddenPhrases: config.phrases,
+        forbiddenRegexes: config.regexes,
+      });
+    } catch (err) {
+      if (!(err instanceof DispatchRejected)) throw err;
+      // validateParsed surfaced something our walk above didn't.
+      // Preserve the message in parseError so the operator sees it.
+      if (parseError === null) parseError = err.message;
+    }
+  }
+
+  const refactorViolations = refactorPreconditionViolations(
+    args.response,
+    args.agentType,
+  );
+
+  const valid =
+    parseError === null &&
+    forbiddenHits.length === 0 &&
+    skippedAudit === null &&
+    refactorViolations.length === 0;
+
+  const summary = buildValidateSummary({
+    valid,
+    parseError,
+    forbiddenHits,
+    skippedAudit,
+    refactorViolations,
+    agentType: args.agentType,
+  });
+
+  return {
+    valid,
+    foundBlocks: {
+      searched: searchedFound,
+      included: includedFound,
+      excluded: excludedFound,
+    },
+    missingBlocks,
+    parseError,
+    forbiddenPhrases: forbiddenHits,
+    refactorPreconditionViolations: refactorViolations,
+    skippedAudit,
+    summary,
+  };
+}
+
+interface ValidateSummaryInput {
+  readonly valid: boolean;
+  readonly parseError: string | null;
+  readonly forbiddenHits: ReadonlyArray<ForbiddenPhraseHit>;
+  readonly skippedAudit: string | null;
+  readonly refactorViolations: ReadonlyArray<string>;
+  readonly agentType: string;
+}
+
+function buildValidateSummary(input: ValidateSummaryInput): string {
+  if (input.valid) {
+    return `validate-return: response valid for agent-type=${input.agentType}`;
+  }
+  const reasons: string[] = [];
+  if (input.parseError !== null) reasons.push(input.parseError);
+  if (input.skippedAudit !== null) reasons.push('skipped-audit');
+  if (input.forbiddenHits.length > 0) {
+    const phrases = input.forbiddenHits
+      .map((h) => `"${h.phrase}" at ${h.file}:${h.line}`)
+      .join(', ');
+    reasons.push(`forbidden-phrase: ${phrases}`);
+  }
+  if (input.refactorViolations.length > 0) {
+    reasons.push(`refactor-preconditions: ${input.refactorViolations.length} violation(s)`);
+  }
+  return `validate-return: REJECTED (${reasons.join('; ')})`;
+}

--- a/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts
+++ b/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts
@@ -1,0 +1,198 @@
+/**
+ * plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper-overrides.ts
+ *
+ * YAML override loaders + resolved-config resolver for the CLI bridge in
+ * `dispatch-wrapper-cli.ts`. Factored out so the CLI module stays under
+ * the 500-line file cap.
+ *
+ * Mirror of the override-loader logic in `dispatch-wrapper.ts` (which
+ * keeps its own copy private to its `resolveConfig` so the in-band
+ * `wrap()` callers don't accidentally couple to this surface). The
+ * duplication is intentional: the in-band path's `WrapOptions` accepts
+ * direct overrides for tests, the CLI path's `ResolvedConfig` tracks
+ * which lists came from disk so the stderr summary can report it.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import {
+  FORBIDDEN_DEFERRAL_PHRASES,
+  FORBIDDEN_DEFERRAL_REGEXES,
+} from './dispatch-grammar.js';
+import { REFACTOR_CONTEXT_MARKERS } from './refactor-preconditions-prompt.js';
+import { errorMessage, isEnoent, isPlainObject } from './util/typeguards.js';
+
+const FORBIDDEN_OVERRIDE_PATH =
+  '.dw-lifecycle/scope-discovery/forbidden-deferral-phrases.yaml';
+const REFACTOR_MARKERS_OVERRIDE_PATH =
+  '.dw-lifecycle/scope-discovery/refactor-markers.yaml';
+
+interface ForbiddenOverride {
+  readonly phrases: ReadonlyArray<string>;
+  readonly regexes: ReadonlyArray<RegExp>;
+}
+
+async function loadForbiddenOverride(
+  repoRoot: string,
+): Promise<ForbiddenOverride | null> {
+  const absPath = resolve(repoRoot, FORBIDDEN_OVERRIDE_PATH);
+  let text: string;
+  try {
+    text = await readFile(absPath, 'utf8');
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw new Error(
+      `dispatch-wrapper-cli: cannot read override ${absPath}: ${errorMessage(err)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(text);
+  } catch (err) {
+    throw new Error(
+      `dispatch-wrapper-cli: cannot parse override ${absPath}: ${errorMessage(err)}`,
+    );
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `dispatch-wrapper-cli: override ${absPath} did not parse to a YAML object`,
+    );
+  }
+  const phrasesRaw = parsed['phrases'];
+  const regexesRaw = parsed['regexes'];
+  const phrases: string[] = [];
+  if (phrasesRaw !== undefined) {
+    if (!Array.isArray(phrasesRaw)) {
+      throw new Error(
+        `dispatch-wrapper-cli: override ${absPath} 'phrases' must be a list when set`,
+      );
+    }
+    phrasesRaw.forEach((p: unknown, i: number) => {
+      if (typeof p !== 'string' || p.length === 0) {
+        throw new Error(
+          `dispatch-wrapper-cli: override ${absPath} phrases[${i}] must be a non-empty string`,
+        );
+      }
+      phrases.push(p);
+    });
+  }
+  const regexes: RegExp[] = [];
+  if (regexesRaw !== undefined) {
+    if (!Array.isArray(regexesRaw)) {
+      throw new Error(
+        `dispatch-wrapper-cli: override ${absPath} 'regexes' must be a list when set`,
+      );
+    }
+    regexesRaw.forEach((r: unknown, i: number) => {
+      if (typeof r !== 'string' || r.length === 0) {
+        throw new Error(
+          `dispatch-wrapper-cli: override ${absPath} regexes[${i}] must be a non-empty string`,
+        );
+      }
+      try {
+        regexes.push(new RegExp(r, 'i'));
+      } catch (err) {
+        throw new Error(
+          `dispatch-wrapper-cli: override ${absPath} regexes[${i}] is not a valid RegExp: ${errorMessage(err)}`,
+        );
+      }
+    });
+  }
+  if (phrases.length === 0 && regexes.length === 0) {
+    throw new Error(
+      `dispatch-wrapper-cli: override ${absPath} produced zero phrases AND zero regexes ` +
+        `(operator must supply at least one when overriding the built-in list)`,
+    );
+  }
+  return { phrases, regexes };
+}
+
+async function loadRefactorMarkersOverride(
+  repoRoot: string,
+): Promise<ReadonlyArray<RegExp> | null> {
+  const absPath = resolve(repoRoot, REFACTOR_MARKERS_OVERRIDE_PATH);
+  let text: string;
+  try {
+    text = await readFile(absPath, 'utf8');
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw new Error(
+      `dispatch-wrapper-cli: cannot read override ${absPath}: ${errorMessage(err)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(text);
+  } catch (err) {
+    throw new Error(
+      `dispatch-wrapper-cli: cannot parse override ${absPath}: ${errorMessage(err)}`,
+    );
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `dispatch-wrapper-cli: override ${absPath} did not parse to a YAML object`,
+    );
+  }
+  const markersRaw = parsed['markers'];
+  if (!Array.isArray(markersRaw)) {
+    throw new Error(
+      `dispatch-wrapper-cli: override ${absPath} missing required 'markers:' list`,
+    );
+  }
+  const markers: RegExp[] = [];
+  markersRaw.forEach((m: unknown, i: number) => {
+    if (typeof m !== 'string' || m.length === 0) {
+      throw new Error(
+        `dispatch-wrapper-cli: override ${absPath} markers[${i}] must be a non-empty string`,
+      );
+    }
+    try {
+      markers.push(new RegExp(m, 'i'));
+    } catch (err) {
+      throw new Error(
+        `dispatch-wrapper-cli: override ${absPath} markers[${i}] is not a valid RegExp: ${errorMessage(err)}`,
+      );
+    }
+  });
+  if (markers.length === 0) {
+    throw new Error(
+      `dispatch-wrapper-cli: override ${absPath} produced zero markers (must have at least one)`,
+    );
+  }
+  return markers;
+}
+
+/**
+ * Active phrase / regex / marker lists after applying any on-disk
+ * overrides. The two `*FromOverride` booleans let the CLI summary
+ * report which lists came from disk vs. defaults.
+ */
+export interface ResolvedConfig {
+  readonly phrases: ReadonlyArray<string>;
+  readonly regexes: ReadonlyArray<RegExp>;
+  readonly markers: ReadonlyArray<RegExp>;
+  readonly phrasesFromOverride: boolean;
+  readonly markersFromOverride: boolean;
+}
+
+export async function resolveCliConfig(repoRoot: string): Promise<ResolvedConfig> {
+  let phrases: ReadonlyArray<string> = FORBIDDEN_DEFERRAL_PHRASES;
+  let regexes: ReadonlyArray<RegExp> = FORBIDDEN_DEFERRAL_REGEXES;
+  let markers: ReadonlyArray<RegExp> = REFACTOR_CONTEXT_MARKERS;
+  let phrasesFromOverride = false;
+  let markersFromOverride = false;
+
+  const phraseOverride = await loadForbiddenOverride(repoRoot);
+  if (phraseOverride !== null) {
+    phrases = phraseOverride.phrases;
+    regexes = phraseOverride.regexes;
+    phrasesFromOverride = true;
+  }
+  const markerOverride = await loadRefactorMarkersOverride(repoRoot);
+  if (markerOverride !== null) {
+    markers = markerOverride;
+    markersFromOverride = true;
+  }
+  return { phrases, regexes, markers, phrasesFromOverride, markersFromOverride };
+}

--- a/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts
+++ b/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts
@@ -270,7 +270,7 @@ function regexToPromptShape(re: RegExp): string {
 }
 
 /** Build the grammar instruction text given the active phrase/regex lists. */
-function buildGrammarInstruction(
+export function buildGrammarInstruction(
   phrases: ReadonlyArray<string>,
   regexes: ReadonlyArray<RegExp>,
 ): string {

--- a/plugins/dw-lifecycle/src/subcommands/validate-return.ts
+++ b/plugins/dw-lifecycle/src/subcommands/validate-return.ts
@@ -1,0 +1,193 @@
+/**
+ * plugins/dw-lifecycle/src/subcommands/validate-return.ts
+ *
+ * CLI shim for the orchestrator-facing sub-agent response validation
+ * step. Companion to `dw-lifecycle wrap-prompt`. After the Agent tool
+ * returns the sub-agent's response, the orchestrator writes the response
+ * to a file and invokes this verb to validate against the same dispatch
+ * grammar `wrap()` enforces in-band — see TF-005 in the canary's
+ * tooling-feedback.md for the motivating friction.
+ *
+ * Reads the response from `--response-file`, parses the three required
+ * blocks (Searched/Included/Excluded), checks forbidden-deferral phrases
+ * + the skipped-audit shape + refactor-precondition cues (when the
+ * agent-type is refactor-eligible), and emits a structured
+ * `ValidationResult` (JSON) to stdout.
+ *
+ * Exit codes:
+ *   0 — response valid; the orchestrator accepts the response.
+ *   1 — response rejected by validation; the orchestrator re-dispatches
+ *        with the augmented prompt + a correction note describing the
+ *        violation(s) surfaced in the JSON.
+ *   2 — usage error (missing flag, unknown arg, bad agent-type, file
+ *        unreadable).
+ */
+
+import { readFile } from 'node:fs/promises';
+import { validateReturnForCli } from '../scope-discovery/dispatch-wrapper-cli.js';
+import { errorMessage, isEnoent } from '../scope-discovery/util/typeguards.js';
+
+const USAGE = [
+  'Usage: dw-lifecycle validate-return',
+  '    --response-file <path>',
+  '    --agent-type <type>',
+  '    [--repo-root <path>]',
+  '    [--json]',
+  '    [--help]',
+  '',
+  '--response-file <path>   Path to the file containing the sub-agent\'s',
+  '                         response text (the Agent tool return value).',
+  '--agent-type <type>      The Agent-tool agent type the response is from.',
+  '                         Some validation rules vary by agent type — the',
+  '                         refactor-precondition cue check only fires when',
+  '                         the agent type is refactor-eligible.',
+  '--repo-root <path>       Project root for resolving',
+  '                         \`.dw-lifecycle/scope-discovery/*.yaml\` overrides.',
+  '                         Defaults to the current working directory.',
+  '--json                   Suppress the stderr one-line summary; emit only',
+  '                         the structured JSON to stdout. Use in pipelines',
+  '                         where stderr noise is unwanted.',
+  '',
+  'Emits a ValidationResult (JSON) to stdout. Exit 0 on valid; exit 1',
+  'when one or more validation rules reject the response. The agent',
+  'branches on the exit code: 0 = accept; 1 = re-dispatch with correction.',
+  '',
+].join('\n');
+
+const KNOWN_AGENT_TYPES: ReadonlyArray<string> = [
+  'implementer',
+  'reviewer',
+  'code-explorer',
+  'code-architect',
+  'ui-engineer',
+  'typescript-pro',
+  'documentation-engineer',
+  'project-orchestrator',
+  'feature-orchestrator',
+  'codebase-auditor',
+  'architect-reviewer',
+  'code-reviewer',
+];
+
+export interface ValidateReturnParsedArgs {
+  readonly responseFile: string;
+  readonly agentType: string;
+  readonly repoRoot: string;
+  readonly jsonOnly: boolean;
+}
+
+export interface ValidateReturnParseResult {
+  readonly ok: boolean;
+  readonly args?: ValidateReturnParsedArgs;
+  readonly help?: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Exported for tests. Parses argv without touching `process.exit` —
+ * tests assert against the parse result directly.
+ */
+export function parseFlags(argv: ReadonlyArray<string>): ValidateReturnParseResult {
+  let responseFile: string | undefined;
+  let agentType: string | undefined;
+  let repoRoot: string | undefined;
+  let jsonOnly = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === '--help' || flag === '-h') {
+      return { ok: true, help: true };
+    }
+    if (flag === '--json') {
+      jsonOnly = true;
+      continue;
+    }
+    if (
+      flag === '--response-file' ||
+      flag === '--agent-type' ||
+      flag === '--repo-root'
+    ) {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ok: false, error: `${flag} requires a value` };
+      }
+      i += 1;
+      if (flag === '--response-file') responseFile = value;
+      else if (flag === '--agent-type') agentType = value;
+      else if (flag === '--repo-root') repoRoot = value;
+      continue;
+    }
+    return { ok: false, error: `unknown arg: ${flag ?? '(empty)'}` };
+  }
+
+  if (responseFile === undefined) {
+    return { ok: false, error: '--response-file <path> is required' };
+  }
+  if (agentType === undefined) {
+    return { ok: false, error: '--agent-type <type> is required' };
+  }
+  if (!KNOWN_AGENT_TYPES.includes(agentType)) {
+    return {
+      ok: false,
+      error:
+        `--agent-type ${agentType} is not a recognized agent type — ` +
+        `expected one of: ${KNOWN_AGENT_TYPES.join(', ')}`,
+    };
+  }
+  return {
+    ok: true,
+    args: {
+      responseFile,
+      agentType,
+      repoRoot: repoRoot ?? process.cwd(),
+      jsonOnly,
+    },
+  };
+}
+
+export async function validateReturn(argv: string[]): Promise<void> {
+  const parsed = parseFlags(argv);
+  if (parsed.help === true) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (!parsed.ok || parsed.args === undefined) {
+    process.stderr.write(`validate-return: ${parsed.error ?? 'parse error'}\n`);
+    process.stderr.write(USAGE);
+    process.exit(2);
+  }
+
+  let response: string;
+  try {
+    response = await readFile(parsed.args.responseFile, 'utf8');
+  } catch (err) {
+    if (isEnoent(err)) {
+      process.stderr.write(
+        `validate-return: --response-file not found: ${parsed.args.responseFile}\n`,
+      );
+      process.exit(2);
+    }
+    process.stderr.write(
+      `validate-return: cannot read ${parsed.args.responseFile}: ${errorMessage(err)}\n`,
+    );
+    process.exit(2);
+  }
+
+  let result;
+  try {
+    result = await validateReturnForCli({
+      response,
+      agentType: parsed.args.agentType,
+      repoRoot: parsed.args.repoRoot,
+    });
+  } catch (err) {
+    process.stderr.write(`validate-return: ${errorMessage(err)}\n`);
+    process.exit(2);
+  }
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!parsed.args.jsonOnly) {
+    process.stderr.write(`${result.summary}\n`);
+  }
+  process.exit(result.valid ? 0 : 1);
+}

--- a/plugins/dw-lifecycle/src/subcommands/wrap-prompt.ts
+++ b/plugins/dw-lifecycle/src/subcommands/wrap-prompt.ts
@@ -1,0 +1,199 @@
+/**
+ * plugins/dw-lifecycle/src/subcommands/wrap-prompt.ts
+ *
+ * CLI shim for the orchestrator-facing prompt augmentation step. The
+ * orchestrating Claude session uses this verb to engage the dispatch
+ * wrapper's prompt-augmentation logic (refactor-marker auto-prelude,
+ * project-override loading, GRAMMAR_INSTRUCTION append) without needing
+ * to supply a TypeScript `dispatchFn` to `wrap()` — see TF-005 in the
+ * canary's tooling-feedback.md for the motivating friction.
+ *
+ * Reads the operator-authored sub-agent prompt from `--prompt-file` and
+ * emits the augmented prompt (grammar instruction + optional refactor
+ * prelude appended) to stdout. The orchestrator pastes stdout into the
+ * Agent tool's `prompt` parameter.
+ *
+ * Exit codes:
+ *   0 — success.
+ *   1 — infra error (prompt-file unreadable, malformed override YAML).
+ *   2 — usage error (missing flag, unknown arg, bad agent-type).
+ */
+
+import { readFile } from 'node:fs/promises';
+import { wrapPromptForCli } from '../scope-discovery/dispatch-wrapper-cli.js';
+import { errorMessage, isEnoent } from '../scope-discovery/util/typeguards.js';
+
+const USAGE = [
+  'Usage: dw-lifecycle wrap-prompt',
+  '    --agent-type <type>',
+  '    --prompt-file <path>',
+  '    [--repo-root <path>]',
+  '    [--quiet]',
+  '    [--help]',
+  '',
+  '--agent-type <type>    The Agent-tool agent type the augmented prompt',
+  '                       will dispatch to. Required. One of:',
+  '                       implementer, reviewer, code-explorer,',
+  '                       code-architect, ui-engineer, typescript-pro,',
+  '                       documentation-engineer, project-orchestrator,',
+  '                       feature-orchestrator, codebase-auditor,',
+  '                       architect-reviewer, code-reviewer.',
+  '                       (The augmentation profile is the same for every',
+  '                       agent type today; the flag is required so the',
+  '                       stderr summary names the dispatch correctly and',
+  '                       future per-agent-type profiles are forward-',
+  '                       compatible without a CLI breaking change.)',
+  '--prompt-file <path>   Path to the operator-authored sub-agent prompt.',
+  '                       Read verbatim; the augmented prompt is stdout.',
+  '--repo-root <path>     Project root for resolving',
+  '                       \`.dw-lifecycle/scope-discovery/*.yaml\` overrides.',
+  '                       Defaults to the current working directory.',
+  '--quiet                Suppress the stderr one-line summary.',
+  '',
+  'Outputs the augmented prompt (original prompt + grammar instruction',
+  '+ optional refactor-context prelude) to stdout. The orchestrator',
+  'pastes stdout into the Agent tool prompt parameter.',
+  '',
+].join('\n');
+
+const KNOWN_AGENT_TYPES: ReadonlyArray<string> = [
+  'implementer',
+  'reviewer',
+  'code-explorer',
+  'code-architect',
+  'ui-engineer',
+  'typescript-pro',
+  'documentation-engineer',
+  'project-orchestrator',
+  'feature-orchestrator',
+  'codebase-auditor',
+  'architect-reviewer',
+  'code-reviewer',
+];
+
+export interface WrapPromptParsedArgs {
+  readonly agentType: string;
+  readonly promptFile: string;
+  readonly repoRoot: string;
+  readonly quiet: boolean;
+}
+
+export interface WrapPromptParseResult {
+  readonly ok: boolean;
+  readonly args?: WrapPromptParsedArgs;
+  readonly help?: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Exported for tests. Parses argv without touching `process.exit` —
+ * tests assert against the parse result directly.
+ */
+export function parseFlags(argv: ReadonlyArray<string>): WrapPromptParseResult {
+  let agentType: string | undefined;
+  let promptFile: string | undefined;
+  let repoRoot: string | undefined;
+  let quiet = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === '--help' || flag === '-h') {
+      return { ok: true, help: true };
+    }
+    if (flag === '--quiet') {
+      quiet = true;
+      continue;
+    }
+    if (
+      flag === '--agent-type' ||
+      flag === '--prompt-file' ||
+      flag === '--repo-root'
+    ) {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ok: false, error: `${flag} requires a value` };
+      }
+      i += 1;
+      if (flag === '--agent-type') agentType = value;
+      else if (flag === '--prompt-file') promptFile = value;
+      else if (flag === '--repo-root') repoRoot = value;
+      continue;
+    }
+    return { ok: false, error: `unknown arg: ${flag ?? '(empty)'}` };
+  }
+
+  if (agentType === undefined) {
+    return { ok: false, error: '--agent-type <type> is required' };
+  }
+  if (!KNOWN_AGENT_TYPES.includes(agentType)) {
+    return {
+      ok: false,
+      error:
+        `--agent-type ${agentType} is not a recognized agent type — ` +
+        `expected one of: ${KNOWN_AGENT_TYPES.join(', ')}`,
+    };
+  }
+  if (promptFile === undefined) {
+    return { ok: false, error: '--prompt-file <path> is required' };
+  }
+  return {
+    ok: true,
+    args: {
+      agentType,
+      promptFile,
+      repoRoot: repoRoot ?? process.cwd(),
+      quiet,
+    },
+  };
+}
+
+export async function wrapPrompt(argv: string[]): Promise<void> {
+  const parsed = parseFlags(argv);
+  if (parsed.help === true) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (!parsed.ok || parsed.args === undefined) {
+    process.stderr.write(`wrap-prompt: ${parsed.error ?? 'parse error'}\n`);
+    process.stderr.write(USAGE);
+    process.exit(2);
+  }
+
+  let taskPrompt: string;
+  try {
+    taskPrompt = await readFile(parsed.args.promptFile, 'utf8');
+  } catch (err) {
+    if (isEnoent(err)) {
+      process.stderr.write(
+        `wrap-prompt: --prompt-file not found: ${parsed.args.promptFile}\n`,
+      );
+      process.exit(1);
+    }
+    process.stderr.write(
+      `wrap-prompt: cannot read ${parsed.args.promptFile}: ${errorMessage(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = await wrapPromptForCli({
+      agentType: parsed.args.agentType,
+      taskPrompt,
+      repoRoot: parsed.args.repoRoot,
+    });
+  } catch (err) {
+    process.stderr.write(`wrap-prompt: ${errorMessage(err)}\n`);
+    process.exit(1);
+  }
+
+  process.stdout.write(result.augmentedPrompt);
+  // Ensure trailing newline so the agent pasting stdout into Agent tool
+  // ends cleanly when the original prompt did not.
+  if (!result.augmentedPrompt.endsWith('\n')) process.stdout.write('\n');
+
+  if (!parsed.args.quiet) {
+    process.stderr.write(`${result.summary}\n`);
+  }
+  process.exit(0);
+}

--- a/scripts/repair-install.sh
+++ b/scripts/repair-install.sh
@@ -64,6 +64,8 @@ PLUGINS=(deskwork deskwork-studio dw-lifecycle)
 REPAIRED=()
 HEALTHY=()
 ERRORS=()
+DEP_REPAIRED=()
+DEP_ERRORS=()
 
 # ---------- helpers ----------
 
@@ -168,6 +170,105 @@ verify_version() {
   local version=$2
   local bin_path="$CACHE_BASE/$plugin/$version/bin/$plugin"
   [[ -x "$bin_path" ]]
+}
+
+# List the runtime dependencies declared in a plugin's package.json.
+# Output: one dep name per line; empty output for packages with no
+# declared runtime deps (or when the package.json is unreadable). The
+# package.json read is best-effort — any parse failure surfaces an
+# empty list, which forces the caller to treat the plugin as
+# "no deps to probe" rather than mid-stream-erroring.
+plugin_declared_deps() {
+  local plugin_dir=$1
+  local pkg="$plugin_dir/package.json"
+  [[ -f "$pkg" ]] || return 0
+  PKG_PATH="$pkg" node -e '
+    try {
+      const p = JSON.parse(require("fs").readFileSync(process.env.PKG_PATH, "utf8"));
+      const deps = p.dependencies || {};
+      for (const name of Object.keys(deps)) {
+        if (name) console.log(name);
+      }
+    } catch (e) { /* unreadable manifest -> empty list */ }
+  ' 2>/dev/null
+}
+
+# Return the list of declared runtime deps missing from
+# $plugin_dir/node_modules/<dep>/package.json. One name per line.
+# Empty output means every declared dep is installed (or the plugin
+# declared no deps).
+plugin_missing_deps() {
+  local plugin_dir=$1
+  local dep
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    if [[ ! -f "$plugin_dir/node_modules/$dep/package.json" ]]; then
+      echo "$dep"
+    fi
+  done < <(plugin_declared_deps "$plugin_dir")
+}
+
+# Run `npm install --omit=dev --workspaces=false` in a plugin directory.
+# Used by the repair phase when a plugin's declared deps are missing.
+# Stdout/stderr surface to the calling shell so operators see install
+# progress; npm's --loglevel=error keeps the noise tolerable.
+run_plugin_install() {
+  local plugin_dir=$1
+  (
+    cd "$plugin_dir"
+    npm install --omit=dev --workspaces=false \
+      --no-audit --no-fund --loglevel=error
+  ) >&2
+}
+
+# Per-plugin dep audit: walk every plugin we're responsible for,
+# probe the marketplace clone's plugin directory for missing declared
+# deps, and either report (--check) or install (full repair).
+#
+# The clone is where the bin shim resolves PLUGIN_ROOT to. We probe
+# the same path the shim probes; the false-positive that TF-004 named
+# (clone's node_modules missing ajv etc., but --check says "healthy")
+# is the gap this loop closes.
+process_plugin_deps() {
+  local plugin=$1
+  local plugin_dir="$MARKETPLACE_CLONE/plugins/$plugin"
+  [[ -d "$plugin_dir" ]] || return 0
+
+  local missing
+  missing=$(plugin_missing_deps "$plugin_dir")
+  if [[ -z "$missing" ]]; then
+    return 0
+  fi
+
+  # Compress the missing list to a single space-separated line for the
+  # operator-facing report.
+  local missing_line
+  missing_line=$(echo "$missing" | tr '\n' ' ' | sed 's/ *$//')
+
+  if [[ $CHECK_ONLY -eq 1 ]]; then
+    err "  $plugin: missing declared deps: $missing_line"
+    DEP_ERRORS+=("$plugin")
+    return 0
+  fi
+
+  log "  $plugin: installing missing deps ($missing_line)"
+  if run_plugin_install "$plugin_dir"; then
+    # Verify the install actually landed the deps it was supposed to.
+    local still_missing
+    still_missing=$(plugin_missing_deps "$plugin_dir")
+    if [[ -n "$still_missing" ]]; then
+      local still_line
+      still_line=$(echo "$still_missing" | tr '\n' ' ' | sed 's/ *$//')
+      err "  $plugin: npm install completed but deps still missing: $still_line"
+      DEP_ERRORS+=("$plugin")
+    else
+      DEP_REPAIRED+=("$plugin")
+      log "  $plugin: deps installed"
+    fi
+  else
+    err "  $plugin: npm install failed"
+    DEP_ERRORS+=("$plugin")
+  fi
 }
 
 # Restore a plugin/version cache subtree from the marketplace clone.
@@ -326,6 +427,11 @@ main() {
   for plugin in "${PLUGINS[@]}"; do
     log "checking $plugin"
     process_plugin "$plugin"
+    # Dep audit on the marketplace clone's plugin directory. The bin
+    # shim resolves PLUGIN_ROOT here; missing declared deps in the
+    # clone are the TF-004 failure shape `--check` previously lied
+    # about.
+    process_plugin_deps "$plugin"
   done
 
   prune_registry
@@ -350,14 +456,37 @@ main() {
     exit 1
   fi
 
-  if [[ ${#REPAIRED[@]} -gt 0 ]]; then
+  local any_repaired=0
+  if [[ ${#REPAIRED[@]} -gt 0 ]] || [[ ${#DEP_REPAIRED[@]} -gt 0 ]]; then
+    any_repaired=1
+  fi
+
+  if [[ $any_repaired -eq 1 ]]; then
+    local repaired_summary=""
+    if [[ ${#REPAIRED[@]} -gt 0 ]]; then
+      repaired_summary="${REPAIRED[*]}"
+    fi
+    if [[ ${#DEP_REPAIRED[@]} -gt 0 ]]; then
+      if [[ -n "$repaired_summary" ]]; then
+        repaired_summary="$repaired_summary; deps: ${DEP_REPAIRED[*]}"
+      else
+        repaired_summary="deps: ${DEP_REPAIRED[*]}"
+      fi
+    fi
     if [[ $QUIET -eq 1 ]]; then
       # In quiet mode: announce what was repaired (the SessionStart
       # hook should still tell the operator if it actually fixed
       # something).
-      echo "deskwork repair-install: repaired ${REPAIRED[*]}"
+      echo "deskwork repair-install: repaired $repaired_summary"
     else
-      log "repaired: ${REPAIRED[*]}"
+      log "repaired: $repaired_summary"
+    fi
+  elif [[ ${#DEP_ERRORS[@]} -gt 0 ]]; then
+    # --check mode found missing deps but cannot repair (read-only).
+    # Caller below promotes this to exit 1 so the diagnostic stops
+    # lying about healthy state.
+    if [[ $QUIET -eq 0 ]]; then
+      log "needs repair: deps missing for ${DEP_ERRORS[*]}"
     fi
   elif [[ $QUIET -eq 0 ]]; then
     log "all plugins healthy."
@@ -380,6 +509,21 @@ main() {
 
   if [[ ${#ERRORS[@]} -gt 0 ]]; then
     err "errors during restore: ${ERRORS[*]}"
+    exit 1
+  fi
+
+  # In --check mode, missing deps are an unrepaired diagnostic. Exit 1
+  # so operator-facing tooling (and SessionStart hooks invoking
+  # `--check`) get a truthful signal: the state is not all-clear.
+  # In repair mode, dep-install failures are repair errors and exit 1
+  # via the DEP_ERRORS path below.
+  if [[ $CHECK_ONLY -eq 1 ]] && [[ ${#DEP_ERRORS[@]} -gt 0 ]]; then
+    err "  In Claude Code, run:"
+    err "    ${BASH_SOURCE[0]##*/}    # (without --check, to repair)"
+    exit 1
+  fi
+  if [[ ${#DEP_ERRORS[@]} -gt 0 ]]; then
+    err "errors during dep install: ${DEP_ERRORS[*]}"
     exit 1
   fi
 }

--- a/scripts/smoke-bin-shim.sh
+++ b/scripts/smoke-bin-shim.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Local smoke for the dw-lifecycle bin shim's first-run install path.
+# Not in CI per the deskwork repo's no-CI-testing rule. Run before
+# tagging a release that touches the shim or any declared dep.
+#
+# Strategy: copy the plugin shell into a tmpdir (so the workspace
+# node_modules hoist is invisible to the shim), wipe the copied
+# plugin's node_modules/, run the shim, and verify:
+#   1. The install advisory prints to stderr.
+#   2. After install, every declared dep (tsx, yaml, zod, ajv,
+#      ajv-formats, jscpd) is resolvable from <tmpdir>/node_modules/.
+#   3. The install-complete sentinel was written.
+#   4. A second invocation does NOT re-install (sentinel short-circuit).
+#
+# This smoke is the one TF-004 explicitly named: a sparse-clone-shaped
+# install state where tsx might happen to land via some other path but
+# the rest of the deps are missing. We avoid that subtlety here by
+# wiping the entire node_modules/ — the install path has to run from
+# scratch.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+PLUGIN_SOURCE="$ROOT/plugins/dw-lifecycle"
+TMP=$(mktemp -d)
+PLUGIN_COPY="$TMP/dw-lifecycle"
+
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+echo "== smoke: copying plugin shell to $PLUGIN_COPY =="
+mkdir -p "$PLUGIN_COPY"
+# Copy everything except node_modules (we want a clean install path).
+# Skip vitest config / tests too — not needed for the smoke and shaves
+# the copy cost.
+for entry in .claude-plugin bin src package.json package-lock.json README.md LICENSE templates skills commands tsconfig.json; do
+  [[ -e "$PLUGIN_SOURCE/$entry" ]] || continue
+  cp -R "$PLUGIN_SOURCE/$entry" "$PLUGIN_COPY/"
+done
+
+# Sanity: confirm we did NOT bring node_modules across.
+if [[ -d "$PLUGIN_COPY/node_modules" ]]; then
+  echo "FAIL: tmpdir copy unexpectedly contains node_modules" >&2
+  exit 1
+fi
+
+echo "== smoke: first invocation should install =="
+# Capture stderr so we can verify the install advisory printed.
+STDERR_LOG="$TMP/stderr-1.log"
+if ! "$PLUGIN_COPY/bin/dw-lifecycle" --help >/dev/null 2>"$STDERR_LOG"; then
+  # `--help` may exit non-zero in some CLI layouts; we don't care about
+  # the exit code as much as we care that the install ran and the shim
+  # got past dep resolution. Inspect deps below.
+  :
+fi
+
+if ! grep -q "installing plugin dependencies" "$STDERR_LOG"; then
+  echo "FAIL: expected install advisory on stderr; got:" >&2
+  cat "$STDERR_LOG" >&2
+  exit 1
+fi
+
+echo "== smoke: every declared dep resolvable =="
+for dep in tsx yaml zod ajv ajv-formats jscpd; do
+  if [[ ! -f "$PLUGIN_COPY/node_modules/$dep/package.json" ]]; then
+    echo "FAIL: $dep/package.json missing after install" >&2
+    exit 1
+  fi
+done
+
+echo "== smoke: sentinel written =="
+VERSION=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$PLUGIN_COPY/.claude-plugin/plugin.json','utf8')).version || '')")
+if [[ -z "$VERSION" ]]; then
+  echo "FAIL: could not read plugin version" >&2
+  exit 1
+fi
+SENTINEL="$PLUGIN_COPY/node_modules/.deskwork-install-complete-$VERSION"
+if [[ ! -f "$SENTINEL" ]]; then
+  echo "FAIL: sentinel missing at $SENTINEL" >&2
+  exit 1
+fi
+
+echo "== smoke: second invocation should NOT re-install =="
+STDERR_LOG_2="$TMP/stderr-2.log"
+if ! "$PLUGIN_COPY/bin/dw-lifecycle" --help >/dev/null 2>"$STDERR_LOG_2"; then
+  :
+fi
+if grep -q "installing plugin dependencies" "$STDERR_LOG_2"; then
+  echo "FAIL: second invocation re-ran the install path; sentinel short-circuit broken" >&2
+  cat "$STDERR_LOG_2" >&2
+  exit 1
+fi
+
+echo "== smoke: partial-install (delete ajv, expect re-install) =="
+rm -rf "$PLUGIN_COPY/node_modules/ajv"
+# Also blow away the sentinel — a partial install only re-triggers when
+# the sentinel is stale (per the shim contract: sentinel is the
+# fast-path, dep probe runs when sentinel is absent).
+rm -f "$SENTINEL"
+STDERR_LOG_3="$TMP/stderr-3.log"
+if ! "$PLUGIN_COPY/bin/dw-lifecycle" --help >/dev/null 2>"$STDERR_LOG_3"; then
+  :
+fi
+if ! grep -q "installing plugin dependencies" "$STDERR_LOG_3"; then
+  echo "FAIL: partial-install state did not trigger re-install" >&2
+  cat "$STDERR_LOG_3" >&2
+  exit 1
+fi
+if [[ ! -f "$PLUGIN_COPY/node_modules/ajv/package.json" ]]; then
+  echo "FAIL: ajv still missing after re-install" >&2
+  exit 1
+fi
+
+echo "== smoke: PASS =="


### PR DESCRIPTION
## Summary

Two HIGH-severity findings the graphical-entries canary surfaced against v0.24.1:

### TF-004 — bin shim probes only `tsx`; `repair-install.sh` lies "healthy"

The plugin bin shim's first-run resolver checked only for `tsx`; the rest of the declared `package.json` runtime deps (`ajv`, `ajv-formats`, `jscpd`) were never installed. Adopters hit `ERR_MODULE_NOT_FOUND: ajv` on first invocation. Worse, `scripts/repair-install.sh --check` reported `all plugins healthy.` even with missing deps — the diagnostic path lied.

**Fix:**
- `bin/dw-lifecycle` — probes every declared runtime dep; runs `npm install --omit=dev --workspaces=false` when any is missing. Version-keyed sentinel `<node_modules>/.deskwork-install-complete-<version>` short-circuits subsequent invocations.
- `scripts/repair-install.sh` — `--check` mode walks per-plugin `package.json` deps + tests `node_modules/<dep>/package.json` for each; missing deps flip plugin status to `needs-repair` and `--check` exits 1. Full-repair phase auto-installs.
- New `scripts/smoke-bin-shim.sh` — local-only bash smoke verifying install + sentinel + partial-install re-install behavior.

### TF-005 — dispatch-wrapper unreachable from the orchestrating session

Same architectural shape as TF-007 (which v0.24.1 fixed for the orchestrator loop): `wrap()` takes a `dispatchFn` callback the agent is supposed to supply, but Claude Code's Agent tool is a runtime primitive, not a TypeScript callable. SKILL.md said every dispatch MUST route through `wrap()`; the agent had no execution path that did so.

**Fix:** ship two CLI verbs that bridge:

- `dw-lifecycle wrap-prompt --agent-type <type> --prompt-file <path>` — reads the operator-authored prompt + runs the same enrichment `wrap()` does (GRAMMAR_INSTRUCTION append, refactor-marker auto-prelude, project-override loading). Stdout is the augmented prompt.
- `dw-lifecycle validate-return --agent-type <type> --response-file <path>` — parses Searched/Included/Excluded blocks, checks forbidden-deferral phrases + refactor-preconditions; emits structured JSON; exit 0 if valid, 1 on violations.

Shared `dispatch-wrapper-cli.ts` library factors the CLI flows out of the in-band `wrap()`. `skills/implement/SKILL.md` § "Dispatch-wrapper engagement" rewritten to instruct the agent to invoke the two Bash verbs instead of describing TS function calls.

## Verification

- `npx tsc -p plugins/dw-lifecycle --noEmit`: clean.
- Full plugin suite: **1398 / 1398 tests pass** (117 files; +32 new scenarios).
- `scripts/smoke-bin-shim.sh`: PASS — install fires, sentinel writes, second invocation skips, partial-install (delete ajv) triggers re-install.
- Live `wrap-prompt` augments a 1-line prompt to 43 lines.
- Live `validate-return` returns `valid: true` for a well-formed response; `valid: false` with structured `missingBlocks` for ill-formed responses.

## Status against canary's TF doc

- **TF-004** — fixed by this PR; canary re-test will confirm.
- **TF-005** — fixed by this PR; canary re-test will confirm.
- **TF-001 / TF-002 / TF-003** — still listed Open in the canary's table but actually shipped in v0.24.1 (commit `2e8fdd1` / PR #320 squashed as `05b8272`). The canary's status table just hasn't been updated. Their re-test pending.
- **TF-006 / TF-007** — already marked Closed against v0.24.1.

## Test plan

- [ ] Verify post-merge that a fresh marketplace install of dw-lifecycle invokes the bin shim cleanly on first call (the install path fires).
- [ ] Verify `repair-install.sh --check` against an install with a deliberately-removed `ajv` reports the missing dep.
- [ ] Verify `dw-lifecycle wrap-prompt` + `dw-lifecycle validate-return` work end-to-end in a real `/dw-lifecycle:implement` session against a feature on the canary branch.
