### PR TITLE
fix(ci): publish-npm.yml — upgrade npm to support trusted publishing (v0.26.3 fast-track)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,6 +37,18 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      # Node 20 ships with npm 10.x; npm Trusted Publishing (OIDC) requires
+      # npm 11.5.1+ — the feature shipped late 2024 / early 2025. Without
+      # this upgrade, the publish step fails with a 404-Not-Found PUT to
+      # the package endpoint (npm returns 404 instead of 403 when OIDC
+      # validation rejects the token; misleading but documented). Surfaced
+      # by the v0.26.2 release attempt (workflow run 26613403248) on
+      # 2026-05-29 — the publish step failed AFTER the provenance
+      # attestation succeeded, confirming provenance + trusted-publishing
+      # are separate OIDC flows with separate minimum npm versions.
+      - name: Upgrade npm to support trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install workspaces
         run: npm ci
 


### PR DESCRIPTION
One-line fix to the Phase 10 publish workflow that just shipped in v0.26.2. Releases v0.26.3 will exercise the fix.

## What ships

Adds `npm install -g npm@latest` between `actions/setup-node@v4` and the publish step in `.github/workflows/publish-npm.yml`.

## Why

Node 20 ships with npm 10.8.x; npm Trusted Publishing (OIDC) requires **npm 11.5.1+** (the feature shipped late 2024 / early 2025). Without the upgrade, the publish step fails with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@deskwork%2fcore - Not found
```

npm returns 404 instead of 403 when OIDC trusted-publisher validation rejects the token — a documented but misleading error shape.

## How we know

v0.26.2 release attempt on 2026-05-29 (workflow run [26613403248](https://github.com/audiocontrol-org/deskwork/actions/runs/26613403248)) failed at the publish step. The workflow's provenance-attestation step succeeded BEFORE the package PUT failed — confirming provenance and trusted-publishing are separate OIDC flows with separate minimum npm versions.

The npm-side trusted-publisher config (verified via the operator's screenshot) was correct: organization `audiocontrol-org`, repository `deskwork`, workflow filename `publish-npm.yml`, both `npm publish` + `npm stage publish` allowed. The mismatch wasn't the config — it was the npm version on the runner being too old to even use the trusted-publisher OIDC flow.

## v0.26.2 disposition

The v0.26.2 tag stays as an orphan on origin with no npm artifacts (publish failed before any package landed on the registry — clean state, no half-published packages). The marketplace.json on main currently references v0.26.2 plugin refs, which would cause adopter installs to fail with the same 404. The next release (v0.26.3) bumps the marketplace.json forward and supersedes v0.26.2 cleanly.

Adopters who somehow attempt v0.26.2 directly (via `--ref v0.26.2`) will hit the same 404 — they should pick v0.26.3 or later. Not worth deleting the tag (destructive operation); the orphan is harmless once the marketplace.json moves forward.

## Test plan

- [ ] Merge this PR.
- [ ] Run `/release` and ship v0.26.3 through the patched workflow.
- [ ] Watch the workflow run succeed end-to-end (publish + assert-published + marketplace smoke all pass).
- [ ] Post-release: install v0.26.3 via `/plugin marketplace update deskwork`; verify the three `@deskwork/*@0.26.3` packages reach the local cache.
- [ ] Re-run `complete-parent-closure propose --slug hygiene` on the installed v0.26.3 to close [#342](https://github.com/audiocontrol-org/deskwork/issues/342) verification per the project rule.

## Refs

- Phase 10 (the workflow this commit fixes): #343
- v0.26.2 release attempt that surfaced the issue: workflow run 26613403248
