### PR TITLE
fix(stack-control): release-hygiene — smoke coverage + backlog.md dep probe

### DIFF
--- a/plugins/stack-control/bin/stackctl
+++ b/plugins/stack-control/bin/stackctl
@@ -5,9 +5,10 @@
 #
 # Mirrors plugins/dw-lifecycle/bin/dw-lifecycle's resolution order. The
 # runtime deps the dispatched code imports are markdown-it, peggy, yaml,
-# jscpd, ajv, ajv-formats, and tsx (the document-primitives modules import
-# the first three at runtime; the scope-discovery clone-detector + schema
-# validators import jscpd/ajv/ajv-formats — 010). The probe list below MUST
+# jscpd, ajv, ajv-formats, backlog.md, and tsx (the document-primitives modules
+# import the first three at runtime; the scope-discovery clone-detector + schema
+# validators import jscpd/ajv/ajv-formats — 010; the backlog backend spawns the
+# backlog.md CLI for write operations — 008). The probe list below MUST
 # stay in sync with package.json's "dependencies" — if the plugin gains a new
 # runtime dep, add it to RUNTIME_DEPS or an adopter install with a partial
 # node_modules/ will skip npm install and then fail Node module resolution on
@@ -76,11 +77,12 @@ dep_installed() {
 }
 
 # Declared runtime deps — keep in sync with package.json "dependencies".
-# The dispatched code imports markdown-it / peggy / yaml at runtime; tsx is
-# the runner. A probe that only checked tsx would skip npm install on a
-# partial adopter install (tsx present, the rest missing) and then crash on
-# Node module resolution at first dispatch.
-RUNTIME_DEPS="markdown-it peggy yaml jscpd ajv ajv-formats tsx"
+# The dispatched code imports markdown-it / peggy / yaml at runtime; the
+# backlog backend spawns the backlog.md CLI; tsx is the runner. A probe that
+# only checked tsx would skip npm install on a partial adopter install (tsx
+# present, the rest missing) and then crash on Node module resolution (or a
+# missing backlog.md binary) at first dispatch.
+RUNTIME_DEPS="markdown-it peggy yaml jscpd ajv ajv-formats backlog.md tsx"
 
 # Probe every declared runtime dep.
 all_deps_installed() {

--- a/scripts/smoke-marketplace.sh
+++ b/scripts/smoke-marketplace.sh
@@ -241,6 +241,7 @@ PLUGIN_BIN_PAIRS=(
   "deskwork:deskwork"
   "deskwork-studio:deskwork-studio"
   "dw-lifecycle:dw-lifecycle"
+  "stack-control:stackctl"
 )
 
 # ----- Phase A: full marketplace clone -----------------------------------


### PR DESCRIPTION
## Summary

Post-merge release-hygiene for stack-control (follow-up to #437). Found while verifying the plugin is adopter-installable end-to-end.

## Changes

- **smoke-marketplace.sh**: add `stack-control:stackctl` to `PLUGIN_BIN_PAIRS` so the release-gate smoke clone-installs and dispatches `stackctl` like the other plugins. Previously only deskwork / deskwork-studio / dw-lifecycle were covered, so a regression in stack-control's adopter install would not be caught at release time. The harness (`phase_b_per_source`) is already plugin-agnostic.
- **bin/stackctl**: add `backlog.md` to the `RUNTIME_DEPS` probe. It is a declared dependency (the backlog backend spawns its CLI for write ops) but was absent from the probe — a partial adopter `node_modules/` could skip `npm install` and then crash on the missing `backlog.md` binary. Fresh installs were unaffected; this closes the partial-install edge case.

## Verification

- Adopter path proven: a sparse copy outside the monorepo first-run-installs (142 pkgs) and dispatches — `version`, `setup --apply` ("ready: yes"), `roadmap next`, `backlog list` all work.
- `bash -n` clean on both files; `stackctl --help` exits 0 (the smoke gate's assertion).
