### PR TITLE
fix(release): assert-published retries with exponential backoff (v0.26.4 transient gate fix)

### DIFF
--- a/.claude/skills/release/lib/release-helpers.ts
+++ b/.claude/skills/release/lib/release-helpers.ts
@@ -228,6 +228,62 @@ export function verifyNpmStatus(
   return { version, published, unpublished };
 }
 
+export interface VerifyNpmStatusUntilPublishedOptions {
+  /** Total attempts including the first immediate probe. Default 6. */
+  readonly maxAttempts?: number;
+  /** Initial backoff delay in ms (doubled each attempt, capped). Default 5000. */
+  readonly initialBackoffMs?: number;
+  /** Backoff cap in ms. Default 30000. */
+  readonly maxBackoffMs?: number;
+  /** Sleep function (await on it). Tests inject a no-op; default uses setTimeout. */
+  readonly sleep?: (ms: number) => Promise<void>;
+  /** Viewer callback. Default `realNpmViewer`. */
+  readonly viewer?: NpmViewer;
+}
+
+/**
+ * Retry-with-backoff wrapper around `verifyNpmStatus`. Polls the npm
+ * registry until every `@deskwork/*` package is visible at `version`, OR
+ * the attempts budget runs out.
+ *
+ * Existence-of-publishes only — exists because npm's read API (registry +
+ * CDN) lags the write API by seconds. The v0.26.4 release surfaced this:
+ * the publish step accepted PUTs for all three packages in <5 seconds,
+ * but `npm view` returned "not published" for `@deskwork/studio` for
+ * another ~10 seconds after the publish completed. Without retry, the
+ * post-publish gate fails on a transient and the workflow halts before
+ * the marketplace smoke step.
+ *
+ * Sleep is parameterized so tests inject a no-op; production uses
+ * setTimeout via the default sleep.
+ *
+ * Returns the final `NpmStatusReport`. Caller decides exit code from
+ * `report.unpublished.length === 0`.
+ */
+export async function verifyNpmStatusUntilPublished(
+  version: string,
+  opts: VerifyNpmStatusUntilPublishedOptions = {},
+): Promise<NpmStatusReport> {
+  const maxAttempts = opts.maxAttempts ?? 6;
+  const initialBackoffMs = opts.initialBackoffMs ?? 5000;
+  const maxBackoffMs = opts.maxBackoffMs ?? 30000;
+  const viewer = opts.viewer ?? realNpmViewer;
+  const sleep =
+    opts.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let lastReport = verifyNpmStatus(version, viewer);
+  let attempt = 1;
+  let backoff = initialBackoffMs;
+  while (lastReport.unpublished.length > 0 && attempt < maxAttempts) {
+    await sleep(backoff);
+    lastReport = verifyNpmStatus(version, viewer);
+    backoff = Math.min(backoff * 2, maxBackoffMs);
+    attempt += 1;
+  }
+  return lastReport;
+}
+
 export interface AtomicPushOptions {
   readonly tag: string;
   readonly branch: string;
@@ -372,12 +428,18 @@ async function dispatch(argv: readonly string[]): Promise<number> {
         process.stderr.write('usage: assert-published <version>\n');
         return 2;
       }
-      const report = verifyNpmStatus(version);
+      // Retry-with-backoff: npm's read API (registry + CDN) lags the
+      // write API by seconds. The v0.26.4 release surfaced this when
+      // the publish step completed in 5s but @deskwork/studio took
+      // another 10s to become visible to `npm view`. Without retry, the
+      // post-publish gate failed on a transient and the workflow halted
+      // before the marketplace smoke step.
+      const report = await verifyNpmStatusUntilPublished(version);
       if (report.unpublished.length > 0) {
         process.stderr.write(
           `Version ${version} is NOT yet published on npm for: ${report.unpublished.join(', ')}.\n` +
             `Either the publish step did not complete (re-run \`make publish\` in your terminal),\n` +
-            `or registry propagation is still pending (try again in a few seconds).\n`,
+            `or registry propagation is still pending after the maximum backoff window (~2 minutes).\n`,
         );
         return 1;
       }

--- a/.claude/skills/release/test/release-helpers.test.ts
+++ b/.claude/skills/release/test/release-helpers.test.ts
@@ -164,7 +164,12 @@ describe('checkPreconditions', () => {
   });
 });
 
-import { verifyNpmStatus, DESKWORK_PACKAGES, type NpmViewer } from '../lib/release-helpers.js';
+import {
+  verifyNpmStatus,
+  verifyNpmStatusUntilPublished,
+  DESKWORK_PACKAGES,
+  type NpmViewer,
+} from '../lib/release-helpers.js';
 
 describe('verifyNpmStatus', () => {
   it('reports all unpublished when viewer returns false for every spec', () => {
@@ -201,6 +206,79 @@ describe('verifyNpmStatus', () => {
       '@deskwork/cli@0.9.6',
       '@deskwork/studio@0.9.6',
     ]);
+  });
+});
+
+describe('verifyNpmStatusUntilPublished', () => {
+  it('returns on the first attempt when every spec is already visible', async () => {
+    const viewer: NpmViewer = () => true;
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    };
+    const r = await verifyNpmStatusUntilPublished('0.26.5', { viewer, sleep });
+    expect(r.unpublished).toEqual([]);
+    expect(r.published).toEqual([...DESKWORK_PACKAGES]);
+    expect(sleeps).toEqual([]);
+  });
+
+  it('retries with exponential backoff until every spec becomes visible', async () => {
+    // Simulates CDN propagation: studio first visible on the 3rd probe.
+    let probes = 0;
+    const viewer: NpmViewer = (spec) => {
+      if (spec.startsWith('@deskwork/studio@')) {
+        probes += 1;
+        return probes >= 3;
+      }
+      return true;
+    };
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    };
+    const r = await verifyNpmStatusUntilPublished('0.26.5', {
+      viewer,
+      sleep,
+      initialBackoffMs: 100,
+      maxBackoffMs: 1000,
+    });
+    expect(r.unpublished).toEqual([]);
+    // First probe sees studio unpublished; sleep(100) → second probe sees
+    // studio unpublished; sleep(200) → third probe sees studio published.
+    expect(sleeps).toEqual([100, 200]);
+  });
+
+  it('caps backoff at maxBackoffMs', async () => {
+    const viewer: NpmViewer = () => false;
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    };
+    await verifyNpmStatusUntilPublished('0.26.5', {
+      viewer,
+      sleep,
+      maxAttempts: 6,
+      initialBackoffMs: 100,
+      maxBackoffMs: 300,
+    });
+    // 5 backoffs between 6 attempts: 100, 200, 300 (capped), 300, 300.
+    expect(sleeps).toEqual([100, 200, 300, 300, 300]);
+  });
+
+  it('returns the final report (unpublished still set) when budget exhausts', async () => {
+    const viewer: NpmViewer = () => false;
+    const sleep = () => Promise.resolve();
+    const r = await verifyNpmStatusUntilPublished('0.26.5', {
+      viewer,
+      sleep,
+      maxAttempts: 3,
+      initialBackoffMs: 10,
+    });
+    expect(r.unpublished).toEqual([...DESKWORK_PACKAGES]);
+    expect(r.published).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Surfaced by the v0.26.4 release — the `Assert all three packages published` workflow step failed on a transient npm CDN propagation race even though all three packages had genuinely published seconds earlier.

## What ships

`verifyNpmStatusUntilPublished` — retry-with-backoff wrapper around the existing `verifyNpmStatus`. The `assert-published` CLI subcommand (used by the workflow's post-publish gate at `.github/workflows/publish-npm.yml:assert-published`) now calls the retry variant.

Defaults: **6 attempts, initial 5s backoff, exponential doubling capped at 30s.** Total max wait ~2 minutes — enough to ride out npm CDN propagation, short enough that a real publish failure surfaces promptly.

`assert-not-published` (used at `/release` Pause 3 pre-flight) stays one-shot — semantically asserting absence; npm caches what it has, not what it doesn't.

## Why

v0.26.4 workflow run [26614243637](https://github.com/audiocontrol-org/deskwork/actions/runs/26614243637):

- 02:25:00 — `Publish all @deskwork packages` step succeeds (all three packages PUT to npm).
- 02:26:01 — `Assert all three packages published` runs `npm view @deskwork/studio@0.26.4` → "not yet published" (CDN lag).
- 02:26:03 — Step exits non-zero. Workflow halts. Marketplace smoke skipped.
- 02:26:30 — Same `npm view` invocation locally returns success — propagation completed.

The packages WERE published. The gate was just too eager. Retry-with-backoff is the fix.

## Test coverage

4 new vitest tests in `.claude/skills/release/test/release-helpers.test.ts`:

- Immediate-success path: viewer returns true on first probe → no sleeps.
- Retry-until-visible with sleep accounting: studio first visible on third probe → sleeps are `[100, 200]` ms with `initialBackoffMs: 100`.
- Backoff capping: 6 attempts, `initialBackoffMs: 100, maxBackoffMs: 300` → sleeps are `[100, 200, 300, 300, 300]`.
- Budget exhaustion: viewer always returns false → final report carries all three in `unpublished`.

Sleep is parameterized so tests don't actually wait. Full release-helpers suite: **32 / 32 pass** (was 28; +4 new).

## Test plan

- [ ] Merge this PR.
- [ ] The next release (v0.26.5 or later) exercises the retry path. If npm propagation lag re-occurs, the workflow now rides it out instead of failing.
- [ ] Update Phase 10 Task 5 acceptance criterion as ✓ in `docs/1.0/001-IN-PROGRESS/hygiene/workplan.md` — v0.26.4 + this fix together close out "first real release uses the new workflow and succeeds end-to-end" with the documented transient surface and its remediation.

## Refs

- Phase 10 (the workflow this commit hardens): #343
- v0.26.4 release: https://github.com/audiocontrol-org/deskwork/releases/tag/v0.26.4
