### PR TITLE
docs(scope-discovery): scrub lone Phase 11 vocab leak (nucleation-site cleanup)

### DIFF
--- a/plugins/dw-lifecycle/src/scope-discovery/discovery-agents/synthesis-discovered-candidates.ts
+++ b/plugins/dw-lifecycle/src/scope-discovery/discovery-agents/synthesis-discovered-candidates.ts
@@ -166,10 +166,10 @@ function buildShape(view: SourceFileView): FileShape | null {
  * Strip comments + string literals; tokenize on non-alphanumeric.
  *
  * The stripping is heuristic, not language-aware (we accept .ts,
- * .tsx, .md, .css, .yaml, .json, .html — see Phase 11 multi-content-
- * type support). For language-aware tokenization (e.g. JSX-aware
- * unwrapping of attribute values), an AST tokenizer would replace
- * this; not in scope for #318.
+ * .tsx, .md, .css, .yaml, .json, .html — the same content types the
+ * scan engine handles uniformly via the polymorphic dispatcher). For
+ * language-aware tokenization (e.g. JSX-aware unwrapping of attribute
+ * values), an AST tokenizer would replace this; not in scope for #318.
  */
 function tokenize(text: string): string[] {
   const stripped = text


### PR DESCRIPTION
One-line docstring tweak in `synthesis-discovered-candidates.ts`. The v0.24.1 Phase 11 vocabulary purge couldn't cover this comment because the file was written afterward (during the #318 clustering algorithm work). Per agent-discipline § 'Just for now is bullshit' nucleation-site framing: a single leak becomes the justification for the next one. Scrubbed at first sight.

## Verification

- `npx tsc -p plugins/dw-lifecycle --noEmit`: clean.
- Tests still pass.
- `grep -i 'phase 11\|phase 12' plugins/ --include='*.ts'`: zero refs in production code.
- No behavior change (docstring-only).