### PR TITLE
fix(scope-discovery): TF-008 + TF-009 — validate-return parser + prelude gotchas

### DIFF
--- a/plugins/dw-lifecycle/src/__tests__/scope-discovery/validate-return.test.ts
+++ b/plugins/dw-lifecycle/src/__tests__/scope-discovery/validate-return.test.ts
@@ -339,3 +339,130 @@ describe('validate-return flag parser', () => {
     expect(parsed.help).toBe(true);
   });
 });
+
+/**
+ * TF-008 (canary 2026-05-28) — Searched-count noun whitelist.
+ *
+ * Real implementer dispatches naturally use descriptive nouns
+ * ("source-emitter call sites", "occurrences", "hits") instead of
+ * the literal "matches". Pre-fix parser required exactly "matches"
+ * and rejected everything else. Fix: accept a whitelist of head
+ * nouns + up to 3 modifier tokens preceding the head.
+ */
+describe('validate-return — TF-008 Searched-count noun whitelist', () => {
+  function responseWithCount(searchedCountPhrase: string): string {
+    return [
+      'Did the work.',
+      '',
+      `Searched: foo-pattern — ${searchedCountPhrase}`,
+      'Included: src/a.tsx:42',
+      'Excluded: src/legacy.tsx:88 — different primitive (CodeMirror)',
+      '',
+    ].join('\n');
+  }
+
+  async function validate(response: string) {
+    return validateReturnForCli({
+      response,
+      agentType: 'implementer',
+      repoRoot: '/nonexistent',
+    });
+  }
+
+  it('accepts the original literal "matches"', async () => {
+    const r = await validate(responseWithCount('2 matches'));
+    expect(r.valid).toBe(true);
+  });
+
+  it('accepts the canary failing case: "2 source-emitter call sites (...)"', async () => {
+    const r = await validate(
+      responseWithCount('2 source-emitter call sites (`swimlane-card.ts`)'),
+    );
+    expect(r.valid).toBe(true);
+  });
+
+  it('accepts synonym nouns: hits, occurrences, instances, sites, files, results, references', async () => {
+    for (const phrase of [
+      '3 hits',
+      '5 occurrences',
+      '7 instances',
+      '4 sites',
+      '2 files',
+      '6 results',
+      '1 reference',
+    ]) {
+      const r = await validate(responseWithCount(phrase));
+      expect(r.valid, `expected accept for: ${phrase}; parseError=${r.parseError}`).toBe(true);
+    }
+  });
+
+  it('accepts up to 3 modifier tokens before head noun', async () => {
+    for (const phrase of [
+      '3 unique occurrences',
+      '2 cross-cutting call sites',
+      '5 distinct source-emitter call sites',
+    ]) {
+      const r = await validate(responseWithCount(phrase));
+      expect(r.valid, `expected accept for: ${phrase}; parseError=${r.parseError}`).toBe(true);
+    }
+  });
+
+  it('rejects nouns outside the whitelist (issues, places, spots, things)', async () => {
+    for (const phrase of [
+      '5 issues found',
+      '7 places',
+      '4 spots',
+      '3 things',
+    ]) {
+      const r = await validate(responseWithCount(phrase));
+      expect(r.valid, `expected reject for: ${phrase}`).toBe(false);
+      expect(r.parseError).toContain('Malformed Searched: count');
+    }
+  });
+
+  it('rejection message names the whitelist so the agent can self-correct', async () => {
+    const r = await validate(responseWithCount('5 widgets'));
+    expect(r.valid).toBe(false);
+    expect(r.parseError).toContain('matches/match/hits');
+    expect(r.parseError).toContain('call sites');
+  });
+});
+
+/**
+ * TF-008 + TF-009 (canary 2026-05-28) — GRAMMAR_INSTRUCTION prelude
+ * documents the three known agent-natural-writing gotchas: noun
+ * whitelist, :LINE-with-:1-sentinel, project-vocabulary collisions.
+ *
+ * Documentation-only assertions; the actual workaround is for the
+ * agent to read these before writing the grammar block.
+ */
+describe('GRAMMAR_INSTRUCTION prelude — TF-008 + TF-009 documentation', () => {
+  it('documents the Searched-count noun whitelist (TF-008)', async () => {
+    const { GRAMMAR_INSTRUCTION } = await import(
+      '../../scope-discovery/dispatch-wrapper.js'
+    );
+    expect(GRAMMAR_INSTRUCTION).toContain('Searched-count noun whitelist');
+    expect(GRAMMAR_INSTRUCTION).toContain('`matches`');
+    expect(GRAMMAR_INSTRUCTION).toContain('`call sites`');
+    expect(GRAMMAR_INSTRUCTION).toContain('modifier tokens');
+  });
+
+  it('documents the :LINE :1 sentinel for whole-file Excluded entries (TF-008 addendum)', async () => {
+    const { GRAMMAR_INSTRUCTION } = await import(
+      '../../scope-discovery/dispatch-wrapper.js'
+    );
+    expect(GRAMMAR_INSTRUCTION).toContain('Excluded entries require');
+    expect(GRAMMAR_INSTRUCTION).toContain(':1');
+    expect(GRAMMAR_INSTRUCTION).toContain('whole-file');
+  });
+
+  it('documents the project-vocabulary collision workaround (TF-009)', async () => {
+    const { GRAMMAR_INSTRUCTION } = await import(
+      '../../scope-discovery/dispatch-wrapper.js'
+    );
+    expect(GRAMMAR_INSTRUCTION).toContain('Forbidden-deferral phrase list');
+    expect(GRAMMAR_INSTRUCTION).toContain('project');
+    expect(GRAMMAR_INSTRUCTION.toLowerCase()).toContain('swim-stub');
+    expect(GRAMMAR_INSTRUCTION).toContain('PURPOSE');
+  });
+});

--- a/plugins/dw-lifecycle/src/scope-discovery/dispatch-grammar.ts
+++ b/plugins/dw-lifecycle/src/scope-discovery/dispatch-grammar.ts
@@ -202,6 +202,22 @@ function findLastBlockStart(text: string, label: string): number {
   return off === undefined ? -1 : off;
 }
 
+/**
+ * Recognized head nouns for the Searched-count phrase. Closes TF-008
+ * (canary 2026-05-28): the parser previously required the literal
+ * "matches"; agents naturally wrote "call sites", "occurrences",
+ * "hits" etc. Accept a whitelist of head nouns, with up to 3
+ * intervening modifier tokens (hyphenated/kebab-case identifiers
+ * like "source-emitter call sites") between the digit and the head.
+ *
+ * The whitelist is deterministic — extending it is a code change,
+ * not a regex-permissiveness slide. To add a noun, append to this
+ * regex AND to the GRAMMAR_INSTRUCTION prelude's noun-whitelist
+ * documentation in dispatch-wrapper.ts.
+ */
+const SEARCHED_COUNT_NOUN_REGEX =
+  /^(\d+)\s+(?:[\w-]+\s+){0,3}(?:match(?:es)?|hits?|occurrences?|instances?|call\s+sites?|sites?|files?|results?|references?)\b/i;
+
 function parseSearchedLine(line: string, rawText: string): SearchedBlock {
   const body = line.replace(/^\s*Searched:\s*/, '');
   const parts = body.split(SEPARATOR_REGEX);
@@ -215,10 +231,13 @@ function parseSearchedLine(line: string, rawText: string): SearchedBlock {
   const first = parts[0];
   const pattern = first === undefined ? '' : first.trim();
   const countPart = parts.slice(1).join(' - ').trim();
-  const countMatch = /^(\d+)\s+match(?:es)?\b/i.exec(countPart);
+  const countMatch = SEARCHED_COUNT_NOUN_REGEX.exec(countPart);
   if (countMatch === null) {
     throw new DispatchRejected(
-      `Malformed Searched: count — expected "<N> matches" but got: ${countPart}`,
+      `Malformed Searched: count — expected "<N> <noun>" where <noun> is one of ` +
+        `matches/match/hits/hit/occurrences/instances/sites/call sites/files/results/references ` +
+        `(optionally preceded by up to 3 modifier tokens, e.g. "2 source-emitter call sites"); ` +
+        `but got: ${countPart}`,
       [],
       rawText,
     );

--- a/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts
+++ b/plugins/dw-lifecycle/src/scope-discovery/dispatch-wrapper.ts
@@ -319,6 +319,43 @@ ${regexesPrompt}.
 If you want to write "for now" or "TODO": STOP. Either include the
 file:line in your fix, or write a permanent-exclusion reason (different
 primitive, deprecated path being deleted, scoped differently, etc.).
+
+### Gotchas — agent-natural writing vs. parser strictness
+
+The parser has three known points where natural agent writing collides
+with strict-format requirements. Read these before writing the block:
+
+1. **Searched-count noun whitelist.** The count after the em-dash
+   must end in one of: \`matches\`, \`match\`, \`hits\`, \`hit\`,
+   \`occurrences\`, \`instances\`, \`sites\`, \`call sites\`,
+   \`files\`, \`results\`, \`references\`. Up to 3 modifier tokens
+   are permitted before the head noun (e.g. \`2 source-emitter call
+   sites\`, \`3 unique occurrences\`). Anything outside this set is
+   rejected — \`5 issues found\`, \`7 places\`, \`4 spots\` all fail.
+
+2. **Excluded entries require \`path:LINE\`.** Every Excluded
+   citation must carry a line number. For whole-file exclusions
+   (the exclusion is structural, not anchored to a specific line),
+   use \`:1\` as the conventional sentinel and explain the whole-
+   file nature in the reason:
+       Excluded: test/dashboard.test.ts:1 — test-file references
+       are assertions, not production code under review.
+   Don't omit \`:LINE\`; the parser rejects.
+
+3. **Forbidden-deferral phrase list collides with project
+   vocabulary.** If a project's canonical class name or function
+   contains a deferral-class word (e.g. \`.swim-stub\` /
+   \`renderSwimStub\` / \`.placeholder-tile\`), describe the
+   affordance's PURPOSE rather than its CANONICAL NAME in the
+   Excluded reason. Example:
+       OK:    Excluded: src/swimlane-card.ts:330 — focus-off
+              compact button for filtered-out lanes (not a stage-
+              bearing body)
+       FAIL:  Excluded: src/swimlane-card.ts:330 — renderSwimStub
+              is the focus-off stub button   ← contains "stub"
+   The parser's substring match doesn't distinguish proper-noun
+   usage from deferral usage; the workaround is to talk about what
+   the code DOES, not what it's CALLED.
 `;
 }
 


### PR DESCRIPTION
## Summary

Two LOW-severity findings from the graphical-entries canary against v0.24.2 — both `validate-return` parser strictness vs. agent-natural-writing collisions. Same fix-class: relax the parser where it clashes with reasonable agent prose; document the remaining strictness in `GRAMMAR_INSTRUCTION` so the agent sees the constraint up front.

### TF-008 — Searched-count noun whitelist (Medium)

Pre-fix: parser required the literal noun `matches` after the digit count. Real dispatches naturally wrote "source-emitter call sites" / "occurrences" / "hits" — all rejected.

**Fix:** `SEARCHED_COUNT_NOUN_REGEX` now accepts a deterministic whitelist: `match(es)?`, `hits?`, `occurrences?`, `instances?`, `sites?` / `call sites?`, `files?`, `results?`, `references?`. Up to 3 modifier tokens (`source-emitter`, `unique`, `distinct`) permitted before the head noun. Rejection message names the whitelist so the agent can self-correct.

### TF-008 addendum — `:LINE` requirement on whole-file Excluded entries (Light)

**Fix:** kept the parser strict (the structural shape is load-bearing). Added `GRAMMAR_INSTRUCTION` paragraph naming `:1` as the conventional sentinel for whole-file exclusions, with an example.

### TF-009 — forbidden-phrase / project-vocabulary collision (Light)

`FORBIDDEN_DEFERRAL_PHRASES` includes `"stub"` + `"placeholder"`. Projects using these as canonical CSS class names (`.swim-stub`, `renderSwimStub`) saw the substring match correctly fire on legitimate references.

**Fix:** kept the phrase list as-is (substring match is load-bearing for deferral detection). Added `GRAMMAR_INSTRUCTION` paragraph showing the workaround: describe the affordance's PURPOSE in the Excluded reason, not its CANONICAL NAME. Example uses the swim-stub case verbatim.

### GRAMMAR_INSTRUCTION prelude grew 43 → 80 lines

New "Gotchas — agent-natural writing vs. parser strictness" section near the end of the prelude documents all three known points where the parser is stricter than agents naturally write. Visible to every dispatched sub-agent via `wrap-prompt`.

## Verification

- `npx tsc -p plugins/dw-lifecycle --noEmit`: clean.
- Full plugin suite: **1419 / 1419 tests pass** (118 files; +9 new scenarios).
- `npx tsx plugins/dw-lifecycle/src/cli.ts check-clones --gate-mode`: 0 NEW, 0 DROPPED.
- Live `dw-lifecycle wrap-prompt --agent-type implementer`: 80-line prompt with the new Gotchas section.
- Live `dw-lifecycle validate-return` against the canary's exact failing phrasing (`2 source-emitter call sites (\`swimlane-card.ts\`)`): returns `valid: true`. Same response under v0.24.2 returned `valid: false`.

## Test coverage (9 new scenarios)

- TF-008 noun whitelist:
  - literal "matches" still accepted (back-compat)
  - canary's failing case "2 source-emitter call sites (...)" accepted
  - synonyms accepted (hits/occurrences/instances/sites/files/results/references)
  - modifier tokens accepted (unique/distinct/source-emitter)
  - whitelist-violations rejected (issues/places/spots/things)
  - rejection message names the whitelist
- TF-008+TF-009 documentation: prelude contains all three gotcha callouts (noun whitelist, `:1` sentinel, project-vocabulary workaround)

## Closes

- **Closes TF-008** (Searched-count noun strictness + `:LINE` requirement)
- **Closes TF-009** (forbidden-phrase / project-vocabulary collision)

The canary's status table can mark both Closed against this commit.

## Status against canary's full TF doc

| TF | Status | Note |
|---|---|---|
| TF-001 | Open (per canary table) — but shipped v0.24.1 | Canary re-test pending |
| TF-002 | Open (per canary table) — but shipped v0.24.1 | Canary re-test pending |
| TF-003 | Open (per canary table) — but shipped v0.24.1 | Canary re-test pending |
| TF-004 | Closed v0.24.2 | |
| TF-005 | Closed v0.24.2 | |
| TF-006 | Closed v0.24.1 | |
| TF-007 | Closed v0.24.1 | |
| **TF-008** | **Closed by this PR** | |
| **TF-009** | **Closed by this PR** | |
| TF-010 | Closed by #322 (#318 clustering algorithm) — canary status-table not yet updated | |

## Test plan

- [ ] Verify post-merge that the canary's next implementer dispatch with descriptive noun phrasing passes `validate-return` end-to-end.
- [ ] Verify a real Excluded line with `:1` sentinel against a whole-file exclusion validates.
- [ ] Verify the `swim-stub` workaround pattern (describe-purpose) passes against the existing forbidden-phrase list.
- [ ] Ship as v0.24.3.
