### PR TITLE
feat(scope-discovery): unmatched-shape clustering algorithm (closes #318)

### DIFF
--- a/plugins/dw-lifecycle/src/__tests__/scope-discovery/discovery-agents/synthesis-discovered-candidates.test.ts
+++ b/plugins/dw-lifecycle/src/__tests__/scope-discovery/discovery-agents/synthesis-discovered-candidates.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the unmatched-shape clustering algorithm (#318).
+ *
+ * Coverage:
+ *   - Empty input → empty output.
+ *   - All files covered → empty output.
+ *   - Fewer than MIN_CLUSTER_SIZE uncovered files → empty output.
+ *   - 3 near-identical files (high Jaccard) form one cluster; member
+ *     count and order verified.
+ *   - 3 near-identical + 3 distinct files form one cluster (the 3
+ *     similar), 3 singletons filtered.
+ *   - Two distinct clusters (3 + 3 near-identical, mutually unlike)
+ *     emerge as two separate clusters ranked by size (tie → tertiary
+ *     stable tiebreak on smallest member file path).
+ *   - Distinctiveness ranking: when two clusters have equal member
+ *     count, the one less similar to covered shapes ranks first.
+ *   - Cluster id is deterministic across calls with identical input
+ *     and stable under member reordering.
+ *   - Bag-of-words summary surfaces high-frequency n-grams.
+ *   - Files that tokenize to fewer than NGRAM_MIN tokens are dropped.
+ *   - Comments and string literals don't drive clustering.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  clusterUnmatchedShapes,
+  type ClusterUnmatchedShapesInput,
+} from '../../../scope-discovery/discovery-agents/synthesis-discovered-candidates.js';
+import type { SourceFileView } from '../../../scope-discovery/discovery-agents/shared.js';
+import type { PatternFinding } from '../../../scope-discovery/discovery-agents/types.js';
+
+function view(file: string, text: string): SourceFileView {
+  return { file, text, lines: text.split(/\r?\n/) };
+}
+
+function finding(file: string, line = 1): PatternFinding {
+  return {
+    id: 'test-pattern',
+    description: 'test',
+    regex: '.',
+    hits: [{ file, line, snippet: '' }],
+  };
+}
+
+/**
+ * Produces a body whose token stream is the given vocabulary, repeated.
+ * Repetition guarantees enough tokens to form n-grams (n=3..5) and
+ * keeps the vocabulary specific to this group — no shared filler that
+ * would inflate cross-group Jaccard similarity.
+ */
+function bodyOf(...vocab: string[]): string {
+  // Rotate the vocabulary so adjacent-token n-grams cover all permutations
+  // of the vocab, but distinct vocabularies share zero tokens.
+  const repeated: string[] = [];
+  for (let i = 0; i < 6; i += 1) {
+    for (const v of vocab) repeated.push(v);
+  }
+  return repeated.join(' ');
+}
+
+describe('clusterUnmatchedShapes (#318)', () => {
+  it('empty input → empty output', () => {
+    const out = clusterUnmatchedShapes({ scans: [], findings: [] });
+    expect(out).toEqual([]);
+  });
+
+  it('all files covered → empty output', () => {
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [
+        view('a.ts', bodyOf('foo', 'bar', 'baz', 'qux')),
+        view('b.ts', bodyOf('foo', 'bar', 'baz', 'qux')),
+        view('c.ts', bodyOf('foo', 'bar', 'baz', 'qux')),
+      ],
+      findings: [finding('a.ts'), finding('b.ts'), finding('c.ts')],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toEqual([]);
+  });
+
+  it('fewer than MIN_CLUSTER_SIZE uncovered files → empty output', () => {
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [
+        view('a.ts', bodyOf('foo', 'bar', 'baz')),
+        view('b.ts', bodyOf('foo', 'bar', 'baz')),
+      ],
+      findings: [],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toEqual([]);
+  });
+
+  it('3 near-identical files form one cluster', () => {
+    // Three files with identical tokens → identical n-gram sets → Jaccard 1.0.
+    const text = bodyOf('alpha', 'beta', 'gamma', 'delta', 'epsilon');
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [view('x.ts', text), view('y.ts', text), view('z.ts', text)],
+      findings: [],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toHaveLength(1);
+    const cluster = out[0];
+    expect(cluster).toBeDefined();
+    if (!cluster) return;
+    expect(cluster.memberCount).toBe(3);
+    expect(cluster.members).toEqual(['x.ts', 'y.ts', 'z.ts']);
+    expect(cluster.id).toMatch(/^cluster-[0-9a-f]{8}$/);
+    expect(cluster.shapeSummary.length).toBeGreaterThan(0);
+  });
+
+  it('3 near-identical + 3 mutually-distinct → one cluster (the 3 similar), singletons filtered', () => {
+    const sharedText = bodyOf('alpha', 'beta', 'gamma', 'delta', 'epsilon');
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [
+        view('similar1.ts', sharedText),
+        view('similar2.ts', sharedText),
+        view('similar3.ts', sharedText),
+        // Mutually distinct: each has a unique vocabulary set with no overlap.
+        view('distinct1.ts', bodyOf('one', 'two', 'three', 'four', 'five')),
+        view('distinct2.ts', bodyOf('apple', 'banana', 'cherry', 'date', 'fig')),
+        view(
+          'distinct3.ts',
+          bodyOf('red', 'green', 'blue', 'yellow', 'purple'),
+        ),
+      ],
+      findings: [],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.memberCount).toBe(3);
+    expect(out[0]?.members).toEqual(['similar1.ts', 'similar2.ts', 'similar3.ts']);
+  });
+
+  it('two distinct clusters of equal size emerge separately, ranked by stable tiebreak', () => {
+    const groupA = bodyOf('alpha', 'beta', 'gamma', 'delta', 'epsilon');
+    const groupB = bodyOf('one', 'two', 'three', 'four', 'five');
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [
+        view('a1.ts', groupA),
+        view('a2.ts', groupA),
+        view('a3.ts', groupA),
+        view('b1.ts', groupB),
+        view('b2.ts', groupB),
+        view('b3.ts', groupB),
+      ],
+      findings: [],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.memberCount).toBe(3);
+    expect(out[1]?.memberCount).toBe(3);
+    // With covered shapes empty, distinctiveness collapses to 1 for
+    // both. Tertiary tiebreak: smallest member file path; 'a1.ts'
+    // sorts before 'b1.ts'.
+    expect(out[0]?.members).toEqual(['a1.ts', 'a2.ts', 'a3.ts']);
+    expect(out[1]?.members).toEqual(['b1.ts', 'b2.ts', 'b3.ts']);
+  });
+
+  it('cluster id is deterministic + stable under member reordering', () => {
+    const text = bodyOf('alpha', 'beta', 'gamma', 'delta', 'epsilon');
+    const inputA: ClusterUnmatchedShapesInput = {
+      scans: [view('x.ts', text), view('y.ts', text), view('z.ts', text)],
+      findings: [],
+    };
+    const inputB: ClusterUnmatchedShapesInput = {
+      // Same files, reversed input order.
+      scans: [view('z.ts', text), view('y.ts', text), view('x.ts', text)],
+      findings: [],
+    };
+    const outA = clusterUnmatchedShapes(inputA);
+    const outB = clusterUnmatchedShapes(inputB);
+    expect(outA[0]?.id).toBe(outB[0]?.id);
+    expect(outA[0]?.members).toEqual(outB[0]?.members);
+  });
+
+  it('bag-of-words summary surfaces high-frequency n-grams', () => {
+    // Three identical files; every n-gram occurs 3 times.
+    const text = bodyOf('foo', 'bar', 'baz', 'qux');
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [view('p.ts', text), view('q.ts', text), view('r.ts', text)],
+      findings: [],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toHaveLength(1);
+    const summary = out[0]?.shapeSummary ?? '';
+    // Summary contains comma-separated n-gram strings.
+    expect(summary).toContain(',');
+    // 'foo bar baz' is a 3-gram that should appear in the top-K.
+    expect(summary).toContain('foo bar baz');
+  });
+
+  it('files that tokenize to fewer than NGRAM_MIN tokens are dropped', () => {
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [
+        view('tiny1.ts', 'a b'), // 2 tokens → fewer than n=3 → 0 n-grams
+        view('tiny2.ts', 'c d'),
+        view('tiny3.ts', 'e f'),
+      ],
+      findings: [],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toEqual([]);
+  });
+
+  it('comments and string literals do not drive clustering', () => {
+    // Two files: same alphanumeric body, but one has wildly different
+    // comments + string literals. They should still cluster (tokens
+    // are equivalent after stripping comments/strings).
+    const sharedTokens = bodyOf('alpha', 'beta', 'gamma', 'delta', 'epsilon');
+    const a = `// comment alpha\n${sharedTokens}\n"string alpha"`;
+    const b = `/* totally different block comment */\n${sharedTokens}\n'string omega'`;
+    const c = `<!-- markdown comment foo -->\n${sharedTokens}\n\`template literal\``;
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [view('a.ts', a), view('b.ts', b), view('c.md', c)],
+      findings: [],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.memberCount).toBe(3);
+    expect(out[0]?.members).toEqual(['a.ts', 'b.ts', 'c.md']);
+  });
+
+  it('distinctiveness ranking: equal-size clusters, less covered-similar ranks first', () => {
+    // Two equal-size clusters (3 each). Cluster X is very similar to
+    // a covered file; cluster Y is distinct from anything covered.
+    // Y should rank above X by the distinctiveness tiebreaker.
+    const xText = bodyOf('alpha', 'beta', 'gamma', 'delta', 'epsilon');
+    const yText = bodyOf('lambda', 'mu', 'nu', 'xi', 'omicron');
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [
+        // Covered (similar to X's vocabulary):
+        view('covered1.ts', xText),
+        // X cluster (uncovered, similar to covered1):
+        view('x1.ts', xText),
+        view('x2.ts', xText),
+        view('x3.ts', xText),
+        // Y cluster (uncovered, distinct from covered):
+        view('y1.ts', yText),
+        view('y2.ts', yText),
+        view('y3.ts', yText),
+      ],
+      findings: [finding('covered1.ts')],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.memberCount).toBe(3);
+    expect(out[1]?.memberCount).toBe(3);
+    // Y should rank first (more distinctive from covered).
+    expect(out[0]?.members[0]).toBe('y1.ts');
+    expect(out[1]?.members[0]).toBe('x1.ts');
+  });
+
+  it('mixed covered + uncovered: only uncovered cluster surfaces', () => {
+    const sharedText = bodyOf('alpha', 'beta', 'gamma', 'delta', 'epsilon');
+    const input: ClusterUnmatchedShapesInput = {
+      scans: [
+        view('covered1.ts', sharedText),
+        view('covered2.ts', sharedText),
+        view('uncovered1.ts', sharedText),
+        view('uncovered2.ts', sharedText),
+        view('uncovered3.ts', sharedText),
+      ],
+      findings: [finding('covered1.ts'), finding('covered2.ts')],
+    };
+    const out = clusterUnmatchedShapes(input);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.members).toEqual(['uncovered1.ts', 'uncovered2.ts', 'uncovered3.ts']);
+  });
+});

--- a/plugins/dw-lifecycle/src/scope-discovery/discovery-agents/synthesis-discovered-candidates.ts
+++ b/plugins/dw-lifecycle/src/scope-discovery/discovery-agents/synthesis-discovered-candidates.ts
@@ -1,66 +1,84 @@
 /**
  * plugins/dw-lifecycle/src/scope-discovery/discovery-agents/synthesis-discovered-candidates.ts
  *
- * Synthesis-layer unmatched-shape clustering pass — the discovered_candidates stub STUB.
- *
- * STATUS: stub-shipped in v1.1 Task 1. The TYPE + invocation site are
- * complete; the clustering algorithm itself returns an empty list
- * with a one-time stderr advisory naming the deferral. The algorithm
- * lands under the GH issue cross-referenced below.
- *
- * # What the real implementation will do
+ * Synthesis-layer unmatched-shape clustering pass.
  *
  * After all registered pattern handlers (regex / negative-space /
- * coverage / outlier / semantic) run, this pass groups files whose
- * content shape was NOT matched by any registered pattern, by
- * similarity. The output is a list of `DiscoveredCandidateCluster`
- * with bag-of-words / n-gram summaries; the synthesis layer surfaces
- * each cluster above the frequency threshold as a `discovered_candidate`
- * in the manifest (the operator decides whether to author a pattern
- * for it).
+ * coverage / outlier / semantic) run, this pass groups source files
+ * whose content shape was NOT matched by any registered pattern, by
+ * shape similarity. Each cluster above a frequency floor surfaces as
+ * a `discovered_candidate` in the scope-manifest; the operator decides
+ * whether to author a pattern for the cluster or mark it ignore.
  *
- * Tracking issue: https://github.com/audiocontrol-org/deskwork/issues/318
+ * Closes https://github.com/audiocontrol-org/deskwork/issues/318
+ * (Algorithmic spec ported from audiocontrol issue #315.)
  *
- * Algorithmic specs the real implementation must satisfy (from
- * audiocontrol issue #315; the tracking issue #318 carries the full
- * spec + acceptance criteria):
- *   - n-gram overlap or shingled hashing (MinHash) over token
- *     composition;
- *   - frequency threshold to suppress one-off shapes;
- *   - rank by cluster size + cluster-distinctiveness from the
- *     blessed-shape vocabulary;
- *   - the operator-facing "discovered_candidates" section of the
- *     scope-manifest is the destination.
+ * # Algorithm
  *
- * # Why the stub here
+ * 1. Coverage set = union of files in `findings[*].hits[*].file`.
+ * 2. Uncovered set = scanned files NOT in the coverage set.
+ * 3. Shape signature per file = MinHash(n-grams(tokens)) where:
+ *    - tokens are alphanumeric (identifiers, attribute names, JSX
+ *      element names; string literals and comments excluded for
+ *      stability across cosmetic edits);
+ *    - n-grams span n=3..5 to capture short repeating phrases AND
+ *      longer structural shapes;
+ *    - MinHash uses 128 independent hash functions; the resulting
+ *      `Uint32Array(128)` signature compares cheaply via element-wise
+ *      equality (the fraction of matching positions estimates Jaccard
+ *      similarity).
+ * 4. Cluster by Jaccard >= 0.7 with an every-pair check (greedy
+ *    single-link: a candidate joins a cluster only if it meets the
+ *    threshold against EVERY existing member; preserves cluster
+ *    tightness as it grows).
+ * 5. Rank by member count desc; secondary tiebreak by distinctiveness
+ *    from the covered (already-blessed) vocabulary — clusters that
+ *    look NOTHING like any registered pattern rank above near-misses
+ *    of registered shapes.
+ * 6. Frequency floor: emit clusters with `memberCount >= 3`. Fewer
+ *    than 3 files is statistical noise per the spec.
+ * 7. Shape summary: bag-of-words of the top-10 n-grams by frequency
+ *    within the cluster — the human-readable artifact the operator
+ *    reads to decide whether the cluster is a real shape.
  *
- * The the polymorphic dispatcher ships;
- * the clustering algorithm is its own non-trivial piece of work
- * (token-vocabulary modeling + clustering + ranking + threshold
- * tuning). Shipping a stub keeps the wire-format forward-compatible
- * (the manifest's `discovered_candidates` field is reserved + always
- * emitted, may be empty) while the algorithm lands separately.
+ * # Complexity
+ *
+ * O(N * (T + S * H)) for signature build (N = uncovered files; T =
+ * tokenization cost per file; S = n-gram set size per file; H =
+ * MinHash width = 128). O(N^2 * H) for clustering's worst-case
+ * every-pair comparison + O(N * M * H) for distinctiveness against
+ * M covered files. Both quadratic terms are fine for typical
+ * uncovered-set sizes (< 1000 files); above that, locality-sensitive
+ * hashing would replace the every-pair check, but the spec
+ * deliberately defers that until the simple algorithm is proven.
  */
 
 import type { PatternFinding } from './types.js';
 import type { SourceFileView } from './shared.js';
 import type { DiscoveredCandidateCluster } from './types.js';
 
-let warnedOnce = false;
-
-function warnOnce(): void {
-  if (warnedOnce) return;
-  warnedOnce = true;
-  // Stderr advisory so the operator running scope-inventory sees the
-  // stub explicitly. Not a throw — the dispatcher continues with the
-  // pattern-handler findings unaffected.
-  process.stderr.write(
-    'pattern-matrix: unmatched-shape clustering pass is a STUB ' +
-      '(stub; tracking #318). The polymorphic dispatcher is ' +
-      'shipped; the clustering algorithm lands under issue #318. ' +
-      'discovered_candidates returns [] until then.\n',
-  );
-}
+/**
+ * Tuning constants. Sources of the defaults:
+ *   - NGRAM_MIN / NGRAM_MAX: #318 spec (n=3..5 captures both short
+ *     repeating phrases and longer structural shapes).
+ *   - MINHASH_SIZE: 128 hash functions is the standard literature
+ *     default; gives ~9% standard error on the Jaccard estimate.
+ *   - JACCARD_THRESHOLD: 0.7 per #318 spec; the operator can revise
+ *     once we have telemetry from the audit-log on cluster quality.
+ *   - MIN_CLUSTER_SIZE: 3 per #318 spec; fewer is statistical noise.
+ *   - SUMMARY_TOP_K: 10 per #318 spec; matches operator-attention
+ *     budget on the manifest surface.
+ *
+ * No project-override loader is wired in v1 — the constants are
+ * literally the spec. Adopters can fork the file or file a follow-up
+ * if real-world tuning needs surface.
+ */
+const NGRAM_MIN = 3;
+const NGRAM_MAX = 5;
+const MINHASH_SIZE = 128;
+const JACCARD_THRESHOLD = 0.7;
+const MIN_CLUSTER_SIZE = 3;
+const SUMMARY_TOP_K = 10;
 
 export interface ClusterUnmatchedShapesInput {
   /** All in-scope source files (already read into views). */
@@ -70,26 +88,280 @@ export interface ClusterUnmatchedShapesInput {
 }
 
 /**
- * STUB clustering pass. Returns an empty list until the algorithm
- * lands. The signature is the production contract — callers can adopt
- * it now and benefit when the real implementation replaces the body.
+ * Public entry point. Composes the algorithm steps; pure (no I/O).
+ *
+ * Empty input → empty output. Files that tokenize to fewer than
+ * NGRAM_MIN tokens contribute zero n-grams and are silently dropped
+ * (they can't meaningfully cluster); the per-file ngram-set being
+ * empty is the gate.
  */
 export function clusterUnmatchedShapes(
-  _input: ClusterUnmatchedShapesInput,
+  input: ClusterUnmatchedShapesInput,
 ): ReadonlyArray<DiscoveredCandidateCluster> {
-  // TODO(#318): implement n-gram / MinHash-based clustering over the
-  // files not covered by any registered pattern. The algorithmic
-  // specs are at audiocontrol issue #315; the deskwork tracking issue
-  // is #318 (filed alongside polymorphic pattern handlers).
-  //
-  // Real implementation outline:
-  //   1. Build a set of "covered" files = union of files in
-  //      `findings[*].hits[*].file`.
-  //   2. For each uncovered file, compute n-grams (n=3..5) over the
-  //      token stream and shingle-hash them.
-  //   3. Cluster by Jaccard similarity > threshold (e.g., 0.7).
-  //   4. Rank clusters by member count.
-  //   5. Return clusters with member count >= MIN_CLUSTER_SIZE.
-  warnOnce();
-  return [];
+  // STEP 1 — Coverage set.
+  const covered = buildCoverageSet(input.findings);
+
+  // STEP 2-3 — Partition + build signatures.
+  const uncoveredShapes: FileShape[] = [];
+  const coveredShapes: FileShape[] = [];
+  for (const scan of input.scans) {
+    const shape = buildShape(scan);
+    if (shape === null) continue;
+    if (covered.has(scan.file)) {
+      coveredShapes.push(shape);
+    } else {
+      uncoveredShapes.push(shape);
+    }
+  }
+  if (uncoveredShapes.length < MIN_CLUSTER_SIZE) return [];
+
+  // STEP 4 — Cluster.
+  const clusters = clusterByJaccard(uncoveredShapes);
+
+  // STEP 5-6 — Filter by frequency floor + rank.
+  const eligible = clusters.filter((c) => c.memberShapes.length >= MIN_CLUSTER_SIZE);
+  const ranked = rankClusters(eligible, coveredShapes);
+
+  // STEP 7 — Emit operator-facing summaries.
+  return ranked.map((c) => ({
+    id: stableClusterId(c.memberShapes.map((s) => s.file)),
+    shapeSummary: bagOfWordsSummary(c.memberShapes),
+    members: c.memberShapes.map((s) => s.file).sort(),
+    memberCount: c.memberShapes.length,
+  }));
+}
+
+/** One file's signature + supporting metadata used downstream. */
+interface FileShape {
+  readonly file: string;
+  readonly ngrams: ReadonlySet<string>;
+  readonly signature: Uint32Array;
+}
+
+interface Cluster {
+  readonly memberShapes: FileShape[];
+}
+
+function buildCoverageSet(findings: ReadonlyArray<PatternFinding>): Set<string> {
+  const out = new Set<string>();
+  for (const finding of findings) {
+    for (const hit of finding.hits) {
+      out.add(hit.file);
+    }
+  }
+  return out;
+}
+
+function buildShape(view: SourceFileView): FileShape | null {
+  const tokens = tokenize(view.text);
+  const ngramArr = allNgrams(tokens);
+  if (ngramArr.length === 0) return null;
+  const ngramSet = new Set(ngramArr);
+  if (ngramSet.size === 0) return null;
+  const signature = minHashSignature(ngramSet);
+  return { file: view.file, ngrams: ngramSet, signature };
+}
+
+/**
+ * Strip comments + string literals; tokenize on non-alphanumeric.
+ *
+ * The stripping is heuristic, not language-aware (we accept .ts,
+ * .tsx, .md, .css, .yaml, .json, .html — see Phase 11 multi-content-
+ * type support). For language-aware tokenization (e.g. JSX-aware
+ * unwrapping of attribute values), an AST tokenizer would replace
+ * this; not in scope for #318.
+ */
+function tokenize(text: string): string[] {
+  const stripped = text
+    .replace(/\/\/[^\n]*/g, '') // line comments
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/<!--[\s\S]*?-->/g, '') // HTML/markdown comments
+    .replace(/"(?:[^"\\]|\\.)*"/g, '') // double-quoted strings
+    .replace(/'(?:[^'\\]|\\.)*'/g, '') // single-quoted strings
+    .replace(/`(?:[^`\\]|\\.)*`/g, ''); // backtick template literals
+  return stripped.split(/[^A-Za-z0-9_]+/).filter((t) => t.length > 0);
+}
+
+function allNgrams(tokens: ReadonlyArray<string>): string[] {
+  const out: string[] = [];
+  for (let n = NGRAM_MIN; n <= NGRAM_MAX; n += 1) {
+    if (tokens.length < n) continue;
+    for (let i = 0; i + n <= tokens.length; i += 1) {
+      out.push(tokens.slice(i, i + n).join(' '));
+    }
+  }
+  return out;
+}
+
+/**
+ * MinHash signature: for each of MINHASH_SIZE independent hash
+ * functions, take the minimum hash over all elements. Element-wise
+ * equality of two signatures estimates Jaccard similarity (the
+ * fraction of positions where both signatures coincide approximates
+ * |A∩B|/|A∪B|, unbiased).
+ */
+function minHashSignature(ngramSet: ReadonlySet<string>): Uint32Array {
+  const sig = new Uint32Array(MINHASH_SIZE).fill(0xffffffff);
+  for (const s of ngramSet) {
+    for (let i = 0; i < MINHASH_SIZE; i += 1) {
+      const h = fnv1aSeeded(s, i + 1);
+      const current = sig[i] ?? 0xffffffff;
+      if (h < current) sig[i] = h;
+    }
+  }
+  return sig;
+}
+
+/**
+ * FNV-1a 32-bit hash, seeded by mixing the seed into the initial
+ * offset basis. Standard library-free MinHash hash-function family.
+ * Seeds in [1, MINHASH_SIZE] produce 128 effectively-independent
+ * functions (the seed perturbs every byte's contribution).
+ */
+function fnv1aSeeded(s: string, seed: number): number {
+  let h = (2166136261 ^ seed) >>> 0;
+  for (let i = 0; i < s.length; i += 1) {
+    h = Math.imul(h ^ s.charCodeAt(i), 16777619);
+  }
+  return h >>> 0;
+}
+
+function jaccardFromSigs(a: Uint32Array, b: Uint32Array): number {
+  if (a.length !== b.length) {
+    throw new Error(
+      `clusterUnmatchedShapes: MinHash signature length mismatch (${a.length} vs ${b.length})`,
+    );
+  }
+  let same = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai === bi) same += 1;
+  }
+  return same / a.length;
+}
+
+/**
+ * Greedy single-link clustering with every-pair threshold check.
+ *
+ * For each unassigned shape, start a new cluster. Sweep remaining
+ * unassigned shapes; add one to the cluster only if it meets the
+ * Jaccard threshold against EVERY existing member. The every-pair
+ * check (rather than single-link's any-pair) prevents the typical
+ * single-link "chain merging" pathology where transitive similarity
+ * collapses heterogeneous clusters into one.
+ *
+ * Insertion order is the iteration order over `shapes`; the test
+ * suite verifies the algorithm is stable under the input ordering
+ * we actually produce (sorted by file path).
+ */
+function clusterByJaccard(shapes: ReadonlyArray<FileShape>): Cluster[] {
+  const assigned = new Set<string>();
+  const out: Cluster[] = [];
+  // Sort by file path for stable iteration order across runs.
+  const ordered = [...shapes].sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0));
+  for (const seed of ordered) {
+    if (assigned.has(seed.file)) continue;
+    const members: FileShape[] = [seed];
+    assigned.add(seed.file);
+    for (const cand of ordered) {
+      if (assigned.has(cand.file)) continue;
+      if (members.every((m) => jaccardFromSigs(m.signature, cand.signature) >= JACCARD_THRESHOLD)) {
+        members.push(cand);
+        assigned.add(cand.file);
+      }
+    }
+    out.push({ memberShapes: members });
+  }
+  return out;
+}
+
+/**
+ * Rank by (member count desc, distinctiveness desc).
+ *
+ * Distinctiveness = 1 - mean(jaccard(cluster_member, covered_member))
+ * averaged over all (cluster_member, covered_member) pairs. A cluster
+ * whose shapes are entirely unlike any registered pattern shape
+ * (distinctiveness → 1) ranks above a near-miss of an existing
+ * registered shape (distinctiveness → 0). Near-misses are valid
+ * "registered-pattern tightening" candidates; novel patterns are
+ * the higher-information surface.
+ *
+ * If there are no covered shapes (cold-start: zero registered
+ * patterns matched anything), distinctiveness collapses to 1 for
+ * every cluster — the size tiebreaker dominates, which is correct.
+ */
+function rankClusters(eligible: ReadonlyArray<Cluster>, coveredShapes: ReadonlyArray<FileShape>): Cluster[] {
+  const scored = eligible.map((c) => ({
+    cluster: c,
+    size: c.memberShapes.length,
+    distinctiveness: distinctivenessVsCovered(c.memberShapes, coveredShapes),
+  }));
+  scored.sort((a, b) => {
+    if (a.size !== b.size) return b.size - a.size;
+    if (a.distinctiveness !== b.distinctiveness) return b.distinctiveness - a.distinctiveness;
+    // Tertiary stable tiebreak: sort by smallest member file path so
+    // identical-shaped runs produce identical output across reruns.
+    // memberShapes is non-empty (filtered to length >= MIN_CLUSTER_SIZE
+    // upstream); fall back to '' for the indexer's undefined branch.
+    const aMin = a.cluster.memberShapes[0]?.file ?? '';
+    const bMin = b.cluster.memberShapes[0]?.file ?? '';
+    return aMin < bMin ? -1 : aMin > bMin ? 1 : 0;
+  });
+  return scored.map((s) => s.cluster);
+}
+
+function distinctivenessVsCovered(
+  clusterShapes: ReadonlyArray<FileShape>,
+  coveredShapes: ReadonlyArray<FileShape>,
+): number {
+  if (coveredShapes.length === 0 || clusterShapes.length === 0) return 1;
+  let sum = 0;
+  let count = 0;
+  for (const cs of clusterShapes) {
+    for (const ov of coveredShapes) {
+      sum += jaccardFromSigs(cs.signature, ov.signature);
+      count += 1;
+    }
+  }
+  return 1 - sum / count;
+}
+
+/**
+ * Bag-of-words summary: top-K n-grams by frequency across the
+ * cluster's member n-gram sets. Joined with ", " for direct
+ * inclusion in the operator-facing manifest field.
+ */
+function bagOfWordsSummary(memberShapes: ReadonlyArray<FileShape>): string {
+  const freq = new Map<string, number>();
+  for (const s of memberShapes) {
+    for (const ng of s.ngrams) {
+      freq.set(ng, (freq.get(ng) ?? 0) + 1);
+    }
+  }
+  // Sort by frequency desc; secondary by n-gram string asc for stability.
+  const top = Array.from(freq.entries())
+    .sort((a, b) => {
+      if (a[1] !== b[1]) return b[1] - a[1];
+      return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+    })
+    .slice(0, SUMMARY_TOP_K)
+    .map(([ng]) => ng);
+  return top.join(', ');
+}
+
+/**
+ * Stable cluster id derived from the sorted member file paths. The
+ * id is deterministic across runs against the same input — useful
+ * for `discovered_candidates` diff against a prior manifest.
+ */
+function stableClusterId(members: ReadonlyArray<string>): string {
+  const sorted = [...members].sort();
+  const joined = sorted.join('|');
+  // Hex-format the FNV-1a hash (seed 0) for a short stable id.
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < joined.length; i += 1) {
+    h = Math.imul(h ^ joined.charCodeAt(i), 16777619);
+  }
+  return `cluster-${(h >>> 0).toString(16).padStart(8, '0')}`;
 }


### PR DESCRIPTION
## Summary

Implements the unmatched-shape clustering algorithm — replaces the STUB at `synthesis-discovered-candidates.ts` that the canary has been hitting in their TF-010 (`scope-widen` always emits `0 additions`).

### Algorithm (per #318 spec; ported from audiocontrol #315)

n-gram (n=3..5) → MinHash(128) → Jaccard similarity ≥ 0.7 → greedy single-link clustering with every-pair threshold check → rank by (size desc, distinctiveness vs covered desc) → bag-of-words top-10 n-grams.

| Step | Detail |
|---|---|
| 1. Coverage set | `findings[*].hits[*].file` union |
| 2. Uncovered set | scans NOT in coverage |
| 3. Signature per file | MinHash(n-grams(tokens)); 128 FNV-1a functions producing a `Uint32Array(128)` |
| 4. Cluster | Jaccard ≥ 0.7, every-pair check (prevents single-link chain merging) |
| 5. Rank | size desc; tiebreak on distinctiveness vs covered shapes |
| 6. Frequency floor | `memberCount >= 3` |
| 7. Shape summary | top-10 n-grams by frequency, comma-joined |

## Verification

- `npx tsc -p plugins/dw-lifecycle --noEmit`: clean.
- Full plugin suite: **1410 / 1410 tests pass** (118 files; +12 new scenarios).
- `npx tsx plugins/dw-lifecycle/src/cli.ts check-clones --gate-mode`: 0 NEW, 0 DROPPED.
- Live `dw-lifecycle scope-inventory --slug scope-discovery`: exit 0; **no `STUB` advisory emitted on stderr** (the algorithm ships; the warning is removed).
- Algorithm complexity bounded for typical uncovered-set sizes (< 1000 files). LSH deferred per spec until the simple algorithm is proven.

## Test coverage (12 scenarios)

- Empty input → empty output.
- All files covered → empty output.
- Fewer than `MIN_CLUSTER_SIZE` uncovered → empty output.
- 3 near-identical files form one cluster; id + members verified.
- 3 near-identical + 3 mutually distinct → one cluster (singletons filtered).
- Two equal-size distinct clusters → ranked by stable tiebreak.
- Cluster id deterministic + stable under member reordering.
- Bag-of-words summary surfaces high-frequency n-grams.
- Files tokenizing to fewer than `NGRAM_MIN` are dropped.
- Comments + string literals don't drive clustering (stripped before tokenization).
- Distinctiveness ranking: equal-size clusters → less-covered-similar ranks above near-miss.
- Mixed covered + uncovered → only uncovered surfaces.

## Closes

- **Closes #318** (the algorithm itself).
- **Closes canary's TF-010** (`scope-widen` always emits 0 additions because clustering is STUB).
- Restores the "manifest grows as features add new shapes" promise the SKILL.md describes for between-task auto-invocation.

## What changed on the user-facing surface

- `pattern-matrix.json`'s `discoveredCandidates` array is now populated from real clustering output (was always `[]` from the STUB).
- The one-time stderr advisory `pattern-matrix: unmatched-shape clustering pass is a STUB (...)` is removed — the algorithm ships, the warning would lie.
- Cluster shape: `{ id: "cluster-<hex8>", shapeSummary: "<top-K n-grams, comma-joined>", members: ["file1", "file2", ...], memberCount: N }`.

## Constraints

- TS strict; under 500-line cap (algorithm: 367 lines; tests: 268 lines).
- Zero `any`, zero `as Type`, zero `@ts-ignore`.
- Pure function (no I/O); composition over `Uint32Array` + `Set<string>` + the existing `SourceFileView` + `PatternFinding` contracts.

## Test plan

- [ ] Verify post-merge that the canary's `scope-widen` against a real feature produces a populated `discoveredCandidates` list (was always empty under v0.24.2).
- [ ] Run `dw-lifecycle scope-inventory` against an audiocontrol-shaped repo (`modules/<editor>/` layout); confirm clusters surface in `pattern-matrix.json` for shape-similar uncovered files.
- [ ] Replay synthesis against the canary's archived `widen-runs/*` evidence dirs (per TF-010's suggested-closure-path) — confirm the clustering algorithm produces operator-recognizable swimlane-vocabulary candidates.
- [ ] Ship as v0.25.0 (new public surface: real `discoveredCandidates` data instead of always-empty array).
