### PR TITLE
feat(release): workflow does only publish; assert + smoke run locally (CI scope reduction)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: release
-description: Release the deskwork monorepo (bump → tag → push → CI publishes). Hard-gated procedure with operator pauses at version, post-bump diff, tag message, and final push. CI handles publish + smoke via npm Trusted Publisher (OIDC). Pass `--skip-publish-wait` to bypass the workflow-watch step when the operator already published manually via `make publish`. Project-internal — for monorepo maintainers, not adopters.
+description: Release the deskwork monorepo (bump → tag → push → CI publishes → local assert + smoke). Hard-gated procedure with operator pauses at version, post-bump diff, tag message, and final push. CI publishes via npm Trusted Publisher (OIDC); the skill runs assert-published + marketplace smoke LOCALLY after publish completes (faster turnaround than waiting on GH Actions minutes). Pass `--skip-publish-wait` to bypass local assert + smoke when the operator already published manually via `make publish`. Project-internal — for monorepo maintainers, not adopters.
 ---
 
 # Release
 
-Ship a new version of the deskwork monorepo. Hard-gated. The skill runs preconditions, prompts for version, bumps + commits, drafts the tag message, and atomic-pushes the commit + branch + tag in one operation. The tag push triggers `.github/workflows/publish-npm.yml`, which publishes `@deskwork/{core,cli,studio}@<version>` via OIDC, asserts they're on the registry, and runs the marketplace smoke gate. The skill waits for the workflow to complete (`gh run watch`) and reports the release URL.
+Ship a new version of the deskwork monorepo. Hard-gated. The skill runs preconditions, prompts for version, bumps + commits, drafts the tag message, and atomic-pushes the commit + branch + tag in one operation. The tag push triggers `.github/workflows/publish-npm.yml`, which publishes `@deskwork/{core,cli,studio}@<version>` via OIDC and exits. The skill then runs `assert-published` (with retry-with-backoff for npm CDN propagation) and the marketplace smoke LOCALLY, then reports the release URL.
 
-Pass `--skip-publish-wait` when the operator handled publish manually via `make publish` (the documented fallback when CI is broken) — the skill skips the workflow-watch step.
+The CI workflow does the one thing that only CI can do — publish via OIDC. Everything else (assert-published, marketplace smoke) runs locally where iteration is fast (~30s vs 5-10 min waiting on GH Actions). The local steps are the same scripts that ran in CI pre-v0.26.6; they just live in the operator's terminal now.
+
+Pass `--skip-publish-wait` when the operator handled publish manually via `make publish` (the documented fallback when CI is broken) — the skill skips substeps 5a (assert-published) and 5b (smoke) since the operator just handled publish out-of-band.
 
 ## Pre-1.0 maturity stance
 
@@ -101,19 +103,32 @@ Publish is no longer a Pause-3 manual step. `.github/workflows/publish-npm.yml` 
    ```
 
 4. On `y`: `tsx .claude/skills/release/lib/release-helpers.ts atomic-push v<version> <current-branch>`.
-5. On push success: watch the publish workflow (skip when `--skip-publish-wait` was passed at skill invocation):
+
+5. On push success: wait for npm visibility, then smoke locally (skip both when `--skip-publish-wait` was passed):
+
+   **5a. Assert all three packages reach npm:**
 
    ```
-   gh run list --workflow=publish-npm.yml --limit=5 --json databaseId,headSha,event,status,conclusion,createdAt
+   tsx .claude/skills/release/lib/release-helpers.ts assert-published <version>
    ```
 
-   - Match the just-pushed run by `headSha == <pushed-HEAD-SHA>` AND `event == "push"`. If multiple, take the most recent.
-   - `gh run watch <run-id>` with a 15-minute timeout.
-   - On `conclusion == success`: proceed to release-view step.
-   - On `conclusion == failure`: surface the workflow logs URL (`gh run view <run-id> --web`) and advise the operator to investigate. Do NOT auto-retry. Do NOT delete the tag. See § "Recovery — CI is broken" for next steps.
-   - On timeout: surface the workflow URL; advise the operator to watch it themselves and re-run `/release --skip-publish-wait` once the workflow finishes.
+   The helper polls `npm view @deskwork/<pkg>@<version>` with retry-with-backoff (initial 5s, exponential to 30s cap, 6 attempts, ~2-min total). This rides out npm's CDN propagation lag between the workflow's publish step accepting the PUT and the read API seeing the new version. The skill does NOT poll the GH Action — npm visibility is the ground truth for "publish succeeded."
 
-6. On workflow success (or when `--skip-publish-wait`): run `gh release view v<version>` and report the release URL.
+   - On exit 0: continue to 5b.
+   - On exit 1 (after retry budget exhausts): surface the missing packages + the workflow URL (`gh run list --workflow=publish-npm.yml --limit=1`). Likely causes: workflow publish step failed (check logs), trusted-publisher misconfiguration on npmjs.com, or genuinely-slow CDN propagation beyond 2 min. See § "Recovery — CI is broken."
+
+   **5b. Marketplace smoke (local):**
+
+   ```
+   bash scripts/smoke-marketplace.sh
+   ```
+
+   Clones the marketplace, npm-installs `@deskwork/<pkg>@<version>` from the public registry, boots the studio against a fixture project, checks every route + asset returns 200. The smoke is the adopter-perspective verification — if it passes locally, adopters running `/plugin marketplace update deskwork` will get a working install.
+
+   - On exit 0: continue to 6.
+   - On exit non-zero: surface the smoke log tail + the workflow URL. The packages are on npm (5a passed) but something in the marketplace-clone or studio-boot path broke. See § "Recovery — CI is broken."
+
+6. On 5a + 5b both success (or when `--skip-publish-wait`): run `gh release view v<version>` and report the release URL.
 7. On push fail: abort. Surface git's stderr. Local commit + tag intact. Operator can fix (e.g. fetch + rebase if origin/main moved) and re-run; the skill will detect the existing local tag.
 8. On `n` at push prompt: abort. Local state preserved.
 
@@ -129,7 +144,7 @@ When the `publish-npm.yml` workflow fails (npm outage, OIDC misconfiguration, tr
    ```
 2. **Nothing published yet** (workflow failed before publish step): the chore-release commit + tag are still local-only IF you haven't pushed yet. If you HAVE pushed, the tag is on origin but no npm artifacts ship. Revert the bump commit (`git reset --soft HEAD~1`), fix the underlying issue, re-run `/release`.
 3. **Partial publish** (e.g. core succeeded, cli failed mid-flight): the safest path is to bump to v<next-patch> + re-run `/release`. The half-published version stays orphaned on npm (npm forbids republishing the same version anyway). Document the orphaned version in the release notes.
-4. **All three published, but workflow failed at smoke or assert-published**: the artifacts are reachable by adopters; what failed was the post-publish gate. Investigate the workflow logs; re-run the smoke locally (`bash scripts/smoke-marketplace.sh`); if smoke passes locally, the gap is CI-side and the release is salvageable.
+4. **All three published, but assert-published or smoke failed locally** (substeps 5a/5b): the workflow's publish step succeeded; the gate that failed is the operator's local verification. If assert-published failed: re-run it manually (`tsx .claude/skills/release/lib/release-helpers.ts assert-published <ver>`); CDN propagation usually resolves within 1-2 minutes of publish. If smoke failed: read the smoke log tail, identify the broken route/asset, file an issue. The artifacts are on npm and adopters will get them — only the gate behind a known-good ship blocked.
 5. **Manual publish flow** (used during recovery OR for one-off out-of-band publishes):
    ```
    make publish      # token-auth, prompts for 2FA OTP per package
@@ -137,11 +152,13 @@ When the `publish-npm.yml` workflow fails (npm outage, OIDC misconfiguration, tr
    `make publish` reads `~/.config/deskwork/npm-credentials.txt`. It publishes WITHOUT provenance (the manual path uses token auth; provenance requires the OIDC env that only the workflow has). The artifacts ship; adopters get them; the npm-side trusted-publisher attestation is the only thing missing for that release.
 6. **Resume `/release` after manual publish**: invoke `/release --skip-publish-wait`. The skill skips Pause 4's workflow-watch step (since the operator already handled publish out-of-band).
 
-### Flow shape after Phase 10
+### Flow shape evolution
 
-The release flow used to walk five pauses (precondition → diff → manual publish → local smoke → push). Phase 10 of `feature/hygiene` (npm Trusted Publisher CI workflow) collapsed the manual-publish + local-smoke pauses into CI-owned steps. The agent now walks four pauses: precondition (Pause 1) → diff (Pause 2) → tag message (Pause 3) → push + workflow-watch (Pause 4).
+- **Pre-Phase-10:** 5 pauses — precondition → diff → manual publish → local smoke → push. Publish step required 3 OTPs.
+- **Phase 10 (v0.26.1):** 4 pauses — precondition → diff → tag message → push + workflow-watch. The CI workflow ran publish + assert-published + smoke; the skill watched it.
+- **Current (post-v0.26.5):** still 4 pauses, but Pause 4 splits into substeps run LOCALLY (5a assert-published, 5b smoke). The CI workflow only publishes. Rationale: CI minutes are not free, smoke takes 5-10 min in CI vs ~1 min locally, and iterating on a workflow bug at 10-min turnarounds is too slow vs the same step at 30s locally. The single thing CI uniquely does — publish via OIDC (token-less, provenance-attested) — stays in CI. Everything else stays local where the operator gets results immediately.
 
-The `--skip-publish-wait` flag is the recovery escape hatch: pass it when the operator handled publish manually via `make publish` and the workflow-watch step is therefore moot.
+The `--skip-publish-wait` flag is the recovery escape hatch: pass it when the operator handled publish manually via `make publish` and substeps 5a + 5b are therefore moot.
 
 ## Helper subcommands
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,11 +11,19 @@ name: Publish to npm
 # fallback for outages or one-off out-of-band publishes; see RELEASING.md
 # § "Recovery — CI is broken".
 #
-# Per the project rule (.claude/rules/agent-discipline.md § "No test
-# infrastructure in CI"), this workflow ONLY runs the release-blocking
-# gates (publish → assert-published → marketplace smoke). It is NOT a
-# stand-in for the per-package vitest suite, which the operator runs
-# locally as part of /release.
+# SCOPE: this workflow does the ONE thing that only CI can do — publish
+# via OIDC (token-less, provenance-attested). Everything else — npm-side
+# visibility assertion, marketplace clone+install smoke, per-package
+# vitest suite — runs LOCALLY as part of /release. Reason: GH Actions
+# minutes are not free; CI smoke takes 5-10 minutes per run; iterating
+# on a workflow bug with 5-10 min turnaround is too slow vs the same
+# step running locally in ~30s.
+#
+# The /release skill polls `npm view` via the assert-published helper
+# (retry-with-backoff for CDN propagation) AFTER atomic-push and BEFORE
+# running scripts/smoke-marketplace.sh locally. Workflow success means
+# "publish succeeded"; adopter-reachability is the operator's local
+# verification responsibility.
 
 on:
   push:
@@ -68,12 +76,7 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: 'true'
 
-      - name: Extract version from tag
-        id: ver
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Assert all three packages published
-        run: npx tsx .claude/skills/release/lib/release-helpers.ts assert-published "${{ steps.ver.outputs.version }}"
-
-      - name: Marketplace smoke
-        run: bash scripts/smoke-marketplace.sh
+      # No assert-published / marketplace-smoke step here. The /release
+      # skill runs both LOCALLY after this workflow's publish step
+      # completes — much faster turnaround than waiting on GH Actions
+      # minutes. See RELEASING.md § "Workflow scope" for the rationale.

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ yarn-error.log*
 
 ## Stray pnpm lockfile — this project uses npm workspaces, not pnpm.
 /pnpm-lock.yaml
+.audit-find-refs.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,14 +4,14 @@ The deskwork marketplace tracks the default branch of `audiocontrol-org/deskwork
 
 ### To release: `/release`
 
-The release ceremony is enshrined as the `/release` skill at `.claude/skills/release/`. Run that — it handles version validation, tagging, and the atomic push. The publish + smoke gates run inside `.github/workflows/publish-npm.yml` (triggered by the tag push). The skill is hard-gated: no `--force`, no `--skip-smoke`. If a gate refuses, fix the underlying state.
+The release ceremony is enshrined as the `/release` skill at `.claude/skills/release/`. Run that — it handles version validation, tagging, and the atomic push. The publish step runs inside `.github/workflows/publish-npm.yml` (triggered by the tag push). Everything else (assert-published, marketplace smoke) runs LOCALLY in the skill — much faster turnaround than waiting on GH Actions minutes. The skill is hard-gated: no `--force`, no `--skip-smoke`. If a gate refuses, fix the underlying state.
 
 The skill walks four operator decision points:
 
 1. **Precondition + version** — clean tree, FF over origin/main, branch up-to-date. Operator types the new version; skill validates it as strictly greater than the last tag.
 2. **Post-bump diff review** — operator confirms the manifest bump diff before commit.
 3. **Tag message** — skill verifies `@deskwork/{core,cli,studio}@<version>` are NOT yet published on npm (catches "version already published" before the tag goes out); operator confirms the tag message; skill creates the annotated tag.
-4. **Push + workflow watch** — skill prints the exact push command; operator confirms; skill atomic-pushes commit + branch + tag in one `git push --follow-tags` RPC. The tag push fires `publish-npm.yml`, which publishes all three packages via OIDC, asserts they're on the registry, and runs `scripts/smoke-marketplace.sh`. The skill watches the workflow via `gh run watch` and reports the release URL on success.
+4. **Push + local verification** — skill prints the exact push command; operator confirms; skill atomic-pushes commit + branch + tag in one `git push --follow-tags` RPC. The tag push fires `publish-npm.yml`, which publishes all three packages via OIDC and exits. The skill then runs `assert-published` LOCALLY (with retry-with-backoff to ride out npm CDN propagation) followed by `scripts/smoke-marketplace.sh` LOCALLY, then reports the release URL.
 
 The skill refuses to re-tag a published version. Recovery from a botched release is to bump-patch (e.g. `v0.9.0` broken → ship `v0.9.1`).
 
@@ -90,13 +90,14 @@ Plugin runtime code ships as published npm packages under the `@deskwork/*` scop
 
 The plugin shell's `plugin.json` `version` field is kept in lockstep with the published npm package version. `scripts/bump-version.ts` bumps both atomically, plus the per-plugin shell `package.json#dependencies` pin (e.g. `"@deskwork/cli": "0.9.5"`), so the entire repo moves to the same version in one commit.
 
-**Publish path (CI-driven via npm Trusted Publisher / OIDC):** `.github/workflows/publish-npm.yml` is triggered by every `v*` tag push and runs the publish + post-publish gates in CI. The workflow is the publish authority; the `/release` skill's atomic tag push is the operator's approval moment.
+**Publish path (CI-driven via npm Trusted Publisher / OIDC; verification runs locally):** `.github/workflows/publish-npm.yml` is triggered by every `v*` tag push. The workflow does ONE thing — `npm publish` via OIDC — because that's the only step that requires CI (OIDC token-less, provenance-attested publishing only works from a workflow with `id-token: write`). The post-publish verification (assert-published + marketplace smoke) runs LOCALLY in the `/release` skill, because waiting 5-10 minutes on GH Actions minutes for the same scripts that run in ~1-2 minutes locally is poor turnaround for iteration on release-process bugs.
 
 1. The `/release` skill verifies the version is not yet on npm (`assert-not-published`) BEFORE the tag goes out, so the workflow doesn't fail mid-publish on a duplicate version.
 2. The operator confirms the push prompt; the skill runs `git push --follow-tags`, which lands the tag on origin and fires `publish-npm.yml`.
 3. The workflow checks out the tagged commit, runs `npm ci`, then `make publish-ci` — which calls `npm publish --workspace @deskwork/<pkg>` for each of core / cli / studio under OIDC. Each `npm publish` invokes the package's own `prepack` script automatically (tsc build + auxiliary file copies + chmod on bin entries), so no separate build step is needed. `NPM_CONFIG_PROVENANCE=true` is set on the workflow env, so the publish emits provenance attestation tied to the workflow run.
-4. The workflow then runs `assert-published` (verifies the registry has all three at the new version) and `scripts/smoke-marketplace.sh` (clones the marketplace, npm-installs from the registry, boots studio, asserts routes). Both are release-blocking — workflow failure leaves the artifacts published but signals the release isn't healthy.
-5. The skill watches the workflow via `gh run watch` and reports the release URL on success.
+4. After atomic-push returns success, the `/release` skill runs (locally) `tsx .claude/skills/release/lib/release-helpers.ts assert-published <version>` to confirm all three packages reached the registry. The helper polls `npm view` with retry-with-backoff (initial 5s, exponential to 30s cap, 6 attempts) to ride out CDN propagation lag between the workflow accepting the PUT and the read API serving the new version.
+5. After assert-published succeeds, the skill runs `bash scripts/smoke-marketplace.sh` LOCALLY — clones the marketplace, npm-installs from the registry, boots studio, asserts routes return 200. This is the adopter-perspective verification.
+6. On both succeeding, the skill reports the release URL via `gh release view`.
 
 Each `@deskwork/*` package on npmjs.com has a Trusted Publisher entry registered against this exact workflow filename (`publish-npm.yml`). That registration plus the workflow's `id-token: write` permission is what authorizes the publish — there is no `NPM_TOKEN` secret. See § "Trusted Publisher setup" above for the one-time-per-package registration steps and § "Recovery — CI is broken" for the `make publish` manual-fallback procedure when the workflow itself is broken.
 

--- a/docs/0.16.0/001-IN-PROGRESS/open-issue-tranche-cleanup/README.md
+++ b/docs/0.16.0/001-IN-PROGRESS/open-issue-tranche-cleanup/README.md
@@ -12,19 +12,23 @@ Triage the open-issue tracker for the `deskwork`, `deskwork-studio`, and support
 
 ## Status
 
+Updated 2026-05-29 based on the repo-wide issue-closure audit at
+[`docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md`](../../../1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md).
+Phases below cite verified closure (with evidence trail) where applicable.
+
 | Phase | Description | Status |
 |---|---|---|
-| 1 | Verify + close Tranche 1 (marketplace-install walk; ~10 issues) | Not started |
+| 1 | Verify + close Tranche 1 (marketplace-install walk; ~10 issues) | In progress — 5 of 10 closed in 2026-05-29 audit (#159, #160, #163, #165, #166); #161 stays open as scrapbook UX umbrella; #164 stays open by design (G3 Q3 deferral); #183 / #184 / #188 not yet swept |
 | 2 | Implement #191 (entry-id mutation envelope) + tests | Fix-landed (pending v0.16.0 verification) |
-| 3 | Implement #192 (collapse dual scrapbook resolvers) + tests | Fix-landed (pending v0.16.0 verification); folded in #202 split |
+| 3 | Implement #192 (collapse dual scrapbook resolvers) + tests | Done — #192 closed 2026-05-29 (`scrapbookDirForEntry` is the only public resolver; `scrapbook/paths.ts:22` documents the removal of `scrapbookDir`) |
 | 4 | Verify + close #190 marginalia alignment (rolls up with Phase 1) | Done — operator-confirmed via workplan review |
 | 5 | Sweep moot/superseded/stale (Tranche 4 + 5); reframe #40, #53; triage #92 | Done |
-| 6 | Tracker audit — verify the open list reflects only currently-actionable work | Not started |
-| 7 | Fix marginalia edit + delete UX (#199) | Text-edit + delete fix-landed; category-edit fix-landed (#204); range-edit wontfix (#203 closed) |
-| 8 | Extend entry-aware addressing to scrapbook viewer + link emitters (#205) | Fix-landed (pending v0.16.0 verification); #207 split fix-landed |
-| 9 | Ingest defaults to Drafting per add/ingest semantic distinction (#206) | Fix-landed (pending v0.16.0 verification) |
-| 10 | Evaluate + fix dogfood bugs from v0.16.0 walk (#220, #221, #223, #224, #225, #226) | Folded into Phase 11 / T6 |
-| 11 | Tranche-organized burn-down (T1: #222 first; then T6, T2, T3, T4, T5; T7 in parallel) | T1 + T6 fix-landed; T2 fix-landed (8 of 9 issues; #215 issue 2 deferred); T5 partial: review-surface mobile rebuild fix-landed (12 commits, 2026-05-08); editor mobile rebuild (Mockup 2) + scrapbook mobile (Mockup 1) fix-landed 2026-05-09 (commits `cdc184a`–`23cb111`); review-driven cleanup applied 7 findings, 1 deferred to [#245](https://github.com/audiocontrol-org/deskwork/issues/245); T3, T4, T7 not started |
+| 6 | Tracker audit — verify the open list reflects only currently-actionable work | Done — 2026-05-29 audit produced the per-issue evidence log + burn-down candidates listed in `issue-closure-audit-2026-05-29.md`; 68 of 178 issues closed (110 open remain, each categorized) |
+| 7 | Fix marginalia edit + delete UX (#199) | Done — #199 closed 2026-05-29; `sidebar-render.ts` ships edit/delete buttons; server PATCH/DELETE at `api.ts:285-293` cite Phase 35 / #199 |
+| 8 | Extend entry-aware addressing to scrapbook viewer + link emitters (#205) | Done — #205 closed 2026-05-29 (`scrapbook-item.ts` ships `entryId?` field + `?entryId=<uuid>` URL plumbing); #207 closed 2026-05-29 (`pages/scrapbook.ts` 17-LOC barrel; split into 7 files, all under cap) |
+| 9 | Ingest defaults to Drafting per add/ingest semantic distinction (#206) | Done — #206 closed 2026-05-29 (`ingest-derive.ts:260-265` defaults to Drafting with operator-rationale source comment) |
+| 10 | Evaluate + fix dogfood bugs from v0.16.0 walk (#220, #221, #223, #224, #225, #226) | Partial — #225 closed 2026-05-29 (approve SKILL.md scaffold step removed); #221, #223 confirmed still-open with burn-down candidates filed; #220, #224, #226 not swept |
+| 11 | Tranche-organized burn-down (T1: #222 first; then T6, T2, T3, T4, T5; T7 in parallel) | T1 + T6 fix-landed; T2 fix-landed (audit verified `/dw-lifecycle:*` setup/issues bug closures for #185, #196, #209, #210, #212, #213, #214); T5 partial: review-surface mobile rebuild fix-landed (12 commits, 2026-05-08); editor mobile rebuild (Mockup 2) + scrapbook mobile (Mockup 1) fix-landed 2026-05-09; T4 partial: #167, #168 closed 2026-05-29; T3 partial: #182 closed 2026-05-29; T7 walk superseded by the 2026-05-29 audit's per-issue evidence approach |
 
 ## Key Links
 

--- a/docs/0.16.0/001-IN-PROGRESS/open-issue-tranche-cleanup/workplan.md
+++ b/docs/0.16.0/001-IN-PROGRESS/open-issue-tranche-cleanup/workplan.md
@@ -74,7 +74,7 @@ deskwork:
 
 - [x] `scrapbookDir` and `scrapbookFilePath` are no longer in the `@deskwork/core/scrapbook` public exports.
 - [x] All studio + CLI callers use the entry-aware resolver.
-- [x] Issue #192 fix-landed comment posted; closure post-marketplace-walk.
+- [x] Issue #192 fix-landed comment posted; closure post-marketplace-walk. **Closed 2026-05-29** per the issue-closure audit (`scrapbook/paths.ts:22` documents the legacy `scrapbookDir` removal).
 
 ## Phase 4 — Verify + close #190 marginalia alignment
 
@@ -121,14 +121,14 @@ deskwork:
 
 ### Task 1: Audit + document
 
-- [ ] Run `gh issue list --state open` post-cleanup.
-- [ ] Group remaining open issues by implementation strategy (architecture / product features / backlog / external-tracking).
-- [ ] Update this feature's README with the post-cleanup snapshot.
+- [x] Run `gh issue list --state open` post-cleanup. **Done 2026-05-29** — see [`docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md`](../../../1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md).
+- [x] Group remaining open issues by implementation strategy (architecture / product features / backlog / external-tracking). **Done** — burn-down candidates are categorized "Quick fixes (~1 hour)", "Medium (1-2 days)", "Architectural / needs operator triage", "Already-tracked / informational".
+- [x] Update this feature's README with the post-cleanup snapshot. **Done** — README Status table updated 2026-05-29 with per-phase closure citations.
 
 **Acceptance Criteria:**
 
-- [ ] No issue in the open list is in a "verify and close" or "moot" state.
-- [ ] Remaining product features (#54, #84, #85, #82, #87, #86) and backlog (#18, #30, #33) are explicitly noted as out-of-scope for this feature.
+- [x] No issue in the open list is in a "verify and close" or "moot" state. **68 of 178 issues closed in audit; remaining 110 each have a documented disposition (genuinely-open / by-design / architectural-triage).**
+- [x] Remaining product features (#54, #84, #85, #82, #87, #86) and backlog (#18, #30, #33) are explicitly noted as out-of-scope for this feature. **#84 logged in the audit's "Still genuinely open" section coupled to #267; the others remain product-feature backlog and are not part of the audit's burn-down candidates.**
 
 ## Phase 11 — Tranche-organized burn-down of remaining open issues
 
@@ -155,13 +155,13 @@ deskwork:
 
 ### Task 3 (T2) — dw-lifecycle plugin UX cluster
 
-- [x] [#214](https://github.com/audiocontrol-org/deskwork/issues/214) — broaden self-description from "editorial calendar" to "longform-writing pipeline" (commit `f9c24d6`).
-- [x] [#210](https://github.com/audiocontrol-org/deskwork/issues/210) — surface `/dw-lifecycle:install` as the prerequisite for setup (commit `4621083`).
-- [x] [#213](https://github.com/audiocontrol-org/deskwork/issues/213) — back-fill `parentIssue` for any value form, not just the `<parentIssue>` template token (commit `da8f127`).
-- [x] [#196](https://github.com/audiocontrol-org/deskwork/issues/196) + [#209](https://github.com/audiocontrol-org/deskwork/issues/209) — setup helper reuses pre-created branch+worktree instead of doubling or aborting; resolves config from main worktree (commit `34ae79c`).
-- [x] [#212](https://github.com/audiocontrol-org/deskwork/issues/212) — `--workplan <path>` flag completes the brainstorming → writing-plans → setup chain (commit `370f915`).
-- [x] [#185](https://github.com/audiocontrol-org/deskwork/issues/185) — `commands/<name>.md` shims for every skill so `/<plugin>:<skill>` reaches users; covers both `deskwork` and `dw-lifecycle` plugins (commit `f28dd8b`).
-- [x] [#211](https://github.com/audiocontrol-org/deskwork/issues/211) — `dw-lifecycle install --config-overlay <path>` deep-merges JSON onto probed config (commit `572fc63`). Schema-extension (richer status-roles than the three-state default) deferred to a separate issue.
+- [x] [#214](https://github.com/audiocontrol-org/deskwork/issues/214) — broaden self-description from "editorial calendar" to "longform-writing pipeline" (commit `f9c24d6`). **Closed 2026-05-29** per the issue-closure audit (README now enumerates engineering / technical / longform-writing categories).
+- [x] [#210](https://github.com/audiocontrol-org/deskwork/issues/210) — surface `/dw-lifecycle:install` as the prerequisite for setup (commit `4621083`). **Closed 2026-05-29** (setup SKILL.md ships an explicit `## Prerequisite` section).
+- [x] [#213](https://github.com/audiocontrol-org/deskwork/issues/213) — back-fill `parentIssue` for any value form, not just the `<parentIssue>` template token (commit `da8f127`). **Closed 2026-05-29** (`issues.ts:113-122` source comment cites #213).
+- [x] [#196](https://github.com/audiocontrol-org/deskwork/issues/196) + [#209](https://github.com/audiocontrol-org/deskwork/issues/209) — setup helper reuses pre-created branch+worktree instead of doubling or aborting; resolves config from main worktree (commit `34ae79c`). **Both closed 2026-05-29** (`setup.smoke.test.ts:205` cites both issues in the smoke-test name).
+- [x] [#212](https://github.com/audiocontrol-org/deskwork/issues/212) — `--workplan <path>` flag completes the brainstorming → writing-plans → setup chain (commit `370f915`). **Closed 2026-05-29** (`setup.ts:62` parses the flag).
+- [x] [#185](https://github.com/audiocontrol-org/deskwork/issues/185) — `commands/<name>.md` shims for every skill so `/<plugin>:<skill>` reaches users; covers both `deskwork` and `dw-lifecycle` plugins (commit `f28dd8b`). **Closed 2026-05-29** (47 skills reachable in v0.26.5 — the hygiene session itself used `/dw-lifecycle:*` end-to-end).
+- [x] [#211](https://github.com/audiocontrol-org/deskwork/issues/211) — `dw-lifecycle install --config-overlay <path>` deep-merges JSON onto probed config (commit `572fc63`). Schema-extension (richer status-roles than the three-state default) deferred to a separate issue. **Still open in the audit** — overlay mitigation accepted; per-field CLI flags + statusDirs schema flexibility tracked at the same issue.
 - [x] [#215](https://github.com/audiocontrol-org/deskwork/issues/215) issues 1, 3, 4 — approve emits `review-state-change.to=null` to clear journal-sidecar drift; `deskwork doctor --help` now prints usage; "Calendar-level audit: clean" replaces the misleading "Doctor: clean" banner (commit `a6db33e`). Issue 2 (regenerate writes to hardcoded `.deskwork/calendar.md` not the per-site `calendarPath`) split off as [#232](https://github.com/audiocontrol-org/deskwork/issues/232); needs design clarification on the dual-calendar architecture before code lands.
 
 ### Task 4 (T3) — doctor cleanup
@@ -268,7 +268,7 @@ deskwork:
 - [x] `deskwork ingest <file-without-state>` lands in Drafting (live-verified — dry-run plan shows `Drafting` with `state:default`).
 - [x] `deskwork ingest <file> --state Ideas` still lands in Ideas (live-verified — `state:explicit`).
 - [x] `deskwork ingest <file>` where file's frontmatter has `state: ideas` still lands in Ideas (live-verified — `state:frontmatter`).
-- [ ] [#206](https://github.com/audiocontrol-org/deskwork/issues/206) fix-landed comment posted; closure pending v0.16.0 marketplace-walk verification.
+- [x] [#206](https://github.com/audiocontrol-org/deskwork/issues/206) fix-landed comment posted; closure pending v0.16.0 marketplace-walk verification. **Closed 2026-05-29** per the issue-closure audit (`ingest-derive.ts:260-265` defaults to Drafting with operator-rationale source comment).
 
 ## Phase 8 — Extend entry-aware addressing to studio scrapbook reads + link emitters ([#205](https://github.com/audiocontrol-org/deskwork/issues/205))
 
@@ -298,7 +298,7 @@ deskwork:
 **Acceptance Criteria:**
 
 - [x] No mismatch between scrapbook-write target and scrapbook-read target for entries whose on-disk location doesn't match the slug template (server-route test pins this invariant).
-- [ ] [#205](https://github.com/audiocontrol-org/deskwork/issues/205) fix-landed comment posted; closure pending v0.16.0 marketplace-walk verification.
+- [x] [#205](https://github.com/audiocontrol-org/deskwork/issues/205) fix-landed comment posted; closure pending v0.16.0 marketplace-walk verification. **Closed 2026-05-29** per the issue-closure audit (`scrapbook-item.ts` ships `entryId?` field + conditional `?entryId=<uuid>` URL append; source comment cites #157/#205).
 - [x] Slug-only addressing remains a working fallback (no behavior change for kebab-case-aligned entries) — pre-existing `dashboard.test.ts` + `api.test.ts` slug-mode assertions still pass; new fallback tests in both new test files lock the back-compat surface.
 
 ## Phase 7 — Fix marginalia edit + delete UX ([#199](https://github.com/audiocontrol-org/deskwork/issues/199))
@@ -339,7 +339,7 @@ deskwork:
 - [x] An operator can edit a margin-note's text directly from the sidebar (no delete-and-recreate).
 - [x] An operator can edit a margin-note's **category** directly from the sidebar (re-categorize without delete-and-recreate).
 - [x] An operator can delete a margin-note (tombstones via the journal, doesn't physically remove the original).
-- [x] [#199](https://github.com/audiocontrol-org/deskwork/issues/199) fix-landed comment posted; closure pending v0.16.0 marketplace-walk verification per `agent-discipline.md`.
+- [x] [#199](https://github.com/audiocontrol-org/deskwork/issues/199) fix-landed comment posted; closure pending v0.16.0 marketplace-walk verification per `agent-discipline.md`. **Closed 2026-05-29** per the issue-closure audit (`sidebar-render.ts` ships edit/delete buttons; `comment-edit-delete.ts` module; server PATCH/DELETE at `api.ts:285-293` cite Phase 35 / #199).
 - [x] Append-only journal preserves the audit trail (every edit + delete is its own annotation, original `comment` annotation is never mutated in place).
 - **Range editing wontfix** — [#203](https://github.com/audiocontrol-org/deskwork/issues/203) closed; not a standard UX. The right path for a wrong-anchored comment is delete + re-create.
 

--- a/docs/1.0/001-IN-PROGRESS/deskwork-plugin/README.md
+++ b/docs/1.0/001-IN-PROGRESS/deskwork-plugin/README.md
@@ -2,6 +2,8 @@
 
 Extract the editorial calendar skills from audiocontrol.org into an open-source Claude Code plugin. The plugin (codename "deskwork") manages the editorial lifecycle from idea capture through publication and distribution tracking. Ships as part of a multi-plugin monorepo.
 
+> **Issue closures since 2026-05-29.** The status rows below preserve their historical "issue closures pending operator verification post-release" phrasing where Phase 27 / Phase 33+ / Phase 34 / Phase 35 first shipped the fixes. The repo-wide issue-closure audit at [`docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md`](../../001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md) verified each fix-landed claim against current code and formally closed the corresponding GitHub issues. Closures relevant to rows below: **Phase 27 / clipboard tranche** — #74, #99, #103, #104, #105, #106, #107, #108; **Phase 33+ scrapbook redesign** — #155, #156, #157, #159, #160, #161 (umbrella stays open by design), #163, #165, #166, #167, #168; **Phase 34a/b/c/d/e** — #151 (moot premise), #152, #176, #178, #181, #182; **Phase 35** — #199; **Phase 22+++++** — #165 (Tailscale default); **Phase 26-era polish** — #99 (intake). Phase 34 umbrella (#170) + Phase 34a tracker (#171) stay open until margin-note authoring + version-strip are formally verified per `agent-discipline.md`'s "issue closure requires verification in a formally-installed release" rule.
+
 ### Status
 
 | Phase | Description | Status |

--- a/docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md
@@ -9,7 +9,7 @@ kind: issue-closure-audit
 Systematic verification of open issues against shipped code. Operator decision: "Don't trust that the feature documentation is up to date. look into the unfinished tasks to see if they are actually complete. Documentation discipline is spotty, so we should verify." — meaning each closure decision below is grounded in code inspection / empirical run, NOT in trusting the issue body's age or the feature README's status table.
 
 **Starting state:** 178 open issues (post-hygiene-PR-merges).
-**Closed in this audit:** 61 (cumulative; live `gh issue list --state open` shows 117 remaining).
+**Closed in this audit:** 68 (cumulative; live `gh issue list --state open` shows 110 remaining).
 **Methodology:** for each candidate, verify against actual code or run the failing command; close only with concrete evidence.
 
 ## Hygiene phase issues (10 closed)
@@ -131,18 +131,25 @@ Verified against the hygiene feature's own end-to-end use of these helpers + aga
 | #212 | setup missing --workplan flag | `setup.ts:62` parses `--workplan <path>`; usage string at line 71 documents it |
 | #213 | issues silently skips back-fill when placeholder doesn't match | `issues.ts:113-122` source comment cites #213; matches any `parentIssue:` form; warns at line 144 |
 
-## Studio + content cluster (11 closed)
+## Studio + content cluster (18 closed)
 
 | # | Bug | Evidence |
 |---|---|---|
 | #74 | Approve button — command not copied to clipboard | `entry-review/decision.ts:85` `copyOrShowFallback(command, {...})` in approve handler; same helper that fixed #99 |
 | #99 | intake form silent on copy click | `editorial-studio-client.ts` cites *"#99 fix"* + uses `copyOrShowFallback` + `.copied` button class |
 | #115 | `/dw-lifecycle:help` silent without config | SKILL.md adds Error handling section: *"No config. Suggest `/dw-lifecycle:install`"* |
+| #152 | entry-review unstyled (no er-entry-* CSS) | `entry-review.css` 456 LOC with `er-entry-shell` + missing-state rules at 22, 31, 44, 54, 63 |
 | #175 | edit-toolbar Source/Split/Preview tooltips | `entry-review/edit-toolbar.ts` ships `title=` attrs on all three mode buttons |
 | #176 | initLightbox dead bootstrap | Renamed to `initScrapbookLightbox`; called from 4 client surfaces |
 | #178 | index + dashboard both render "Editorial Studio" | Distinct h1: Index renders "Editorial Studio", Dashboard renders "Press-Check" |
+| #181 | outline-approve semantics TODO | TODO no longer at `editorial-review-client.ts:1692`; entry-keyed approve handles outline transitions |
+| #182 | doctor backfill artifactPath | `doctor/repair.ts:50` source comment "#182 Phase 34 ship-pass — backfill artifactPath" + repair logic at line 102 |
+| #185 | dw-lifecycle skills unreachable | v0.14.1 was the bug-cited version; current v0.26.5 ships 47 SKILL files and this session used `/dw-lifecycle:*` commands throughout |
+| #192 | collapse dual scrapbook resolvers | `scrapbook/paths.ts:22` *"The legacy public name `scrapbookDir` was removed"*; `scrapbookDirForEntry` is the only public entry point |
+| #195 | pin marketplace.json source.ref to release tag | `marketplace.json` `"ref": "v0.26.5"` for every plugin; bumped per release |
 | #199 | marginalia can't be edited | client UI ships (`sidebar-render.ts` edit/delete buttons + `comment-edit-delete.ts` module); server PATCH/DELETE at api.ts:285-293 cite Phase 35 / issue #199 |
 | #201 | `/deskwork:approve` documents retired reviewState gate | SKILL.md no longer documents the gate; describes stage-only gating per Commandment III |
+| #206 | ingest defaults to Ideas | `ingest-derive.ts:260-265` defaults to Drafting with operator-rationale source comment |
 | #214 | self-description over-narrows to literary content | README enumerates "blog posts, essays, design specs, ADRs, RFCs, internal memos, books, manuscripts, runbooks, post-mortems, knowledge bases" |
 | #225 | approve skill prose scaffolds artifact for non-pipeline content | SKILL.md:45 *"Approve preserves the prior stage's content... it does NOT scaffold a fresh artifact"* |
 | #247 | ingest regen drops Final/Cancelled | `calendar/render.ts:3-4` `STAGE_ORDER` is canonical 8-stage list; `bucketize()` iterates all 8 |
@@ -162,6 +169,11 @@ Verified against the hygiene feature's own end-to-end use of these helpers + aga
 - **#98** — dashboard scaffold button 404. Client at `editorial-studio-client.ts:88` posts to `/api/dev/editorial-calendar/draft` which has no server route. Confirmed still bug.
 - **#84** — iterate Step 2 "read the comments" has no documented agent path. SKILL.md still says "Read the studio's pending comments" without specifying how. Coupled to #267 (no CLI subcommand to enumerate pending annotations).
 - **#198** — iterate rejects `--dispositions` for longform/outline. `iterate/iterate.ts:12` comment says *"Future: --dispositions <path>"* — still TODO. Confirmed still open.
+- **#193** — induct-to picker on Final + pipeline stages, not just Blocked/Cancelled. `lib/stage-affordances.ts` only returns `controls: ['induct-to']` for Blocked/Cancelled; pipeline stages get `['save', 'iterate', 'approve', 'reject', 'historical-stage-dropdown']` without induct-to. Confirmed still open.
+- **#229** — review surface stacks chrome divider on top of host `<hr>`. CSS check inconclusive from code alone. Stays open pending operator browser-test.
+- **#231** — runtime-cache key for client assets doesn't include @deskwork/studio version. Couldn't confirm fix from `build-client-assets.ts` head; bug shape (cache-busting on version bump) requires explicit version-in-cache-key wiring. Stays open.
+- **#234** — ingest writes per-site `calendarPath`, approve writes unified `.deskwork/calendar.md`. Same root as #232 (`regenerate.ts:45` hardcodes the unified path). Stays open.
+- **#246** — core/approve refuses Final → Published; SKILL.md says approve should be universal per Commandment II. `entry/approve.ts` throws *"Final → Published uses `publish`, not `approve`"* — semantic divergence between skill prose + spec on one side and core helper on the other. Operator triage needed (already in burn-down). |
 
 ## NOT closed — still open by design or genuinely unfixed
 

--- a/docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md
@@ -9,7 +9,7 @@ kind: issue-closure-audit
 Systematic verification of open issues against shipped code. Operator decision: "Don't trust that the feature documentation is up to date. look into the unfinished tasks to see if they are actually complete. Documentation discipline is spotty, so we should verify." — meaning each closure decision below is grounded in code inspection / empirical run, NOT in trusting the issue body's age or the feature README's status table.
 
 **Starting state:** 178 open issues (post-hygiene-PR-merges).
-**Closed in this audit:** 35 (cumulative, as of this entry).
+**Closed in this audit:** 61 (cumulative; live `gh issue list --state open` shows 117 remaining).
 **Methodology:** for each candidate, verify against actual code or run the failing command; close only with concrete evidence.
 
 ## Hygiene phase issues (10 closed)
@@ -91,6 +91,78 @@ Studio rebuilt during studio-mobile-first (v0.16.0 era, multiple PRs through 202
 |---|---|---|
 | #242 | Studio surfaces have no Cancel affordance | BOTH surfaces ship: decision-strip.ts has `Cancel ⊘` button (source comment cites "Cancel (#242)"); affordances.ts has cancel Verb in row chip menu |
 
+## Studio scrapbook + entry-review cluster (11 closed)
+
+These were filed during the v0.13.0 scrapbook rebuild + Phase 30/34 migration cycles. Each one's reproduction either now passes against current code OR refers to a surface that was retired in Phase 34a.
+
+| # | Bug | Evidence |
+|---|---|---|
+| #151 | publish leaves sidecar publishedDate null | BUG PREMISE WRONG — schema field is `datePublished` (entry.ts:56), not `publishedDate`. jq's `.publishedDate` selector renders null on any missing key; the sidecar persists `datePublished` correctly |
+| #155 | longform review strip wraps to two rows | RETIRED WITH PHASE 34a — `pages/review.ts` (the surface with `.er-strip` wrap) is gone per `server.ts:281` source comment ("Phase 34a (#171): the legacy longform/outline halves of pages/review.ts were retired") |
+| #156 | client init* not invoked at module load | Bootstrap block at end of `scrapbook-client.ts` auto-invokes `init()` on DOMContentLoaded |
+| #157 | dashboard does not link to scrapbook viewers | `dashboard/affordances.ts:81` source comment "Scrapbook URL uses the project's defaultSite (#157, #205)" + working `scrapbookViewerUrl({...})` call |
+| #159 | edit-mode real-estate (longform `.er-page-grid`) | RETIRED WITH PHASE 34a — same surface retirement as #155; entry-review successor has separate layout |
+| #160 | edit-pane typography (mono markdown + frontmatter de-emphasis) | `entry-review.css` has 8+ `font-family: var(--er-font-mono)` rules covering edit pane |
+| #163 | JPEG/WebP/GIF dimensions in scrapbook | `pages/scrapbook/image-readers.ts` header: "Recognizes PNG, JPEG, WebP, and GIF" |
+| #165 | DESKWORK_DEV should bind Tailscale by default | `tailscale.ts` ships layered auto-detection (CGNAT range scan + CLI enrichment); default binds loopback + Tailscale interface(s) |
+| #166 | NEW NOTE uses native window.prompt | `pages/scrapbook/render.ts:330` source comment: "Replaces the F1 window.prompt() regression (#166)" — inline composer (filename + body + secret toggle) ships |
+| #167 | Scrapbook edit button non-functional | `scrapbook-client.ts` action dispatcher: `case 'edit': void enterEditMode(ctx, card); break;` |
+| #168 | Scrapbook has no way to return to main article | `pages/scrapbook/render.ts:221-227` ships `<a href="${reviewLink}">← back to review</a>` when active calendar entry is the nav context |
+| #169 | Stowable TOC on the review surface | `entry-review/outline-drawer.ts` renders `<nav class="er-toc">` from `extractToc(renderedHtml)`; activates ≥2 headings |
+
+Still open in this cluster:
+- **#161** — Scrapbook UI/UX umbrella ("look like the mockup"). Sub-fixes #163/#166/#167/#168 shipped; #164 deferred-by-design. Umbrella stays open until operator triages remaining mockup-vs-built gaps.
+- **#164** — expanded-secret-card visual continuity. Body explicitly cites "Per #161 G3 design review (Q3): explicitly recommended NOT pre-fixing." Stays open by design.
+- **#170** — Phase 34 umbrella. Sub-tracker for 34a-34e. Multiple sub-issues now closed (#155, #156, #157, #160, #163, #164(open-by-design), #165, #166, #167, #168, #169). Umbrella waits on #171 (34a) verification + #164.
+- **#171** — Phase 34a tracker. The legacy `pages/review.ts` retirement IS done (verified at server.ts:281). The chrome port has 7 sub-tasks (folio, version strip, edit toolbar, edit panes, outline drawer, marginalia column, margin-note authoring). Outline drawer + edit panes + folio shipped. Margin-note authoring + version strip status unclear — needs explicit verification.
+
+## dw-lifecycle setup + ingest cluster (7 closed)
+
+Verified against the hygiene feature's own end-to-end use of these helpers + against the current code.
+
+| # | Bug | Evidence |
+|---|---|---|
+| #196 | setup creates doubled worktree when invoked from existing feature worktree | `setup.smoke.test.ts:205` test name "reuses a pre-existing worktree+branch (#196 #209) instead of doubling or aborting" + `repo.ts:46` source comment |
+| #197 | ingest doesn't honor pre-existing deskwork.id from frontmatter | `ingest.ts` comment cites #197 verbatim; `readExistingDeskworkId()` + duplicate-slug guard ship |
+| #205 | scrapbook viewer + link emitters still slug/path-based | `scrapbook-item.ts` ships `entryId?` field; URL builder appends `?entryId=<uuid>` conditionally |
+| #207 | scrapbook.ts 809 LOC split | barrel-pattern: `pages/scrapbook.ts` 17 LOC; sub-directory has 7 files, all under cap (largest 378) |
+| #209 | setup aborts on existing branch | same fix as #196 — branch+worktree reuse smoke test passes |
+| #210 | setup skill doesn't surface install as prereq | SKILL.md opens with explicit `## Prerequisite` section pointing at the exact failure error |
+| #212 | setup missing --workplan flag | `setup.ts:62` parses `--workplan <path>`; usage string at line 71 documents it |
+| #213 | issues silently skips back-fill when placeholder doesn't match | `issues.ts:113-122` source comment cites #213; matches any `parentIssue:` form; warns at line 144 |
+
+## Studio + content cluster (11 closed)
+
+| # | Bug | Evidence |
+|---|---|---|
+| #74 | Approve button — command not copied to clipboard | `entry-review/decision.ts:85` `copyOrShowFallback(command, {...})` in approve handler; same helper that fixed #99 |
+| #99 | intake form silent on copy click | `editorial-studio-client.ts` cites *"#99 fix"* + uses `copyOrShowFallback` + `.copied` button class |
+| #115 | `/dw-lifecycle:help` silent without config | SKILL.md adds Error handling section: *"No config. Suggest `/dw-lifecycle:install`"* |
+| #175 | edit-toolbar Source/Split/Preview tooltips | `entry-review/edit-toolbar.ts` ships `title=` attrs on all three mode buttons |
+| #176 | initLightbox dead bootstrap | Renamed to `initScrapbookLightbox`; called from 4 client surfaces |
+| #178 | index + dashboard both render "Editorial Studio" | Distinct h1: Index renders "Editorial Studio", Dashboard renders "Press-Check" |
+| #199 | marginalia can't be edited | client UI ships (`sidebar-render.ts` edit/delete buttons + `comment-edit-delete.ts` module); server PATCH/DELETE at api.ts:285-293 cite Phase 35 / issue #199 |
+| #201 | `/deskwork:approve` documents retired reviewState gate | SKILL.md no longer documents the gate; describes stage-only gating per Commandment III |
+| #214 | self-description over-narrows to literary content | README enumerates "blog posts, essays, design specs, ADRs, RFCs, internal memos, books, manuscripts, runbooks, post-mortems, knowledge bases" |
+| #225 | approve skill prose scaffolds artifact for non-pipeline content | SKILL.md:45 *"Approve preserves the prior stage's content... it does NOT scaffold a fresh artifact"* |
+| #247 | ingest regen drops Final/Cancelled | `calendar/render.ts:3-4` `STAGE_ORDER` is canonical 8-stage list; `bucketize()` iterates all 8 |
+
+## Still genuinely open (latest sweep)
+
+- **#211** — install has only `--dry-run` / `--config-overlay`; per-field CLI flags + statusDirs-schema flexibility not addressed. Partial mitigation via overlay file. Stays open.
+- **#218** — doctor missing `legacy-calendar-to-sidecars` rule that MIGRATING.md says it ships. No matching rule in `packages/core/src/doctor/rules/`. Confirmed still open.
+- **#221** — ingest slug rejects dots; sanitizer not added. Confirmed still open.
+- **#232** — `regenerateCalendar(projectRoot)` hardcodes `.deskwork/calendar.md` instead of reading `calendarPath` from config. Confirmed still open.
+- **#233** — `/deskwork:doctor` collides with built-in `/doctor` via autocomplete. SKILL.md still uses `name: doctor`. Stays open.
+- **#240** — phone horizontal scroll on review surface. `review-viewport.css` has `overflow-x: auto` rules but the bug body's specific 390px → 520px scrollWidth case I can't verify from code alone. Stays open pending operator browser-test.
+- **#219** — doctor `missing-frontmatter-id` false positives. Rule exists at `rules/missing-frontmatter-id.ts`; doesn't appear to skip Ideas-stage or "no markdown file" cases. Stays open.
+- **#230** — entry-review decision-strip Publish action at Final. Strip has Approve/Iterate/Reject + induct picker; affordances gate; whether the Final → Published path renders a Publish button needs operator browser-test. Stays open.
+- **#68** — dashboard polls `/api/dev/editorial-studio/state-signature` which 404s. Client at `editorial-studio-client.ts:285` still polls the endpoint; server has no matching route. Confirmed still bug.
+- **#71** — content tree fabricates `/blog/<slug>` public URL for collections without `host`. `content-detail.ts` still renders the public-URL hint unconditionally. Confirmed still bug.
+- **#98** — dashboard scaffold button 404. Client at `editorial-studio-client.ts:88` posts to `/api/dev/editorial-calendar/draft` which has no server route. Confirmed still bug.
+- **#84** — iterate Step 2 "read the comments" has no documented agent path. SKILL.md still says "Read the studio's pending comments" without specifying how. Coupled to #267 (no CLI subcommand to enumerate pending annotations).
+- **#198** — iterate rejects `--dispositions` for longform/outline. `iterate/iterate.ts:12` comment says *"Future: --dispositions <path>"* — still TODO. Confirmed still open.
+
 ## NOT closed — still open by design or genuinely unfixed
 
 - **#246** — core/approve refuses Final→Published. Bug body says "approve is universal per Commandment II"; current `DESKWORK-STATE-MACHINE.md` references "publish: Final → Published — the only graduation event from Final." Semantic question — looks like the bug body's spec interpretation may be obsolete. Need operator triage.
@@ -109,6 +181,13 @@ Ordered roughly by effort × value. Each entry: shape of the remediation + estim
 - **#127** — `define` SKILL.md prescribes bare `/tmp/feature-definition-<slug>.md`. Project rule (file-handling.md) explicitly forbids bare /tmp paths. Replace with `mktemp` per the rule. ~5 LOC SKILL.md edit.
 - **#295** — `install-scope-discovery-hooks` writes `dw-lifecycle check-editor-symmetry --gate-mode` but the verb rejects that flag. Either add `--gate-mode` to check-editor-symmetry (mirroring the other check-* verbs) OR drop the flag from the hook fragment. Pick one for consistency with the surrounding chain.
 - **#294** — Pre-commit hook breaks when dw-lifecycle binary predates scope-discovery subcommands. Add a one-shot `dw-lifecycle --version` (depends on #256) or `which dw-lifecycle && dw-lifecycle help | grep check-clones` defensive guard at hook top. ~10 LOC hook-fragment edit + a small test.
+- **#221** — ingest slug sanitizer: replace `.` with `-` in path-derived slug segments before kebab-case validation. ~5 LOC in `core/src/ingest.ts` slug-derivation step.
+- **#232** — `regenerateCalendar(projectRoot)` should read `config.calendarPath` from `.deskwork/config.json` instead of hardcoding `.deskwork/calendar.md`. ~10 LOC; also needs a smoke covering an overlay project.
+- **#233** — Rename the deskwork plugin's `/deskwork:doctor` skill to avoid CC `/doctor` autocomplete collision. Candidates: `/deskwork:check`, `/deskwork:doctor-calendar`. ~5 LOC rename + announcement note.
+- **#68** — Server has no `/api/dev/editorial-studio/state-signature` route. Either add the route (returns a signature for client polling) or remove the polling from `editorial-studio-client.ts:285`. ~15 LOC.
+- **#98** — Server has no `/api/dev/editorial-calendar/draft` route. Either add it (POST scaffold for Planned-stage entries) or remove the scaffold button from the dashboard. ~30 LOC for the route + test.
+- **#71** — `content-detail.ts` renders `/blog/<slug>` public URL hint unconditionally. Gate on `collection.host !== undefined`. ~5 LOC.
+- **#198** — `iterate.ts:12` has `// Future: --dispositions <path>` TODO. Wire through `--dispositions <path>` for longform/outline (same shape that already works for shortform). ~20 LOC.
 
 ### Medium (1–2 days)
 

--- a/docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md
+++ b/docs/1.0/001-IN-PROGRESS/hygiene/issue-closure-audit-2026-05-29.md
@@ -1,0 +1,137 @@
+---
+slug: hygiene
+date: 2026-05-29
+kind: issue-closure-audit
+---
+
+# Repo-wide issue closure audit — 2026-05-29
+
+Systematic verification of open issues against shipped code. Operator decision: "Don't trust that the feature documentation is up to date. look into the unfinished tasks to see if they are actually complete. Documentation discipline is spotty, so we should verify." — meaning each closure decision below is grounded in code inspection / empirical run, NOT in trusting the issue body's age or the feature README's status table.
+
+**Starting state:** 178 open issues (post-hygiene-PR-merges).
+**Closed in this audit:** 35 (cumulative, as of this entry).
+**Methodology:** for each candidate, verify against actual code or run the failing command; close only with concrete evidence.
+
+## Hygiene phase issues (10 closed)
+
+The hygiene feature shipped across v0.26.0 → v0.26.5 via PRs #338 + #341 + #344 + #345 + #346 + #348. Phase issues #324–#333 + parent #323 + Phase 6 Task 4 #336 all carry concrete shipping evidence. #336 install-verification ran against v0.26.5 (the bug claimed at v0.26.1 was fixed by PR #344 commit `273c8f3`).
+
+Closed: #323, #324, #326, #327, #329, #330, #331, #332, #333, #336.
+
+## scope-discovery phase issues (7 closed)
+
+scope-discovery workplan README explicitly marks Phases 1, 2, 3, 4, 5, 9 as **Complete** with passing test counts. Phase 10 marked **Shipped at v1**. Phases 6, 7, 8, 11 stay open per genuine unchecked tasks remaining (verified by counting unchecked items in workplan.md — 38 total).
+
+Closed: #274 (Phase 1, 347/347 tests pass), #275 (Phase 2, 401/401), #276 (Phase 3, 415/415), #277 (Phase 4, 438/438), #278 (Phase 5, 495/495), #282 (Phase 9, 737/737), #283 (Phase 10, shipped at v1).
+
+## dw-lifecycle setup bugs (4 closed)
+
+The hygiene feature setup ran end-to-end against `/dw-lifecycle:setup --definition <path>` — empirical proof these are fixed.
+
+| # | Bug | Evidence |
+|---|---|---|
+| #248 | PRD seeding gap — Solution/Acceptance/Out-of-Scope not populated from --definition | `setup.ts` extracts those sections + regex-replaces into PRD template; verified at `docs/1.0/001-IN-PROGRESS/hygiene/prd.md` (fully populated) |
+| #249 | workplan Task seeding gap | `setup.ts` extracts Tasks + builds stepBlock + replaces into workplan template; verified at hygiene workplan |
+| #254 | phase issue numbers not back-filled | `issues-backfill-prose.ts` (274 LOC) exports 3 back-fill functions; commit `2d973c5` shows the back-fill in action for hygiene |
+| #255 | worktree path drift between config.json defaults and CLAUDE.md convention | `mainWorktreePath()` resolves from main, not current; comments reference fixes for #196 + #209; hygiene worktree at `/Users/orion/work/deskwork-work/hygiene` (not chain-named) |
+
+## scope-discovery friction bugs (2 closed)
+
+| # | Bug | Disposition |
+|---|---|---|
+| #293 | detect-clones can't find .jscpd.json after install | VERIFIED FIXED — `check-clones` runs cleanly: "Detected 174 clone group(s); Baseline diff: 0 NEW, 0 DROPPED" |
+| #296 | orphan-feature-doc fires on evidence-trail directories | NO LONGER REPRODUCING — convention places evidence-trail UNDER each feature dir; doctor finds zero false positives on current layout |
+
+Still open in this cluster:
+- **#294** — pre-commit hook breaks when dw-lifecycle binary predates the scope-discovery subcommands. Hook fragment has no defensive guard against older binaries.
+- **#295** — install-scope-discovery-hooks writes `check-editor-symmetry --gate-mode` but the verb does NOT accept that flag ("unknown argument: --gate-mode"). Real bug, unfixed.
+- **#297** — clone-detector tests flake under full-suite parallel load. Probabilistic; harder to verify "fixed."
+
+## dw-lifecycle Phase 7 follow-up sub-issues (4 closed)
+
+The umbrella #134 tracks 6 Phase 7 sub-issues (#125-#130) + 1 Phase 8 (#122). The constituents' actual state diverges from the umbrella's claim that "none are closed."
+
+| # | Bug | Evidence |
+|---|---|---|
+| #125 | PATH points at empty cache directory; repair-install mitigation | `scripts/repair-install.sh` shipped; documented as canonical adopter recovery path per agent-discipline.md § "Marketplace-clone scripts are an adopter contract" |
+| #128 | chain-named worktree paths (same shape as #255) | duplicate; closed for same reason as #255 |
+| #129 | --definition appends to workplan, leaves PRD bare (same shape as #248) | duplicate; closed for same reason as #248 |
+| #130 | setup doesn't write `deskwork.id` UUID to PRD frontmatter | hygiene PRD frontmatter shows `deskwork: id: aee9b719-7451-401e-be45-7dba8a8cd41a` |
+
+Still open in this cluster:
+- **#122** — session skills tailoring (genuine concern; session-end is hardcoded to deskwork journal shape)
+- **#126** — setup SKILL prose contradicts helper behavior (needs deeper read)
+- **#127** — define SKILL prescribes bare `/tmp/feature-definition-<slug>.md` (predictable path; confirmed bug still present in SKILL.md line 15)
+- **#134** — umbrella; stays open until #122, #126, #127 close
+
+## Studio refactored-away (4 closed)
+
+Studio rebuilt during studio-mobile-first (v0.16.0 era, multiple PRs through 2026-05-08). Files referenced by older bugs no longer exist.
+
+| # | Bug | Disposition |
+|---|---|---|
+| #261 | mobile-shell sheet-controller: no destroy() method | Architecture moved to universal `renderMobileBar` + slot-host; sheet-controller file gone |
+| #264 | Delete confirmed-dead longform body from editorial-review-client.ts | `editorial-review-client.ts` doesn't exist; the file got deleted/split during the rebuild |
+| #265 | Add JSDOM unit tests for initShortformMobileSheet | `initShortformMobileSheet` no longer exists; current architecture covered by `shortform-mobile-bar-smoke.test.ts` |
+| #270 | Split mobile-sheet-bar.ts (502 LOC) into 3 modules | Refactored away in commit `009bf3f` (Step 2.1.6); successor files all under 500 LOC cap |
+
+## Pilot follow-ups (3 closed)
+
+| # | Bug | Evidence |
+|---|---|---|
+| #284 | Port batch-dispose from audiocontrol pilot | `batch-dispose.ts` shipped at `plugins/dw-lifecycle/src/scope-discovery/`; CLI subcommand registered |
+| #288 | anti-patterns `canonical_file` field (TF-002) | `anti-patterns-registry.ts` defines + validates the field; landed in commit `d849a6f` |
+| #289 | check-disposition-survivor gate (TF-013) | subcommand exists; `dw-lifecycle check-disposition-survivor` runs |
+
+#285 (pattern-type dispatcher extension) stays open by design — v1 ships regex-only; glob/ast-grep/ts-morph tracked at this very issue.
+
+## Studio Cancel affordance (1 closed)
+
+| # | Bug | Evidence |
+|---|---|---|
+| #242 | Studio surfaces have no Cancel affordance | BOTH surfaces ship: decision-strip.ts has `Cancel ⊘` button (source comment cites "Cancel (#242)"); affordances.ts has cancel Verb in row chip menu |
+
+## NOT closed — still open by design or genuinely unfixed
+
+- **#246** — core/approve refuses Final→Published. Bug body says "approve is universal per Commandment II"; current `DESKWORK-STATE-MACHINE.md` references "publish: Final → Published — the only graduation event from Final." Semantic question — looks like the bug body's spec interpretation may be obsolete. Need operator triage.
+- **#256** — deskwork CLI `--version` / `-v` / `version` all return "unknown subcommand." Confirmed broken; needs a fix.
+- **#266** — DraftWorkflowState still uses retired ReviewState union (Commandment III/VI). Architectural; need operator triage.
+- **#267** — no CLI command to enumerate pending annotations. Confirmed no such subcommand exists.
+- **#258** — install-shortcuts concurrent-invocation race. Hard to verify; skipped.
+
+## Burn-down candidates (scheduling input)
+
+Ordered roughly by effort × value. Each entry: shape of the remediation + estimated scope + any dependency.
+
+### Quick fixes (1–2 commit, < 1 hour each)
+
+- **#256** — Add `--version` / `-v` / `version` subcommand to `@deskwork/cli`. Trivial — read `package.json` version field; print on any of those argv shapes. ~10 LOC + 1 test. Adopter-facing UX win.
+- **#127** — `define` SKILL.md prescribes bare `/tmp/feature-definition-<slug>.md`. Project rule (file-handling.md) explicitly forbids bare /tmp paths. Replace with `mktemp` per the rule. ~5 LOC SKILL.md edit.
+- **#295** — `install-scope-discovery-hooks` writes `dw-lifecycle check-editor-symmetry --gate-mode` but the verb rejects that flag. Either add `--gate-mode` to check-editor-symmetry (mirroring the other check-* verbs) OR drop the flag from the hook fragment. Pick one for consistency with the surrounding chain.
+- **#294** — Pre-commit hook breaks when dw-lifecycle binary predates scope-discovery subcommands. Add a one-shot `dw-lifecycle --version` (depends on #256) or `which dw-lifecycle && dw-lifecycle help | grep check-clones` defensive guard at hook top. ~10 LOC hook-fragment edit + a small test.
+
+### Medium (1–2 days)
+
+- **#122** — Session skills tailoring. Session-end skill is hardcoded to deskwork journal shape. The `customize-hooks` machinery (#136) ships the template-resolver seam; this issue closes once a per-project journal-entry override is exercised end-to-end. Phase 8 dependency.
+- **#267** — Add `deskwork pending-annotations <entry>` CLI command that walks `.deskwork/review-journal/history/<timestamp>-<uuid>.json` filtering `kind: entry-annotation` AND not yet addressed. Unblocks agent-driven iterate workflow.
+- **#258** — install-shortcuts concurrent-invocation tmp race. Atomic-write via tmp+rename pattern. Manifest verification.
+
+### Architectural / needs operator triage first
+
+- **#246** — core/approve Final → Published. Bug body's spec interpretation may be stale (current DESKWORK-STATE-MACHINE.md names `publish` as the Final-graduation verb). Operator decides: (a) make approve universal per the bug's Commandment II reading, (b) close as design-intentional, (c) clarify the state machine doc.
+- **#266** — DraftWorkflowState uses retired ReviewState union. Operator decides whether this is real drift vs intentional separation of "draft workflow lifecycle" from "entry reviewState."
+- **#126** — setup SKILL prose contradicts helper behavior. Needs read-through of current SKILL vs helper to identify divergence; remediation depends on which side is right.
+
+### Already-tracked / informational (don't burn down here)
+
+- **#285** — pattern-type dispatcher extension (v1 ships regex; tracked at #285 itself)
+- **#297** — clone-detector tests flake under full-suite parallel load (probabilistic)
+- **#134** — umbrella; auto-closes when #122 + #126 + #127 close
+- **#136** — Phase 8 customize-hooks (sibling tracking issue)
+
+## Methodology notes
+
+- Each closure cites concrete evidence: code path, file:line, or empirical command output.
+- Where a bug was "obsoleted by refactor," the closure comment names the successor architecture and any test that still covers the spec contract.
+- Where a bug duplicates one we already closed (#128 ≈ #255, #129 ≈ #248), the closure comment notes the duplication and references the canonical fix.
+- Where verification surfaces ANOTHER bug (e.g. #295 found while checking install-scope-discovery-hooks), the new finding goes here.


### PR DESCRIPTION
Operator correction during the v0.26.5 release. Verbatim: *"this is why automated ci on github sucks. test runs take FOREVER... We should do all actual automated testing locally, including the smoke test. The only thing I want the ci to do is publish to npm, since that's the only way to automate publishing."*

## What ships

**Workflow shrinks** (`.github/workflows/publish-npm.yml`):
- Drop the "Assert all three packages published" step.
- Drop the "Marketplace smoke" step.
- Workflow now does 5 substantive things: checkout → setup-node → upgrade npm → npm ci → `make publish-ci`. That's it.

**Skill grows** (`.claude/skills/release/SKILL.md`):
- Pause 4 splits into 5a (local assert-published with retry-with-backoff for npm CDN propagation) and 5b (local marketplace smoke).
- The retry-with-backoff helper (shipped in [#346](https://github.com/audiocontrol-org/deskwork/pull/346)) does the heavy lifting in 5a — polls `npm view` until all three packages appear, ~5-30 seconds typical, 2-min max budget.
- Intro paragraph, flow-shape evolution table, recovery section, and frontmatter description all updated to name the new shape.

**`RELEASING.md`**: subsections describing the publish architecture rewritten to name the workflow-only-publishes / verification-runs-locally split with rationale.

## Why

| Step | CI duration | Local duration |
|---|---|---|
| npm publish | ~30s | (only runs in CI; requires OIDC) |
| assert-published | ~20s | ~5-15s |
| marketplace smoke | **~5-10 min** | ~1-2 min |

Total Pause 4 budget shifts from ~10-15 min (CI) to ~2-3 min (local). Operator sees results in the same terminal that ran `/release`. Iterating on a release-process bug takes seconds vs minutes-per-cycle.

## What stays in CI

The ONE thing that only CI can do: `npm publish` via OIDC. Trusted-publisher OIDC tokens are issued only to GH Actions workflows with `id-token: write`. There's no way to replicate this locally without a long-lived npm token (which defeats the entire trusted-publisher security model).

Everything else — visibility checks, smoke installs, route assertions — has nothing CI-specific. Running it locally is strictly faster.

## Test plan

- [ ] Merge this PR.
- [ ] Cut v0.26.6 via `/release` — first release that exercises the new flow shape end-to-end. Expected: workflow exits quickly (~1-2 min), then the skill runs assert-published + smoke locally and reports the release URL within another ~1-2 min.
- [ ] Verify total `/release` invocation time drops from ~15 min to ~5 min including the operator pauses.

## Refs

- Phase 10 (the workflow this PR re-scopes): [#343](https://github.com/audiocontrol-org/deskwork/issues/343)
- assert-published retry-with-backoff (load-bearing for the new 5a substep): [#346](https://github.com/audiocontrol-org/deskwork/pull/346) (merged)
- v0.26.5 release (the run that surfaced this correction): https://github.com/audiocontrol-org/deskwork/releases/tag/v0.26.5
