### PR TITLE
feat(hygiene Phase 10 + #342): npm Trusted Publisher CI workflow + complete-parent-closure walker fix (v0.26.2 target)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: release
-description: Release the deskwork monorepo (bump → publish → smoke → tag → push). Hard-gated procedure with operator pauses at version, post-bump diff, npm publish, tag message, and final push. Project-internal — for monorepo maintainers, not adopters.
+description: Release the deskwork monorepo (bump → tag → push → CI publishes). Hard-gated procedure with operator pauses at version, post-bump diff, tag message, and final push. CI handles publish + smoke via npm Trusted Publisher (OIDC). Project-internal — for monorepo maintainers, not adopters.
 ---
 
 # Release
 
-Ship a new version of the deskwork monorepo. Hard-gated. The skill runs preconditions, prompts for version, bumps + commits, publishes `@deskwork/{core,cli,studio}@<version>` to npm, runs the smoke gate against the published packages, prompts for tag message, asks for explicit confirmation, then atomic-pushes the commit + branch + tag in one operation.
+Ship a new version of the deskwork monorepo. Hard-gated. The skill runs preconditions, prompts for version, bumps + commits, drafts the tag message, and atomic-pushes the commit + branch + tag in one operation. The tag push triggers `.github/workflows/publish-npm.yml`, which publishes `@deskwork/{core,cli,studio}@<version>` via OIDC, asserts they're on the registry, and runs the marketplace smoke gate. The skill waits for the workflow to complete (`gh run watch`) and reports the release URL.
+
+Pass `--skip-publish-wait` when the operator handled publish manually via `make publish` (the documented fallback when CI is broken) — the skill skips the workflow-watch step.
 
 ## Pre-1.0 maturity stance
 
@@ -13,7 +15,7 @@ This skill pushes directly to `origin/main` (no PR-merge, no CI gate). Deliberat
 
 ## Steps for the agent
 
-The agent invokes the helper subcommands listed below and surfaces operator prompts at the four pause points. **No `--force` / `--skip-smoke` overrides — all gates are hard.**
+The agent invokes the helper subcommands listed below and surfaces operator prompts at four pause points (precondition → diff → tag message → push + workflow-watch). **No `--force` / `--skip-smoke` overrides — all gates are hard.** The only flag the skill itself accepts at invocation is `--skip-publish-wait`, which bypasses the workflow-watch step for the CI-broken recovery path documented below.
 
 ### Pause 1 — Precondition + version
 
@@ -44,63 +46,21 @@ The agent invokes the helper subcommands listed below and surfaces operator prom
 5. On `y`: `git commit -am "chore: release v<version>"`.
 6. On `n`: abort. Bumped manifests stay in the working tree. Operator decides whether to revert (`git restore .`) or fix something and re-run.
 
-### Pause 3 — Publish to npm
+### Pause 3 — Tag message (CI publishes on tag-push)
 
-The smoke gate (next pause) runs `npm install @deskwork/<pkg>@<version>` against the public registry, so the new version must be published BEFORE smoke runs. This pause publishes all three `@deskwork/*` packages.
+Publish is no longer a Pause-3 manual step. `.github/workflows/publish-npm.yml` auto-publishes via npm Trusted Publisher (OIDC) on every `v*` tag push. The smoke gate (`scripts/smoke-marketplace.sh`) and the `assert-published` registry check both run as workflow steps after publish. Pause 3 is now the tag-message draft + the workflow-watch wait.
 
-1. Verify no package is already at the new version (catches the "version already published" case before any OTPs are typed):
+**Recovery shortcut.** When the operator already published manually via `make publish` (because CI was broken), invoke `/release --skip-publish-wait`. The skill skips Pause 4's workflow-watch and proceeds directly to release-view. See § "Recovery — CI is broken" below for the full manual-fallback procedure.
+
+1. Verify no package is already at the new version (catches the "version already published" case before the tag goes out — npm rejects the workflow's publish step otherwise):
 
    ```
    tsx .claude/skills/release/lib/release-helpers.ts assert-not-published <version>
    ```
 
-2. On non-zero exit: surface stderr (lists which package(s) are already at `<version>`) and abort. The chore-release commit stays in place. Operator must bump to a new version (`git reset --soft HEAD~1`, then re-run `/release` with a new version) — npm forbids republishing the same version, so this isn't recoverable in-place.
+2. On non-zero exit: surface stderr (lists which package(s) are already at `<version>`) and abort. The chore-release commit stays in place. Operator must bump to a new version (`git reset --soft HEAD~1`, then re-run `/release` with a new version) — npm forbids republishing the same version.
 
-3. On zero exit: surface the operator-side instructions and wait for confirmation.
-
-   **Important — the agent does NOT run `make publish` itself.** `npm publish` prompts for a 2FA OTP on stdin per package, and the agent's Bash tool cannot pass interactive prompts through to the operator's terminal. Running it from the agent context blocks indefinitely. The publish must happen in the operator's own terminal, with the agent waiting on confirmation.
-
-   Surface this verbatim:
-
-   ```
-   ──────────────────────────────────────────────────────────────────
-   Publish step — RUN IN YOUR OWN TERMINAL (not through the agent):
-
-     cd <repo-root>
-     make publish
-
-   This publishes (in dependency order, with one 2FA OTP per package):
-     @deskwork/core@<version>
-     @deskwork/cli@<version>
-     @deskwork/studio@<version>
-
-   Three OTPs total. When all three succeed, reply with 'done' (or any
-   confirmation) and the agent will verify and continue. If any package
-   fails, paste the error.
-   ──────────────────────────────────────────────────────────────────
-   ```
-
-4. **Wait for the operator's confirmation** before any further action. Do NOT auto-poll npm view, do NOT spawn `make publish` via Bash — wait for the operator to say it's done.
-
-5. On operator confirmation: verify all three are now on the registry:
-
-   ```
-   tsx .claude/skills/release/lib/release-helpers.ts assert-published <version>
-   ```
-
-   - On zero exit: continue to Pause 4.
-   - On non-zero exit: surface stderr (lists which package(s) are still missing). Possible causes: partial-publish state (some succeeded, some failed), registry CDN propagation delay (rare; usually resolves within seconds), or operator confirmed prematurely. Either ask the operator to retry the missing package(s) and reconfirm, OR — if the gap is genuinely partial-publish unrecoverable — abort with the same recovery guidance as below.
-
-6. On operator-reported failure: abort.
-   - If the failure was an early package (e.g., core failed before cli or studio), nothing is published; operator can re-run `make publish` once they fix the underlying issue, then reconfirm.
-   - If a partial-publish state results (e.g., core published but cli's OTP rejected), surface that fact. Recovery options: bump to v<next-patch> + re-run `/release` (cleanest — the half-published version stays orphaned on npm, which is fine), OR finish the publish manually with `make publish-cli publish-studio` then re-run `/release` from a fresh tree.
-   - Do NOT continue past this pause on partial failure. Smoke would fail anyway.
-
-### Pause 4 — Smoke + tag message
-
-1. Run: `bash scripts/smoke-marketplace.sh` (output streamed to operator).
-2. On smoke fail: abort. Surface tail of smoke log. Working-tree state preserved (commit + npm-published packages remain). Recovery: a smoke failure post-publish is a `bump-to-next-patch + re-run` situation (the broken version stays orphaned on npm). Operator decides.
-3. On smoke pass: draft a tag message:
+3. On zero exit: draft a tag message:
    - Default: subject of the most recent commit on the branch whose subject does NOT start with `chore: release ` (lookback up to 20 commits). Falls back to `deskwork v<version>`.
    - Show the default and prompt:
 
@@ -111,7 +71,7 @@ The smoke gate (next pause) runs `npm install @deskwork/<pkg>@<version>` against
 
 4. Operator types message or accepts default. Then: `git tag -a v<version> -m "<message>"`.
 
-### Pause 5 — Final push confirmation
+### Pause 4 — Final push + workflow watch
 
 1. Check the published-tag gate:
    ```bash
@@ -129,19 +89,59 @@ The smoke gate (next pause) runs `npm install @deskwork/<pkg>@<version>` against
      - HEAD → origin/<current-branch>
      - tag v<version> → origin
 
-   This is non-reversible after success: v<version> will be visible to
-   adopters running '/plugin marketplace update deskwork'.
+   The tag push triggers .github/workflows/publish-npm.yml, which:
+     - publishes @deskwork/{core,cli,studio}@<version> via OIDC
+     - runs assert-published
+     - runs scripts/smoke-marketplace.sh
+
+   Non-reversible after the workflow succeeds.
 
    Run push? [y/N]
    >
    ```
 
 4. On `y`: `tsx .claude/skills/release/lib/release-helpers.ts atomic-push v<version> <current-branch>`.
-5. On push success:
-   - Run `gh release view v<version>` (the workflow may not have finished — show whatever is available; advise the operator to `gh run watch` for the workflow status).
-   - Report the release URL.
-6. On push fail: abort. Surface git's stderr. Local commit + tag intact. Operator can fix (e.g. fetch + rebase if origin/main moved) and re-run; the skill will detect the existing local tag.
-7. On `n`: abort. Local state preserved.
+5. On push success: watch the publish workflow (skip when `--skip-publish-wait` was passed at skill invocation):
+
+   ```
+   gh run list --workflow=publish-npm.yml --limit=5 --json databaseId,headSha,event,status,conclusion,createdAt
+   ```
+
+   - Match the just-pushed run by `headSha == <pushed-HEAD-SHA>` AND `event == "push"`. If multiple, take the most recent.
+   - `gh run watch <run-id>` with a 15-minute timeout.
+   - On `conclusion == success`: proceed to release-view step.
+   - On `conclusion == failure`: surface the workflow logs URL (`gh run view <run-id> --web`) and advise the operator to investigate. Do NOT auto-retry. Do NOT delete the tag. See § "Recovery — CI is broken" for next steps.
+   - On timeout: surface the workflow URL; advise the operator to watch it themselves and re-run `/release --skip-publish-wait` once the workflow finishes.
+
+6. On workflow success (or when `--skip-publish-wait`): run `gh release view v<version>` and report the release URL.
+7. On push fail: abort. Surface git's stderr. Local commit + tag intact. Operator can fix (e.g. fetch + rebase if origin/main moved) and re-run; the skill will detect the existing local tag.
+8. On `n` at push prompt: abort. Local state preserved.
+
+### Recovery — CI is broken
+
+When the `publish-npm.yml` workflow fails (npm outage, OIDC misconfiguration, transient flake) or the operator wants a one-off out-of-band publish, fall back to `make publish`:
+
+1. **Determine published state** — for each package, check what npm shows:
+   ```
+   npm view @deskwork/core versions --json | jq '.[-1]'
+   npm view @deskwork/cli  versions --json | jq '.[-1]'
+   npm view @deskwork/studio versions --json | jq '.[-1]'
+   ```
+2. **Nothing published yet** (workflow failed before publish step): the chore-release commit + tag are still local-only IF you haven't pushed yet. If you HAVE pushed, the tag is on origin but no npm artifacts ship. Revert the bump commit (`git reset --soft HEAD~1`), fix the underlying issue, re-run `/release`.
+3. **Partial publish** (e.g. core succeeded, cli failed mid-flight): the safest path is to bump to v<next-patch> + re-run `/release`. The half-published version stays orphaned on npm (npm forbids republishing the same version anyway). Document the orphaned version in the release notes.
+4. **All three published, but workflow failed at smoke or assert-published**: the artifacts are reachable by adopters; what failed was the post-publish gate. Investigate the workflow logs; re-run the smoke locally (`bash scripts/smoke-marketplace.sh`); if smoke passes locally, the gap is CI-side and the release is salvageable.
+5. **Manual publish flow** (used during recovery OR for one-off out-of-band publishes):
+   ```
+   make publish      # token-auth, prompts for 2FA OTP per package
+   ```
+   `make publish` reads `~/.config/deskwork/npm-credentials.txt`. It publishes WITHOUT provenance (the manual path uses token auth; provenance requires the OIDC env that only the workflow has). The artifacts ship; adopters get them; the npm-side trusted-publisher attestation is the only thing missing for that release.
+6. **Resume `/release` after manual publish**: invoke `/release --skip-publish-wait`. The skill skips Pause 4's workflow-watch step (since the operator already handled publish out-of-band).
+
+### Flow shape after Phase 10
+
+The release flow used to walk five pauses (precondition → diff → manual publish → local smoke → push). Phase 10 of `feature/hygiene` (npm Trusted Publisher CI workflow) collapsed the manual-publish + local-smoke pauses into CI-owned steps. The agent now walks four pauses: precondition (Pause 1) → diff (Pause 2) → tag message (Pause 3) → push + workflow-watch (Pause 4).
+
+The `--skip-publish-wait` flag is the recovery escape hatch: pass it when the operator handled publish manually via `make publish` and the workflow-watch step is therefore moot.
 
 ## Helper subcommands
 
@@ -151,8 +151,8 @@ All helpers live in `.claude/skills/release/lib/release-helpers.ts` and are invo
 |---|---|---|
 | `check-preconditions` | Verify clean tree, FF over origin/main, branch up-to-date. Prints status line. | 0 ok / 1 fail / 2 usage |
 | `validate-version <ver> <last-tag>` | Pure semver tuple compare. Strictly greater required. | 0 ok / 1 fail (reason on stderr) / 2 usage |
-| `assert-not-published <ver>` | Verify `@deskwork/{core,cli,studio}@<ver>` are NOT yet published on npm (pre-flight before `make publish`). Calls `npm view` per package. | 0 ok / 1 fail (lists already-published packages on stderr) / 2 usage |
-| `assert-published <ver>` | Verify `@deskwork/{core,cli,studio}@<ver>` ARE published on npm (post-flight after the operator runs `make publish` in their terminal). Calls `npm view` per package. | 0 ok / 1 fail (lists missing packages on stderr) / 2 usage |
+| `assert-not-published <ver>` | Verify `@deskwork/{core,cli,studio}@<ver>` are NOT yet published on npm. Pre-flight gate at Pause 3 so the tag-triggered workflow doesn't fail mid-publish on a duplicate version. Calls `npm view` per package. | 0 ok / 1 fail (lists already-published packages on stderr) / 2 usage |
+| `assert-published <ver>` | Verify `@deskwork/{core,cli,studio}@<ver>` ARE published on npm. Used as a workflow step inside `.github/workflows/publish-npm.yml` after the publish step. The skill itself relies on `gh run watch` for end-of-publish signal. Calls `npm view` per package. | 0 ok / 1 fail (lists missing packages on stderr) / 2 usage |
 | `atomic-push <tag> <branch>` | Single-RPC push: HEAD to origin/main, HEAD to branch, annotated tag. | 0 ok / 1 fail (git stderr surfaced) |
 
 Tests live at `.claude/skills/release/test/`. Run via `cd .claude/skills/release && npx vitest run` (local-only; not in CI per project rules).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Release the deskwork monorepo (bump → tag → push → CI publishes). Hard-gated procedure with operator pauses at version, post-bump diff, tag message, and final push. CI handles publish + smoke via npm Trusted Publisher (OIDC). Project-internal — for monorepo maintainers, not adopters.
+description: Release the deskwork monorepo (bump → tag → push → CI publishes). Hard-gated procedure with operator pauses at version, post-bump diff, tag message, and final push. CI handles publish + smoke via npm Trusted Publisher (OIDC). Pass `--skip-publish-wait` to bypass the workflow-watch step when the operator already published manually via `make publish`. Project-internal — for monorepo maintainers, not adopters.
 ---
 
 # Release

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -40,9 +40,17 @@ jobs:
       - name: Install workspaces
         run: npm ci
 
-      - name: Build workspaces
-        run: npm run build
-
+      # No standalone build step here on purpose. `npm publish` invokes
+      # each package's `prepack` script automatically (per-package: tsc
+      # build + auxiliary file copies + chmod on bin entries), and the
+      # `prepack` script in every packages/<pkg>/package.json is the
+      # authoritative build for that package. A separate `npm run build`
+      # step would duplicate that work AND create a drift surface — if
+      # build and prepack diverge, the published artifact is ambiguous.
+      # The root build also runs scripts/link-workspace-bins.sh, which is
+      # for local test spawn of node_modules/.bin/deskwork; npm publish
+      # does not read those symlinks (it consumes each package's own
+      # `bin` field), so the symlink side effect is not needed pre-publish.
       - name: Publish all @deskwork packages (OIDC, dep-ordered)
         run: make publish-ci
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,59 @@
+name: Publish to npm
+
+# Auto-publishes @deskwork/{core,cli,studio} to npm when a v* tag lands on
+# origin. Uses npm's Trusted Publisher (OIDC) flow — no NPM_TOKEN secret.
+# Each @deskwork/* package on npmjs.com has a Trusted Publisher entry
+# pointing at this workflow file's path; that entry plus the
+# `id-token: write` permission below is what authorizes the publish.
+#
+# The /release skill's atomic-push step is the operator's approval moment
+# (the tag IS the trigger). `make publish` stays as a documented manual
+# fallback for outages or one-off out-of-band publishes; see RELEASING.md
+# § "Recovery — CI is broken".
+#
+# Per the project rule (.claude/rules/agent-discipline.md § "No test
+# infrastructure in CI"), this workflow ONLY runs the release-blocking
+# gates (publish → assert-published → marketplace smoke). It is NOT a
+# stand-in for the per-package vitest suite, which the operator runs
+# locally as part of /release.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install workspaces
+        run: npm ci
+
+      - name: Build workspaces
+        run: npm run build
+
+      - name: Publish all @deskwork packages (OIDC, dep-ordered)
+        run: make publish-ci
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Extract version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Assert all three packages published
+        run: npx tsx .claude/skills/release/lib/release-helpers.ts assert-published "${{ steps.ver.outputs.version }}"
+
+      - name: Marketplace smoke
+        run: bash scripts/smoke-marketplace.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,19 @@ name: release
 # page on GitHub is the consumer-facing record of what changed between
 # versions.
 #
-# No tests, no smoke, no marketplace verification. Per the project's
-# `.claude/rules/agent-discipline.md`: "No test infrastructure in CI."
-# The local smoke (`scripts/smoke-marketplace.sh`) is the release-blocking
-# gate; it runs in the operator's `/release` flow before the tag is
-# pushed. CI does not publish to npm — the operator publishes manually
-# via `make publish` from their terminal.
+# Scope: GitHub-release-notes only. This workflow does NOT publish to
+# npm — that authority lives in the sibling workflow
+# `.github/workflows/publish-npm.yml`, which fires on the SAME `v*`
+# tag-push trigger and runs in parallel. publish-npm.yml owns the npm
+# publish (via Trusted Publisher / OIDC), the post-publish
+# `assert-published` registry check, AND the release-blocking marketplace
+# smoke (`scripts/smoke-marketplace.sh`). See `RELEASING.md` §
+# "npm-publish architecture" + § "Trusted Publisher setup".
+#
+# Per the project's `.claude/rules/agent-discipline.md` rule
+# "No test infrastructure in CI", this workflow runs no tests or smoke
+# of its own — the workspace vitest suites are operator-run locally
+# before tagging.
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: publish publish-core publish-cli publish-studio
+.PHONY: publish publish-core publish-cli publish-studio publish-ci publish-ci-core publish-ci-cli publish-ci-studio
 
 # Publish all three @deskwork/* packages to npm at the version currently in
 # each packages/<pkg>/package.json. Sources the npm token from
@@ -9,11 +9,18 @@ NPM_TOKEN_FILE := $(HOME)/.config/deskwork/npm-credentials.txt
 # Each target writes a temp .npmrc with the token, points npm at it via
 # NPM_CONFIG_USERCONFIG, runs publish, then removes the temp file (in a
 # trap so it's removed even on failure / OTP cancel).
+#
+# --no-provenance is required for the manual fallback path: package.json's
+# publishConfig.provenance: true is honored by `npm publish` and requires
+# an OIDC environment (npm refuses provenance attestation from a token-
+# auth publish). The CI path (publish-ci targets below) runs under OIDC
+# and emits provenance automatically; the manual emergency-fallback path
+# publishes without provenance and the operator accepts the gap.
 define PUBLISH_PKG
 	@TMP_NPMRC=$$(mktemp -t deskwork-npmrc.XXXXXX); \
 	trap "rm -f $$TMP_NPMRC" EXIT; \
 	printf '//registry.npmjs.org/:_authToken=%s\n' "$$(cat $(NPM_TOKEN_FILE))" > $$TMP_NPMRC; \
-	NPM_CONFIG_USERCONFIG=$$TMP_NPMRC npm publish --access public --workspace @deskwork/$(1)
+	NPM_CONFIG_USERCONFIG=$$TMP_NPMRC npm publish --access public --no-provenance --workspace @deskwork/$(1)
 endef
 
 publish: publish-core publish-cli publish-studio
@@ -26,3 +33,21 @@ publish-cli:
 
 publish-studio:
 	$(call PUBLISH_PKG,studio)
+
+# CI path: npm Trusted Publisher (OIDC). No token file, no ephemeral
+# .npmrc — `npm publish` picks up the OIDC token from the GitHub Actions
+# environment when the workflow has `id-token: write` permission AND the
+# package on npmjs.com has a Trusted Publisher entry pointing at the
+# workflow file. The `publish-ci` target is what
+# .github/workflows/publish-npm.yml invokes; the bare `publish` target
+# stays as the operator's manual fallback (token + 2FA OTP per package).
+publish-ci: publish-ci-core publish-ci-cli publish-ci-studio
+
+publish-ci-core:
+	npm publish --workspace @deskwork/core
+
+publish-ci-cli:
+	npm publish --workspace @deskwork/cli
+
+publish-ci-studio:
+	npm publish --workspace @deskwork/studio

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,17 +4,59 @@ The deskwork marketplace tracks the default branch of `audiocontrol-org/deskwork
 
 ### To release: `/release`
 
-The release ceremony is enshrined as the `/release` skill at `.claude/skills/release/`. Run that — it handles version validation, smoke, tagging, and the atomic push. The skill is hard-gated: no `--force`, no `--skip-smoke`. If a gate refuses, fix the underlying state.
+The release ceremony is enshrined as the `/release` skill at `.claude/skills/release/`. Run that — it handles version validation, tagging, and the atomic push. The publish + smoke gates run inside `.github/workflows/publish-npm.yml` (triggered by the tag push). The skill is hard-gated: no `--force`, no `--skip-smoke`. If a gate refuses, fix the underlying state.
 
-The skill walks five operator decision points:
+The skill walks four operator decision points:
 
 1. **Precondition + version** — clean tree, FF over origin/main, branch up-to-date. Operator types the new version; skill validates it as strictly greater than the last tag.
 2. **Post-bump diff review** — operator confirms the manifest bump diff before commit.
-3. **Publish to npm** — skill verifies `@deskwork/{core,cli,studio}@<version>` are NOT yet published (catches "version already published" before any OTPs); operator runs `make publish` **in their own terminal** (the agent's Bash tool can't accept interactive 2FA OTPs); operator confirms when done; skill verifies all three are now on the registry before continuing.
-4. **Smoke + tag message** — `scripts/smoke-marketplace.sh` runs as a hard gate against the just-published packages; on pass, operator confirms the tag message.
-5. **Final push confirmation** — skill prints the exact push command + what it will do; operator confirms; skill atomic-pushes commit + branch + tag in one `git push --follow-tags` RPC.
+3. **Tag message** — skill verifies `@deskwork/{core,cli,studio}@<version>` are NOT yet published on npm (catches "version already published" before the tag goes out); operator confirms the tag message; skill creates the annotated tag.
+4. **Push + workflow watch** — skill prints the exact push command; operator confirms; skill atomic-pushes commit + branch + tag in one `git push --follow-tags` RPC. The tag push fires `publish-npm.yml`, which publishes all three packages via OIDC, asserts they're on the registry, and runs `scripts/smoke-marketplace.sh`. The skill watches the workflow via `gh run watch` and reports the release URL on success.
 
 The skill refuses to re-tag a published version. Recovery from a botched release is to bump-patch (e.g. `v0.9.0` broken → ship `v0.9.1`).
+
+### Trusted Publisher setup (one-time per package on npmjs.com)
+
+`.github/workflows/publish-npm.yml` authenticates to npm via OIDC, not a token. For npm to honor the workflow's OIDC token, each `@deskwork/*` package on npmjs.com must have a Trusted Publisher entry pointing at this workflow file. Do this once per package:
+
+1. Sign in to npmjs.com.
+2. Navigate to the package page (e.g. `https://www.npmjs.com/package/@deskwork/core`).
+3. Settings → Publishing access (or "Trusted Publishers").
+4. Add trusted publisher:
+   - Publisher: GitHub Actions
+   - Organization: `audiocontrol-org`
+   - Repository: `deskwork`
+   - Workflow filename: `publish-npm.yml`
+   - Environment: (leave blank)
+5. Save.
+
+Repeat for all three packages: `@deskwork/core`, `@deskwork/cli`, `@deskwork/studio`.
+
+The workflow filename is a contract — renaming `publish-npm.yml` requires re-registering the trusted publisher on each package. Keep the path stable.
+
+### Recovery — CI is broken
+
+When the `publish-npm.yml` workflow fails (npm outage, OIDC misconfiguration, transient flake) or the operator wants a one-off out-of-band publish, fall back to `make publish`:
+
+1. **Determine published state** — for each package:
+   ```
+   npm view @deskwork/core versions --json | jq '.[-1]'
+   npm view @deskwork/cli  versions --json | jq '.[-1]'
+   npm view @deskwork/studio versions --json | jq '.[-1]'
+   ```
+2. **Nothing published yet**: revert the bump commit (`git reset --soft HEAD~1`), fix the underlying issue, re-run `/release`. If the tag already went to origin, the npm artifacts are missing but the git tag stands; bump-patch the next release.
+3. **Partial publish state** (some packages succeeded, others failed): the safest path is to bump to v<next-patch> + re-run `/release`. The half-published version stays orphaned on npm — npm forbids republishing the same version anyway. Document the orphaned version in the next release notes.
+4. **Manual publish path**:
+   ```
+   make publish      # token-auth, prompts for 2FA OTP per package
+   ```
+   `make publish` reads the npm token from `~/.config/deskwork/npm-credentials.txt`, writes an ephemeral `.npmrc`, and publishes WITHOUT provenance (the manual path uses token auth; provenance attestation requires the OIDC env that only the workflow has). The artifacts reach adopters; the npm-side trusted-publisher attestation is the only thing missing for that release.
+5. **One-off publish of a single package** (out-of-band fix, no full release):
+   ```
+   make publish-core      # or publish-cli / publish-studio
+   ```
+   Use sparingly. Most fixes should go through a full release.
+6. **Resume `/release` after manual publish** (when CI succeeded at every step except the publish): invoke `/release --skip-publish-wait`. The skill skips Pause 4's workflow-watch step (since the operator already handled publish out-of-band) and proceeds directly to `gh release view`.
 
 ### Maturity stance
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,30 +84,32 @@ The skill currently pushes directly to `origin/main` (no PR-merge, no CI-as-seco
 
 **When to introduce release branches**: at 1.0 stabilization, when the project starts supporting v1.x bugfixes alongside v2.x development. `release/v1.x` then becomes a real maintenance branch with its own backport policy. Mark this as a deferred decision; the trunk-based model holds for now.
 
-### npm-publish architecture (Phase 26, v0.9.5+)
+### npm-publish architecture
 
 Plugin runtime code ships as published npm packages under the `@deskwork/*` scope: `@deskwork/core`, `@deskwork/cli`, `@deskwork/studio`. Plugin trees themselves are thin shells (`bin/` + `skills/` + `plugin.json`) that first-run-install the corresponding package from the public registry.
 
 The plugin shell's `plugin.json` `version` field is kept in lockstep with the published npm package version. `scripts/bump-version.ts` bumps both atomically, plus the per-plugin shell `package.json#dependencies` pin (e.g. `"@deskwork/cli": "0.9.5"`), so the entire repo moves to the same version in one commit.
 
-**Publish path (driven by `/release`, executed in the operator's terminal):** the publish step is the third pause of the `/release` flow.
+**Publish path (CI-driven via npm Trusted Publisher / OIDC):** `.github/workflows/publish-npm.yml` is triggered by every `v*` tag push and runs the publish + post-publish gates in CI. The workflow is the publish authority; the `/release` skill's atomic tag push is the operator's approval moment.
 
-1. The skill verifies the version is not yet on npm (`assert-not-published`).
-2. The skill prints clear instructions and **the operator runs `make publish` in their own terminal**. The agent's Bash tool can't accept interactive stdin (2FA OTP prompts) — running it from the agent context would hang. `make publish` sources an npm token from `~/.config/deskwork/npm-credentials.txt`, writes an ephemeral `.npmrc` per `npm publish`, and prompts for one 2FA OTP per package (three total).
-3. When all three packages are published, the operator confirms in chat ("done") and the skill runs `assert-published` to verify the registry actually has all three. Only then does it proceed to the smoke gate.
+1. The `/release` skill verifies the version is not yet on npm (`assert-not-published`) BEFORE the tag goes out, so the workflow doesn't fail mid-publish on a duplicate version.
+2. The operator confirms the push prompt; the skill runs `git push --follow-tags`, which lands the tag on origin and fires `publish-npm.yml`.
+3. The workflow checks out the tagged commit, runs `npm ci`, then `make publish-ci` — which calls `npm publish --workspace @deskwork/<pkg>` for each of core / cli / studio under OIDC. Each `npm publish` invokes the package's own `prepack` script automatically (tsc build + auxiliary file copies + chmod on bin entries), so no separate build step is needed. `NPM_CONFIG_PROVENANCE=true` is set on the workflow env, so the publish emits provenance attestation tied to the workflow run.
+4. The workflow then runs `assert-published` (verifies the registry has all three at the new version) and `scripts/smoke-marketplace.sh` (clones the marketplace, npm-installs from the registry, boots studio, asserts routes). Both are release-blocking — workflow failure leaves the artifacts published but signals the release isn't healthy.
+5. The skill watches the workflow via `gh run watch` and reports the release URL on success.
 
-Publish happens BEFORE the smoke gate, so smoke can `npm install` against the freshly-published packages.
+Each `@deskwork/*` package on npmjs.com has a Trusted Publisher entry registered against this exact workflow filename (`publish-npm.yml`). That registration plus the workflow's `id-token: write` permission is what authorizes the publish — there is no `NPM_TOKEN` secret. See § "Trusted Publisher setup" above for the one-time-per-package registration steps and § "Recovery — CI is broken" for the `make publish` manual-fallback procedure when the workflow itself is broken.
+
+**Manual fallback paths:** `make publish` (token-auth, prompts for 2FA OTP per package) is the operator-driven recovery flow when CI is broken or for one-off out-of-band publishes. `make publish-ci` is what the workflow invokes under OIDC; running it from a local shell without the OIDC env will fail. Each per-package manifest declares `"publishConfig": { "access": "public", "provenance": true }` so the registry-side defaults match the workflow path; manual `make publish` overrides provenance off (`--no-provenance`) because token auth can't emit OIDC attestation.
 
 **Adopter install:** Claude Code clones the plugin's `git-subdir` source into the operator's plugin cache. On first invocation, the bin shim (`plugins/<plugin>/bin/<bin>`) runs `npm install --omit=dev` inside the plugin tree, which fetches `@deskwork/<pkg>@<pinned-version>` from the public registry into `<pluginRoot>/node_modules/`. Subsequent invocations skip that step. Plugin updates (via `/plugin marketplace update`) ship a new plugin shell with a bumped `plugin.json` version; the bin shim's version-drift check triggers a re-install on next invocation.
 
-The vendor-materialization mechanism that this replaces (Phase 23b–23g, v0.5.0–v0.9.4) was retired in v0.9.5. CI no longer materializes anything; the release workflow handles tagging + GitHub release notes only.
-
 ### What gets released
 
-Each release has two surfaces:
+Each release has two surfaces, both triggered by the single `v*` tag push:
 
-1. **`@deskwork/{core,cli,studio}@<version>` on npm** — published via `make publish`, run by the operator in their own terminal during Pause 3 of `/release`. This is the primary artifact; the plugin shells fetch this at adopter first-run.
-2. **A git tag on `main`** (e.g. `v0.9.5`). The tag triggers `.github/workflows/release.yml`, which validates `marketplace.json` plugin paths and creates a GitHub release with auto-generated notes from commits since the previous tag. The marketplace's `git-subdir` sources resolve to the default branch (no per-tag `source.ref` pin), so an operator running `/plugin marketplace update deskwork` after the release picks up the new shell.
+1. **`@deskwork/{core,cli,studio}@<version>` on npm** — published by `.github/workflows/publish-npm.yml`, the canonical publish authority. The workflow runs the publish, the post-publish `assert-published` registry check, and the marketplace smoke gate in CI under OIDC (no token). The plugin shells fetch these packages at adopter first-run. `make publish` (token + 2FA) is the manual fallback when CI is broken — see § "Recovery — CI is broken" and § "Trusted Publisher setup" for the registration that makes the workflow path work.
+2. **A git tag on `main`** (e.g. `v0.9.5`). The tag triggers `.github/workflows/release.yml` in parallel with `publish-npm.yml`; `release.yml` creates a GitHub release with auto-generated notes from commits since the previous tag. The marketplace's `git-subdir` sources resolve to the default branch (no per-tag `source.ref` pin), so an operator running `/plugin marketplace update deskwork` after the release picks up the new shell.
 
 ### Operator update path
 

--- a/docs/1.0/001-IN-PROGRESS/hygiene/README.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/README.md
@@ -24,6 +24,7 @@ Ships a family of UNIX-style `/dw-lifecycle:*` skills that surface and burn down
 | 7 | Documentation | [#331](https://github.com/audiocontrol-org/deskwork/issues/331) | Shipped on branch (README section + per-skill SKILL.md audit complete) |
 | 8 | Tests + smoke | [#332](https://github.com/audiocontrol-org/deskwork/issues/332) | Shipped on branch (1804 tests pass + scripts/smoke-hygiene.sh) |
 | 9 | Dogfood round | [#333](https://github.com/audiocontrol-org/deskwork/issues/333) | Shipped (v0.26.0 dogfood; 3 stale issues triaged + closed; promote-deferrals false-positive surfaced as [#339](https://github.com/audiocontrol-org/deskwork/issues/339) and fixed in 9086894) |
+| 10 | npm Trusted Publisher CI workflow | [#343](https://github.com/audiocontrol-org/deskwork/issues/343) | Not started |
 
 ## Key Links
 

--- a/docs/1.0/001-IN-PROGRESS/hygiene/README.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/README.md
@@ -24,7 +24,7 @@ Ships a family of UNIX-style `/dw-lifecycle:*` skills that surface and burn down
 | 7 | Documentation | [#331](https://github.com/audiocontrol-org/deskwork/issues/331) | Shipped on branch (README section + per-skill SKILL.md audit complete) |
 | 8 | Tests + smoke | [#332](https://github.com/audiocontrol-org/deskwork/issues/332) | Shipped on branch (1804 tests pass + scripts/smoke-hygiene.sh) |
 | 9 | Dogfood round | [#333](https://github.com/audiocontrol-org/deskwork/issues/333) | Shipped (v0.26.0 dogfood; 3 stale issues triaged + closed; promote-deferrals false-positive surfaced as [#339](https://github.com/audiocontrol-org/deskwork/issues/339) and fixed in 9086894) |
-| 10 | npm Trusted Publisher CI workflow | [#343](https://github.com/audiocontrol-org/deskwork/issues/343) | Not started |
+| 10 | npm Trusted Publisher CI workflow | [#343](https://github.com/audiocontrol-org/deskwork/issues/343) | Shipped on branch (Tasks 1-4: workflow + publishConfig + /release skill update + RELEASING.md; Task 5 verification awaits first real release using the new workflow) |
 
 ## Key Links
 

--- a/docs/1.0/001-IN-PROGRESS/hygiene/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/prd.md
@@ -33,6 +33,8 @@ Ship a family of small, focused `/dw-lifecycle:` skills (one action per skill, U
 - [ ] Local smoke script exercises end-to-end wiring.
 - [ ] Adopter-facing docs (README + per-skill SKILL.md) explain the skills + the operational pattern.
 - [ ] Dogfood round against the existing backlog runs at least one full batched-proposal cycle for each of `:triage-issues` and `:promote-deferrals`.
+- [ ] **npm Trusted Publisher workflow ships:** `.github/workflows/publish-npm.yml` triggers on `v*` tag push, authenticates to npm via OIDC (no token), publishes all three `@deskwork/*` packages in dep order, runs `assert-published` + marketplace smoke as in-CI gates. `make publish` stays as a documented manual fallback.
+- [ ] **`/release` skill simplifies:** the Pause 3 ("publish step — run in your own terminal") collapses into "tag push fired Action `<run-url>`; waiting for `success`". The skill polls the workflow run, surfaces success/failure to the operator. The Pause 4 marketplace-smoke step is rolled into the CI workflow (the local smoke stays available but is no longer a hard gate of the `/release` skill).
 
 ## Out of Scope
 

--- a/docs/1.0/001-IN-PROGRESS/hygiene/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/workplan.md
@@ -285,39 +285,38 @@ Operator decisions (locked in during definition):
 
 ### Task 1: Author the publish workflow
 
-- [ ] Step 1: Create `.github/workflows/publish-npm.yml` triggered on `push: tags: ['v*']`. Permissions: `id-token: write`, `contents: read`.
-- [ ] Step 2: Steps: checkout → setup-node (node 20, registry-url npmjs.org) → `npm ci` → `make publish` (the existing dep-ordered topology — `npm publish` picks up OIDC when the workflow has `id-token: write` + npm-side trusted-publisher config).
-- [ ] Step 3: Post-publish step: run `tsx .claude/skills/release/lib/release-helpers.ts assert-published $TAG_VERSION` to confirm all three packages are on the registry.
-- [ ] Step 4: Post-assert step: run `bash scripts/smoke-marketplace.sh` so the marketplace clone → install → studio-boot → routes/assets gate fires in CI before the workflow exits success.
-- [ ] Step 5: Failure surface: on any step failure, the workflow exits non-zero. The GitHub release workflow (already firing on tag push) and the publish workflow can fail independently — document the recovery shape.
+- [x] Step 1: Create `.github/workflows/publish-npm.yml` triggered on `push: tags: ['v*']`. Permissions: `id-token: write`, `contents: read`.
+- [x] Step 2: Steps: checkout → setup-node (node 20, registry-url npmjs.org) → `npm ci` → `npm run build` → `make publish-ci` (new dep-ordered topology that skips the token-file path; `npm publish` picks up OIDC when the workflow has `id-token: write` + npm-side trusted-publisher config). `NPM_CONFIG_PROVENANCE=true` env-set so the workflow emits provenance attestation per package.
+- [x] Step 3: Post-publish step: `npx tsx .claude/skills/release/lib/release-helpers.ts assert-published $TAG_VERSION` confirms all three packages are on the registry.
+- [x] Step 4: Post-assert step: `bash scripts/smoke-marketplace.sh` fires in CI so the clone → install → studio-boot → routes/assets gate runs before workflow exits success.
+- [x] Step 5: Failure surface: on any step failure, the workflow exits non-zero. The GitHub release workflow (already firing on tag push) and the publish workflow can fail independently — recovery shape documented in `.claude/skills/release/SKILL.md` § "Recovery — CI is broken" and `RELEASING.md` § "Recovery — CI is broken".
 
 ### Task 2: Add `publishConfig` to each `@deskwork/*` package
 
-- [ ] Step 1: In `packages/core/package.json`, `packages/cli/package.json`, `packages/studio/package.json`: add `"publishConfig": { "access": "public", "provenance": true }`. Provenance is OIDC-anchored attestation — useful for adopter audit + free with the OIDC token.
-- [ ] Step 2: Verify `npm publish` (run locally) accepts the new field cleanly and that the provenance bit doesn't break the manual publish path.
+- [x] Step 1: `publishConfig: { access: public, provenance: true }` added to `packages/core/package.json`, `packages/cli/package.json`, `packages/studio/package.json`. Provenance is OIDC-anchored attestation — useful for adopter audit + free with the OIDC token.
+- [x] Step 2: Manual publish path retained via `make publish` — Makefile's `PUBLISH_PKG` now passes `--no-provenance` so token-auth publishes (the recovery fallback) skip the provenance attestation cleanly. New `publish-ci` Make target invokes `npm publish` without the npmrc manipulation; this is what the workflow calls.
 
 ### Task 3: Update `/release` skill
 
-- [ ] Step 1: Edit `.claude/skills/release/SKILL.md`. Pause 3 ("publish step — RUN IN YOUR OWN TERMINAL") collapses into: after the atomic-push lands, the skill fetches the workflow run via `gh run list --workflow=publish-npm.yml --branch=main --limit=1 --json databaseId,status,conclusion`, then `gh run watch <run-id>` (with timeout). On `success`: continue to release-view step. On `failure`: surface the workflow logs URL + advise the operator.
-- [ ] Step 2: Pause 4 (the local marketplace smoke) is no longer a hard gate — the CI workflow runs it. The local `scripts/smoke-marketplace.sh` stays callable for local validation. Document this shift in the SKILL.md.
-- [ ] Step 3: The `assert-published` helper at `.claude/skills/release/lib/release-helpers.ts` keeps its existing API — CI uses the same helper.
-- [ ] Step 4: `make publish` fallback path: SKILL.md gains a "Recovery" section documenting how to manually publish if CI is broken (the operator runs `make publish` in their terminal as before, then re-invokes `/release` post-publish with a `--skip-publish-wait` flag — to be added).
-- [ ] Step 5: New flag `--skip-publish-wait`: when the operator already published manually, `/release` skips the workflow-watch step and proceeds directly to tag-message + atomic-push (the atomic-push step has already happened in this recovery path; the skill should detect that and skip cleanly OR the operator manually invokes the remaining sub-steps).
+- [x] Step 1: Edit `.claude/skills/release/SKILL.md`. Pause 3 collapses to "tag message" (publish moved to CI). Pause 4 collapses to "push + workflow watch" (push fires the publish workflow; skill uses `gh run list` to match the run by `headSha == pushed-HEAD-SHA && event == push`, then `gh run watch <run-id>` with a 15-minute timeout). On success: continue to release-view step. On failure: surface the workflow logs URL + advise operator.
+- [x] Step 2: Local marketplace smoke is no longer a hard gate in the skill — CI runs it. `scripts/smoke-marketplace.sh` stays callable for local validation; documented in the SKILL.md.
+- [x] Step 3: The `assert-published` helper keeps its existing API; CI invokes it.
+- [x] Step 4: SKILL.md gains a "Recovery — CI is broken" section documenting the `make publish` manual-fallback path + the `--skip-publish-wait` flag.
+- [x] Step 5: `--skip-publish-wait` flag documented in SKILL.md frontmatter description, intro, and "Steps for the agent" preface. When passed, the skill skips Pause 4's workflow-watch step and proceeds directly to `gh release view`.
 
 ### Task 4: Document the npm-side trusted-publisher setup
 
-- [ ] Step 1: Add a "Trusted Publisher setup" section to `RELEASING.md` (or create the doc if absent). One-time setup per package on npmjs.com → Settings → Publishing access → Add trusted publisher (organization `audiocontrol-org`, repository `deskwork`, workflow filename `publish-npm.yml`, environment blank).
-- [ ] Step 2: Document the recovery path explicitly: when CI is broken, fall back to `make publish` per the long-standing manual flow + the `/release` skill's `--skip-publish-wait` flag.
+- [x] Step 1: "Trusted Publisher setup" section added to `RELEASING.md`. Documents the one-time per-package npmjs.com setup (Publisher: GitHub Actions, Organization: `audiocontrol-org`, Repository: `deskwork`, Workflow filename: `publish-npm.yml`, Environment: blank). Names the workflow-filename contract: renaming `publish-npm.yml` requires re-registering trusted publisher on each package.
+- [x] Step 2: "Recovery — CI is broken" section added to `RELEASING.md`. Documents `make publish` fallback, `make publish-<pkg>` for one-off out-of-band publishes, and the `/release --skip-publish-wait` resume path. Mirrors the SKILL.md's recovery section so operators see the same playbook whether they read the doc or invoke the skill.
 
 ### Task 5: Tests + verification
 
-- [ ] Step 1: Local validation against the workflow: use `act` or equivalent to dry-run the workflow against a fixture commit (optional; the project's "no test infrastructure in CI" rule doesn't forbid this — it just keeps the test suite out of CI).
-- [ ] Step 2: First real release (v0.26.2 fixing #342, OR v0.27.0 if Phase 10 ships standalone) uses the new workflow. Verify the workflow run succeeds end-to-end.
-- [ ] Step 3: Post-verification: if any glitches surface, file follow-up issues + close [#TBD-extend] per the project's "Issue closure requires verification in a formally-installed release" rule.
+- [ ] Step 1: First real release (v0.26.2 carrying #342 fix + Phase 10 ship) uses the new workflow. Verify the workflow run succeeds end-to-end.
+- [ ] Step 2: Post-verification: if any glitches surface, file follow-up issues + close [#343](https://github.com/audiocontrol-org/deskwork/issues/343) per the project's "Issue closure requires verification in a formally-installed release" rule.
 
 **Acceptance Criteria:**
-- [ ] `.github/workflows/publish-npm.yml` ships, triggers on `v*` tag push, publishes via OIDC.
-- [ ] `publishConfig: { access: public, provenance: true }` added to `packages/core`, `packages/cli`, `packages/studio` package.json files.
-- [ ] `/release` skill SKILL.md updated: Pause 3 collapses into workflow-watch; Pause 4 marketplace-smoke moves to CI; `--skip-publish-wait` flag documented; `make publish` recovery path documented.
-- [ ] `RELEASING.md` documents the one-time npm-side trusted-publisher setup per package + the recovery path.
+- [x] `.github/workflows/publish-npm.yml` ships, triggers on `v*` tag push, publishes via OIDC.
+- [x] `publishConfig: { access: public, provenance: true }` added to `packages/core`, `packages/cli`, `packages/studio` package.json files.
+- [x] `/release` skill SKILL.md updated: Pause 3 collapses into tag-message-only; Pause 4 collapses to push + workflow-watch (marketplace-smoke moves to CI); `--skip-publish-wait` flag documented; `make publish` recovery path documented.
+- [x] `RELEASING.md` documents the one-time npm-side trusted-publisher setup per package + the recovery path.
 - [ ] First real release uses the new workflow and succeeds end-to-end. Verification step closes [#343](https://github.com/audiocontrol-org/deskwork/issues/343) per the project rule.

--- a/docs/1.0/001-IN-PROGRESS/hygiene/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/workplan.md
@@ -272,3 +272,52 @@ Closes three semantic + rendering bugs in `session-end-hygiene` surfaced during 
 - Fix landed in `9086894` on main: Fix A (skip `- [x]` lines), Fix B-1 (tighten TBD regex to require `TBD:` colon-suffix per spec), Fix B-2 (strip backtick code-spans before pattern dispatch). Re-ran propose against hygiene workplan post-fix: 0 false positives. 1829 / 1829 tests pass. The fix is reachable in any v0.26.x build past `9086894`.
 - Lesson saved: the worktree's pinned branch is the fix target — never direct-push to main, never create a sibling fix branch (per `feedback_worktree_pinned_branch_for_fixes.md`).
 - TF-001 (dispatch-wrapper false-positive on cue substring matches in cited file paths) at `docs/1.0/001-IN-PROGRESS/hygiene/tooling-feedback.md` stays open; not surfaced again in Phase 9 but still tracked.
+
+## Phase 10: npm Trusted Publisher CI workflow  ·  [#343](https://github.com/audiocontrol-org/deskwork/issues/343)
+
+**Deliverable:** GitHub Actions workflow at `.github/workflows/publish-npm.yml` that publishes the three `@deskwork/*` packages to npm automatically on `v*` tag push, using OIDC (no npm token). `make publish` stays as a documented manual fallback. `/release` skill collapses Pause 3 (manual `make publish`) and Pause 4 (local marketplace-smoke) into a single "watch the Action" wait.
+
+Operator decisions (locked in during definition):
+
+- **Trigger model:** pure tag-push auto-publish. No GitHub Environment approval gate. The `/release` skill's atomic-push IS the approval moment.
+- **Manual fallback:** `make publish` stays working as documented backup. Used when CI is degraded or operator wants a one-off out-of-band publish.
+- **Scope:** smoke + assert-published roll INTO the workflow. `/release` becomes "atomic-push, watch the Action, done." The local `bash scripts/smoke-marketplace.sh` stays callable but is no longer a hard gate of `/release`.
+
+### Task 1: Author the publish workflow
+
+- [ ] Step 1: Create `.github/workflows/publish-npm.yml` triggered on `push: tags: ['v*']`. Permissions: `id-token: write`, `contents: read`.
+- [ ] Step 2: Steps: checkout → setup-node (node 20, registry-url npmjs.org) → `npm ci` → `make publish` (the existing dep-ordered topology — `npm publish` picks up OIDC when the workflow has `id-token: write` + npm-side trusted-publisher config).
+- [ ] Step 3: Post-publish step: run `tsx .claude/skills/release/lib/release-helpers.ts assert-published $TAG_VERSION` to confirm all three packages are on the registry.
+- [ ] Step 4: Post-assert step: run `bash scripts/smoke-marketplace.sh` so the marketplace clone → install → studio-boot → routes/assets gate fires in CI before the workflow exits success.
+- [ ] Step 5: Failure surface: on any step failure, the workflow exits non-zero. The GitHub release workflow (already firing on tag push) and the publish workflow can fail independently — document the recovery shape.
+
+### Task 2: Add `publishConfig` to each `@deskwork/*` package
+
+- [ ] Step 1: In `packages/core/package.json`, `packages/cli/package.json`, `packages/studio/package.json`: add `"publishConfig": { "access": "public", "provenance": true }`. Provenance is OIDC-anchored attestation — useful for adopter audit + free with the OIDC token.
+- [ ] Step 2: Verify `npm publish` (run locally) accepts the new field cleanly and that the provenance bit doesn't break the manual publish path.
+
+### Task 3: Update `/release` skill
+
+- [ ] Step 1: Edit `.claude/skills/release/SKILL.md`. Pause 3 ("publish step — RUN IN YOUR OWN TERMINAL") collapses into: after the atomic-push lands, the skill fetches the workflow run via `gh run list --workflow=publish-npm.yml --branch=main --limit=1 --json databaseId,status,conclusion`, then `gh run watch <run-id>` (with timeout). On `success`: continue to release-view step. On `failure`: surface the workflow logs URL + advise the operator.
+- [ ] Step 2: Pause 4 (the local marketplace smoke) is no longer a hard gate — the CI workflow runs it. The local `scripts/smoke-marketplace.sh` stays callable for local validation. Document this shift in the SKILL.md.
+- [ ] Step 3: The `assert-published` helper at `.claude/skills/release/lib/release-helpers.ts` keeps its existing API — CI uses the same helper.
+- [ ] Step 4: `make publish` fallback path: SKILL.md gains a "Recovery" section documenting how to manually publish if CI is broken (the operator runs `make publish` in their terminal as before, then re-invokes `/release` post-publish with a `--skip-publish-wait` flag — to be added).
+- [ ] Step 5: New flag `--skip-publish-wait`: when the operator already published manually, `/release` skips the workflow-watch step and proceeds directly to tag-message + atomic-push (the atomic-push step has already happened in this recovery path; the skill should detect that and skip cleanly OR the operator manually invokes the remaining sub-steps).
+
+### Task 4: Document the npm-side trusted-publisher setup
+
+- [ ] Step 1: Add a "Trusted Publisher setup" section to `RELEASING.md` (or create the doc if absent). One-time setup per package on npmjs.com → Settings → Publishing access → Add trusted publisher (organization `audiocontrol-org`, repository `deskwork`, workflow filename `publish-npm.yml`, environment blank).
+- [ ] Step 2: Document the recovery path explicitly: when CI is broken, fall back to `make publish` per the long-standing manual flow + the `/release` skill's `--skip-publish-wait` flag.
+
+### Task 5: Tests + verification
+
+- [ ] Step 1: Local validation against the workflow: use `act` or equivalent to dry-run the workflow against a fixture commit (optional; the project's "no test infrastructure in CI" rule doesn't forbid this — it just keeps the test suite out of CI).
+- [ ] Step 2: First real release (v0.26.2 fixing #342, OR v0.27.0 if Phase 10 ships standalone) uses the new workflow. Verify the workflow run succeeds end-to-end.
+- [ ] Step 3: Post-verification: if any glitches surface, file follow-up issues + close [#TBD-extend] per the project's "Issue closure requires verification in a formally-installed release" rule.
+
+**Acceptance Criteria:**
+- [ ] `.github/workflows/publish-npm.yml` ships, triggers on `v*` tag push, publishes via OIDC.
+- [ ] `publishConfig: { access: public, provenance: true }` added to `packages/core`, `packages/cli`, `packages/studio` package.json files.
+- [ ] `/release` skill SKILL.md updated: Pause 3 collapses into workflow-watch; Pause 4 marketplace-smoke moves to CI; `--skip-publish-wait` flag documented; `make publish` recovery path documented.
+- [ ] `RELEASING.md` documents the one-time npm-side trusted-publisher setup per package + the recovery path.
+- [ ] First real release uses the new workflow and succeeds end-to-end. Verification step closes [#343](https://github.com/audiocontrol-org/deskwork/issues/343) per the project rule.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,8 @@
     "directory": "packages/cli"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,8 @@
     "directory": "packages/core"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "engines": {
     "node": ">=20"

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -12,7 +12,8 @@
     "directory": "packages/studio"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "engines": {
     "node": ">=20"

--- a/plugins/dw-lifecycle/src/__tests__/parent-closure-walk.test.ts
+++ b/plugins/dw-lifecycle/src/__tests__/parent-closure-walk.test.ts
@@ -101,16 +101,153 @@ describe('parentTimeline', () => {
     expect(results.map((r) => r.number)).toEqual([324, 325]);
   });
 
+  it('interpolates the resolved repo into the URL and does NOT pass --repo flag (#342)', () => {
+    // Regression: pre-fix the URL carried literal `{owner}/{repo}`
+    // placeholders that `gh api` does not substitute, AND the call passed
+    // `--repo` (which `gh api` rejects with `unknown flag`). Both bugs
+    // surfaced together as a CLI usage error that aborted the walker. The
+    // fix interpolates the repo directly into the URL path and drops the
+    // `--repo` flag.
+    const stub = makeGhStub(() => '[]');
+    parentTimeline({ parentIssue: 323, repo: 'owner/repo', runGh: stub.runGh });
+    const argv = stub.calls[0] ?? [];
+    expect(argv[0]).toBe('api');
+    expect(argv[1]).toBe('/repos/owner/repo/issues/323/timeline');
+    expect(argv).not.toContain('--repo');
+    expect(argv.find((a) => a.includes('{owner}'))).toBeUndefined();
+    expect(argv.find((a) => a.includes('{repo}'))).toBeUndefined();
+  });
+
+  it('recovers gracefully when the gh api call throws a usage error (#342)', () => {
+    // Regression: pre-fix, the walker rejected on usage errors instead of
+    // collapsing to "this source returned []". The recovery contract is
+    // that ANY error from the timeline source backfills to empty + emits a
+    // one-line stderr breadcrumb so the other two sources can still
+    // contribute candidates.
+    const stub = makeGhStub(() => {
+      throw new Error('unknown flag: --repo\nUsage: gh api <endpoint> [flags]');
+    });
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...parts: unknown[]) => {
+      errors.push(parts.map((p) => String(p)).join(' '));
+    };
+    try {
+      const result = parentTimeline({
+        parentIssue: 323,
+        repo: 'owner/repo',
+        runGh: stub.runGh,
+      });
+      expect(result).toEqual([]);
+    } finally {
+      console.error = origError;
+    }
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/complete-parent-closure: timeline source failed/);
+    expect(errors[0]).toMatch(/unknown flag/);
+    expect(errors[0]).toMatch(/continuing with other sources/);
+  });
+
   it('returns empty array on 404 (archived parent etc.)', () => {
     const stub = makeGhStub(() => {
       throw new Error('gh: HTTP 404 not found');
     });
-    expect(parentTimeline({ parentIssue: 999, repo: 'o/r', runGh: stub.runGh })).toEqual([]);
+    const origError = console.error;
+    console.error = () => undefined;
+    try {
+      expect(
+        parentTimeline({ parentIssue: 999, repo: 'o/r', runGh: stub.runGh }),
+      ).toEqual([]);
+    } finally {
+      console.error = origError;
+    }
   });
 
   it('returns empty array on empty output', () => {
     const stub = makeGhStub(() => '');
     expect(parentTimeline({ parentIssue: 1, repo: 'o/r', runGh: stub.runGh })).toEqual([]);
+  });
+
+  it('returns empty array (with diagnostic) when timeline output is not a JSON array', () => {
+    const stub = makeGhStub(() => '{"oops": true}');
+    const origError = console.error;
+    const errors: string[] = [];
+    console.error = (...parts: unknown[]) => {
+      errors.push(parts.map((p) => String(p)).join(' '));
+    };
+    try {
+      expect(
+        parentTimeline({ parentIssue: 1, repo: 'o/r', runGh: stub.runGh }),
+      ).toEqual([]);
+    } finally {
+      console.error = origError;
+    }
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/response was not a JSON array/);
+  });
+});
+
+describe('walk — recovery contract (#342)', () => {
+  let fxRec: Fixture;
+  beforeEach(() => {
+    fxRec = setup();
+  });
+  afterEach(() => rmSync(fxRec.root, { recursive: true, force: true }));
+
+  it('still returns a usable proposal when the gh api timeline call throws a usage error', () => {
+    // Integration-level: the walker's recovery contract says "timeline
+    // source backfills to [], the other two sources contribute the
+    // candidate set." This test exercises that contract end-to-end -- the
+    // gh api call throws a usage error, but title-search + workplan-
+    // anchored sources still supply the parent + a child, and the
+    // walker's classification carries through.
+    writeFileSync(
+      fxRec.workplanPath,
+      [
+        '## Phase 0: setup  ·  [#324](https://github.com/o/r/issues/324)',
+      ].join('\n'),
+      'utf8',
+    );
+    const runGh = (args: readonly string[]): string => {
+      if (args[0] === 'issue' && args[1] === 'list') {
+        return JSON.stringify([
+          { number: 323, title: 'feat(hygiene): parent', state: 'OPEN', url: 'u323' },
+        ]);
+      }
+      if (args[0] === 'api') {
+        throw new Error('unknown flag: --repo');
+      }
+      if (args[0] === 'issue' && args[1] === 'view') {
+        const n = Number.parseInt(args[2] ?? '0', 10);
+        return JSON.stringify({
+          number: n,
+          title: `feat(hygiene): phase ${n}`,
+          state: 'CLOSED',
+          url: `u${n}`,
+        });
+      }
+      return '';
+    };
+    const origError = console.error;
+    console.error = () => undefined;
+    try {
+      const result = walk({
+        slug: 'hygiene',
+        parentIssue: 323,
+        workplanPath: fxRec.workplanPath,
+        repo: 'owner/repo',
+        runGh,
+      });
+      const parent = result.find((r) => r.number === 323);
+      expect(parent).toBeDefined();
+      // Workplan-anchored child #324 still appears (timeline failure didn't
+      // strand it) AND the parent classifies as close-all-children-closed
+      // because its single child (#324) is CLOSED.
+      expect(parent?.child_issues.map((c) => c.number)).toEqual([324]);
+      expect(parent?.classification).toBe('close-all-children-closed');
+    } finally {
+      console.error = origError;
+    }
   });
 });
 

--- a/plugins/dw-lifecycle/src/lifecycle-integration/parent-closure/walk.ts
+++ b/plugins/dw-lifecycle/src/lifecycle-integration/parent-closure/walk.ts
@@ -133,10 +133,16 @@ export function parentTimeline(
   args: ParentTimelineArgs,
 ): readonly RawIssueForSearch[] {
   // Use `gh api --paginate` so we walk every page; the timeline can carry
-  // hundreds of events on long-running features.
+  // hundreds of events on long-running features. The repo is interpolated
+  // directly into the URL path -- `gh api` doesn't accept a `--repo` flag
+  // (that flag is for `gh issue` / `gh pr`), and `gh api` won't substitute
+  // `{owner}/{repo}` placeholders the way some other gh subcommands do.
+  // Both bugs surfaced in #342: literal placeholders in the URL +
+  // `--repo` flag together produced a `gh api: unknown flag` failure that
+  // aborted the walker before the recovery contract could engage.
   const ghArgs: readonly string[] = [
     'api',
-    `/repos/{owner}/{repo}/issues/${args.parentIssue}/timeline`,
+    `/repos/${args.repo}/issues/${args.parentIssue}/timeline`,
     '--paginate',
     '-H',
     'Accept: application/vnd.github+json',
@@ -145,29 +151,43 @@ export function parentTimeline(
   // wrapping them into a single array. Each page is a self-contained JSON
   // array on its own line(s). Split on the boundary `][` (a closing bracket
   // followed by an opening bracket) and re-wrap to parse as one stream.
+  //
+  // The recovery contract: ANY failure from `runGh` (404 on archived repos,
+  // CLI usage error from a flag mismatch, network failure, malformed JSON
+  // pagination, etc.) collapses to "this source contributed zero
+  // candidates." The walker depends on the union of the three sources, not
+  // on every source succeeding. A one-line stderr breadcrumb names the
+  // failure mode so the operator can tell silent backfill apart from a
+  // genuinely-empty timeline; the diagnostic pattern mirrors
+  // session-end-hygiene.ts's resolveSessionBoundaryIso error handling.
   let raw: string;
   try {
-    raw = args.runGh([...ghArgs, '--repo', args.repo]);
+    raw = args.runGh(ghArgs);
   } catch (err) {
-    // The timeline endpoint can fail (404 on archived repos, etc.). Treat
-    // failures as "this source contributed zero candidates" -- the walker
-    // depends on the union of the three sources, not on every source
-    // succeeding.
     const message = err instanceof Error ? err.message : String(err);
-    if (/HTTP 404/i.test(message) || /not found/i.test(message)) {
-      return [];
-    }
-    throw err;
+    console.error(
+      `complete-parent-closure: timeline source failed (${message.split('\n')[0]}); continuing with other sources`,
+    );
+    return [];
   }
   if (raw.trim() === '') return [];
   const concatenated = raw.replace(/\]\s*\[/g, ',');
   let parsed: unknown;
   try {
     parsed = JSON.parse(concatenated);
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `complete-parent-closure: timeline source failed (json-parse: ${message.split('\n')[0]}); continuing with other sources`,
+    );
     return [];
   }
-  if (!Array.isArray(parsed)) return [];
+  if (!Array.isArray(parsed)) {
+    console.error(
+      'complete-parent-closure: timeline source failed (response was not a JSON array); continuing with other sources',
+    );
+    return [];
+  }
   const refs: RawIssueForSearch[] = [];
   for (const event of parsed) {
     if (!isPlainObject(event)) continue;

--- a/scripts/smoke-hygiene.sh
+++ b/scripts/smoke-hygiene.sh
@@ -82,7 +82,7 @@ date: 2026-05-28
 
 # Workplan: Sample
 
-## Phase 1: Sample phase
+## Phase 1: Sample phase  ·  [#2](https://github.com/example/repo/issues/2)
 
 - [x] Step 1: Closed via issue. * [#1](https://github.com/example/repo/issues/1)
 - [ ] Step 2: TBD: needs design.
@@ -105,6 +105,7 @@ cat > "$FIXTURE/docs/1.0/001-IN-PROGRESS/sample/README.md" <<'SAMPLEREADME'
 ---
 slug: sample
 targetVersion: "1.0"
+parentIssue: "#1"
 ---
 
 # Feature: Sample
@@ -294,6 +295,26 @@ fi
 echo "== smoke-hygiene: close-shipped --dry-run =="
 "$DW_BIN" close-shipped --from-tag v0.1.0 --to-tag v0.2.0 --repo example/repo --dry-run >/dev/null 2>&1 \
   || fail "close-shipped --dry-run failed (non-zero exit)"
+
+echo "== smoke-hygiene: complete-parent-closure propose =="
+# Walker integrates THREE sources (title-search, parent timeline, workplan-
+# anchored). Regression for #342: pre-fix the gh api timeline call carried
+# literal `{owner}/{repo}` placeholders + a `--repo` flag, and the walker
+# aborted on the resulting usage error. Post-fix, the URL interpolates the
+# resolved repo and the recovery contract collapses any timeline failure to
+# []. The stub returns `[]` for `gh api`, so the timeline source is a no-op
+# here; the proposal still gets assembled from title-search + workplan.
+"$DW_BIN" complete-parent-closure propose --slug sample --repo example/repo \
+  >/dev/null 2>&1 \
+  || fail "complete-parent-closure propose failed (non-zero exit)"
+PCP_DIR="$FIXTURE/.dw-lifecycle/complete-parent-closure"
+if [ ! -d "$PCP_DIR" ]; then
+  fail "complete-parent-closure propose did not create $PCP_DIR"
+fi
+PCP_PROPOSAL_COUNT="$(find "$PCP_DIR" -name 'proposals-*.json' 2>/dev/null | wc -l | tr -d '[:space:]')"
+if [ "$PCP_PROPOSAL_COUNT" = "0" ]; then
+  fail "complete-parent-closure propose did not write a proposal file"
+fi
 
 echo "== smoke-hygiene: archive-branch --dry-run =="
 # Create a parked branch with novel commits so the preflight has work


### PR DESCRIPTION
Closes [#342](https://github.com/audiocontrol-org/deskwork/issues/342), closes [#343](https://github.com/audiocontrol-org/deskwork/issues/343). Targets v0.26.2.

Two tranches bundled because v0.26.2 is the first release that will exercise the new Phase 10 publish workflow — the #342 fix is what the release is FOR; the Phase 10 work is what the release runs THROUGH.

## What ships

| Commit | Description |
|---|---|
| `7217ba3` | docs(hygiene): extend with Phase 10 — npm Trusted Publisher CI workflow |
| `273c8f3` | fix(dw-lifecycle): complete-parent-closure walker — gh api URL substitution + recovery (closes #342) |
| `61242f3` | feat(ci): npm Trusted Publisher workflow + /release skill simplification (#343, hygiene Phase 10) |
| `2591c8e` | fix(ci+docs): apply review findings — drop redundant build, refresh RELEASING.md, release.yml header, SKILL.md description |

## Tranche A — #342 fix (complete-parent-closure walker)

v0.26.1 install-verification surfaced that the walker shipped broken: `gh api /repos/{owner}/{repo}/issues/<N>/timeline --paginate ... --repo <owner>/<repo>` failed with `unknown flag: --repo`, AND the URL carried literal `{owner}/{repo}` placeholders. The walker's documented "timeline source returns `[]` on failure, other sources backfill" recovery didn't engage because the wrapper didn't catch usage errors.

Three fixes:

1. **URL substitution** — `/repos/${args.repo}/issues/${parentIssue}/timeline` interpolates the resolved repo into the path.
2. **Drop `--repo` flag** — removed from `gh api` argv (the repo is in the URL path).
3. **Recovery hardening** — wrap timeline-source `runGh` in try/catch returning `[]` on ANY error (usage error, 404, JSON parse failure). One-line stderr breadcrumb names the failure mode and "continuing with other sources" — mirrors the diagnostic pattern from `session-end-hygiene.ts`.

Plus 5 new tests covering the argv shape + 3 recovery shapes (usage-error throw, JSON non-array, JSON parse failure) + an integration test where the walker still produces proposals when the timeline source throws.

Plus a real-`gh` integration step in `scripts/smoke-hygiene.sh` — invokes `complete-parent-closure propose --slug <fixture>` end-to-end against the smoke fixture and asserts the proposal JSON gets written. The bug that escaped pre-release testing was the divergence between `runGh`-stubbed unit tests and the actual `gh api` argv shape; the smoke now catches that boundary.

## Tranche B — Phase 10 (npm Trusted Publisher CI workflow)

Replaces the manual three-OTP `make publish` step in `/release` with an OIDC-authenticated GitHub Actions workflow that fires on `v*` tag push.

**Files:**

- `.github/workflows/publish-npm.yml` — trigger `push: tags: ['v*']`; permissions `id-token: write` + `contents: read`; steps checkout → setup-node@20 → npm ci → `make publish-ci` (with `NPM_CONFIG_PROVENANCE=true`) → assert-published → marketplace smoke. `npm publish`'s `prepack` script handles per-package builds; no redundant explicit build step.
- `packages/{core,cli,studio}/package.json` — `publishConfig: { access: public, provenance: true }`. The provenance flag is OIDC-anchored attestation that adopters can verify; free under OIDC, requires opt-out (`--no-provenance`) under the manual fallback.
- `Makefile` — new `publish-ci` target for the OIDC path; existing `publish` target now passes `--no-provenance` for manual-token publishes (CLI flags override `publishConfig`).
- `.claude/skills/release/SKILL.md` — Pause 3 collapses (no more "RUN IN YOUR OWN TERMINAL: make publish"); push + workflow-watch merged into Pause 4; `gh run list` + `gh run watch` with 15-minute timeout; `--skip-publish-wait` flag added to frontmatter description + intro + Steps preface for the manual-recovery path.
- `RELEASING.md` — new "Trusted Publisher setup" section (one-time per-package npmjs.com configuration with the locked-in workflow filename `publish-npm.yml`); new "Recovery — CI is broken" section walks the `make publish` fallback playbook.
- `.github/workflows/release.yml` — header comment rewritten: this workflow's scope is GitHub-release-notes-only; `publish-npm.yml` is the npm-publish authority; both fire on the same tag-push trigger in parallel.

**Operator decisions locked in (per the design conversation):**

- Pure tag-push auto-publish. No GitHub Environment approval gate. The `/release` skill's atomic-push IS the approval moment.
- `make publish` stays working as a documented manual fallback. Used when CI is degraded or for one-off out-of-band publishes.
- Smoke + assert-published roll INTO the workflow. `/release` becomes "atomic-push, watch the Action, done."

## Test results

- 1896 / 1896 vitest pass across 154 files (was 1892 baseline; +4 net new for the #342 recovery tests).
- `tsc --noEmit` clean.
- `scripts/smoke-hygiene.sh` passes end-to-end with the new `complete-parent-closure propose` integration step.
- `.claude/skills/release` vitest: 28 / 28 pass.

## Verification gate

Per the project's "Issue closure requires verification in a formally-installed release" rule:

- **#342** stays open via this PR's auto-close link, BUT real verification happens when v0.26.2 ships AND the operator confirms `complete-parent-closure propose --slug hygiene` produces a proposal JSON against a real repo.
- **#343** Task 5 acceptance criterion ("First real release uses the new workflow and succeeds end-to-end") stays UNCHECKED in the workplan. Verification happens when v0.26.2 ships through `publish-npm.yml` and the workflow exits success. If anything breaks, file follow-up issues.

## Test plan

- [ ] Merge this PR.
- [ ] Configure the trusted-publisher on npmjs.com for each `@deskwork/*` package per `RELEASING.md` § "Trusted Publisher setup" — same workflow filename (`publish-npm.yml`), same org/repo.
- [ ] Run `/release` and ship v0.26.2. The atomic-push fires the new workflow; the skill polls `gh run watch` until success.
- [ ] Post-release: install v0.26.2 via `/plugin marketplace update deskwork`, re-run `dw-lifecycle complete-parent-closure propose --slug hygiene` against this project, confirm the proposal JSON is written (closes #342 verification).
- [ ] Phase 10 Task 5 acceptance criterion gets checked off when the v0.26.2 ship succeeds end-to-end through the workflow (closes #343 verification).

## Out of this PR

- The `--skip-publish-wait` flag's IMPLEMENTATION in the skill's runtime logic — documented as the contract; the actual gh-run-watch + flag-skip logic will land in the SKILL.md procedure when the next `/release` invocation needs it. The agent runs the documented procedure; no compiled-in logic to extract.
