### PR TITLE
chore(stack-control): import 10 stack-control GitHub issues into the backlog

### DIFF
--- a/plugins/stack-control/.stack-control/backlog/tasks/task-12 - stack-control-audit-barrage-lift-merges-distinct-mechanism-findings-under-one-ID-documents-only-one-systematic.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-12 - stack-control-audit-barrage-lift-merges-distinct-mechanism-findings-under-one-ID-documents-only-one-systematic.md
@@ -1,0 +1,18 @@
+---
+id: TASK-12
+title: >-
+  stack-control: audit-barrage-lift merges distinct-mechanism findings under one
+  ID, documents only one (systematic)
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:bug'
+dependencies: []
+references:
+  - gh-440
+ordinal: 12000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-13 - stack-control-first-barrage-of-a-new-feature-strands-findings-—-lift-aborts-on-missing-feature-audit-log.md.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-13 - stack-control-first-barrage-of-a-new-feature-strands-findings-—-lift-aborts-on-missing-feature-audit-log.md.md
@@ -1,0 +1,18 @@
+---
+id: TASK-13
+title: >-
+  stack-control: first barrage of a new feature strands findings — lift aborts
+  on missing feature audit-log.md
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:bug'
+dependencies: []
+references:
+  - gh-441
+ordinal: 13000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-14 - stack-control-feature-resolution-is-docs-layout-only-—-import-slush-scope-widen-scope-inventory-cannot-see-specs-NNN-slug-features.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-14 - stack-control-feature-resolution-is-docs-layout-only-—-import-slush-scope-widen-scope-inventory-cannot-see-specs-NNN-slug-features.md
@@ -1,0 +1,18 @@
+---
+id: TASK-14
+title: >-
+  stack-control: feature resolution is docs-layout-only —
+  import-slush/scope-widen/scope-inventory cannot see specs/NNN-slug features
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:bug'
+dependencies: []
+references:
+  - gh-442
+ordinal: 14000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-15 - stack-control-docs-backlog-→-per-feature-tasks.md-promotion-seam-is-undocumented-the-two-tiers-never-reference-each-other.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-15 - stack-control-docs-backlog-→-per-feature-tasks.md-promotion-seam-is-undocumented-the-two-tiers-never-reference-each-other.md
@@ -1,0 +1,18 @@
+---
+id: TASK-15
+title: >-
+  stack-control docs: backlog → per-feature tasks.md promotion seam is
+  undocumented (the two tiers never reference each other)
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:gap'
+dependencies: []
+references:
+  - gh-443
+ordinal: 15000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-16 - stack-control-adopt-document-the-tooling-friction-routing-policy-—-upstream-tool-defects-go-to-GitHub-issues-never-the-local-backlog.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-16 - stack-control-adopt-document-the-tooling-friction-routing-policy-—-upstream-tool-defects-go-to-GitHub-issues-never-the-local-backlog.md
@@ -1,0 +1,18 @@
+---
+id: TASK-16
+title: >-
+  stack-control: adopt + document the tooling-friction routing policy —
+  upstream-tool defects go to GitHub issues, never the local backlog
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:gap'
+dependencies: []
+references:
+  - gh-444
+ordinal: 16000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-17 - document-primitives-round-9-residual-hardening-AUDIT-54-55-56-—-fence-length-prose-as-header-engine-floor.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-17 - document-primitives-round-9-residual-hardening-AUDIT-54-55-56-—-fence-length-prose-as-header-engine-floor.md
@@ -1,0 +1,18 @@
+---
+id: TASK-17
+title: >-
+  document-primitives: round-9 residual hardening (AUDIT-54/55/56 —
+  fence-length, prose-as-header, engine floor)
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:gap'
+dependencies: []
+references:
+  - gh-430
+ordinal: 17000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-18 - spec-governance-gate-graduates-at-first-0-HIGH-run-not-FR-010-branch-a-b-FR-014-loop-bound-is-advisory-not-a-code-interlock-AUDIT-20260608-01.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-18 - spec-governance-gate-graduates-at-first-0-HIGH-run-not-FR-010-branch-a-b-FR-014-loop-bound-is-advisory-not-a-code-interlock-AUDIT-20260608-01.md
@@ -1,0 +1,18 @@
+---
+id: TASK-18
+title: >-
+  spec-governance gate: graduates at first 0-HIGH run (not FR-010 branch a/b) +
+  FR-014 loop bound is advisory not a code interlock (AUDIT-20260608-01)
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:bug'
+dependencies: []
+references:
+  - gh-432
+ordinal: 18000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-19 - Governance-graduation-has-no-on-disk-record-roadmap-reconcile-falls-back-to-tasks-completion-as-the-shipped-signal.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-19 - Governance-graduation-has-no-on-disk-record-roadmap-reconcile-falls-back-to-tasks-completion-as-the-shipped-signal.md
@@ -1,0 +1,18 @@
+---
+id: TASK-19
+title: >-
+  Governance graduation has no on-disk record; roadmap reconcile falls back to
+  tasks-completion as the shipped signal
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:gap'
+dependencies: []
+references:
+  - gh-434
+ordinal: 19000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-20 - 006-T052-keep-roadmap-legacy.peg-as-the-row-keyed-example-grammar-dont-remove-—-its-the-only-row-keyed-engine-coverage.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-20 - 006-T052-keep-roadmap-legacy.peg-as-the-row-keyed-example-grammar-dont-remove-—-its-the-only-row-keyed-engine-coverage.md
@@ -1,0 +1,18 @@
+---
+id: TASK-20
+title: >-
+  006 T052: keep roadmap-legacy.peg as the row-keyed example grammar (don't
+  remove — it's the only row-keyed engine coverage)
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:gap'
+dependencies: []
+references:
+  - gh-435
+ordinal: 20000
+---
+
+

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-21 - Roadmap-archival-is-edge-unaware-curate-apply-would-archive-depended-upon-shipped-items-and-dangle-their-edges-FR-005.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-21 - Roadmap-archival-is-edge-unaware-curate-apply-would-archive-depended-upon-shipped-items-and-dangle-their-edges-FR-005.md
@@ -1,0 +1,18 @@
+---
+id: TASK-21
+title: >-
+  Roadmap archival is edge-unaware: curate --apply would archive depended-upon
+  shipped items and dangle their edges (FR-005)
+status: To Do
+assignee: []
+created_date: '2026-06-10 18:33'
+labels:
+  - agent-found
+  - 'type:bug'
+dependencies: []
+references:
+  - gh-436
+ordinal: 21000
+---
+
+


### PR DESCRIPTION
## Summary

Import the 10 stack-control-scoped open GitHub issues into stack-control's backlog and close them on GitHub (tracking moved to the backlog to avoid duplication).

## Mapping (gh issue -> backlog task)

| issue | task | | issue | task |
|---|---|---|---|---|
| #440 | TASK-12 | | #435 | TASK-20 |
| #441 | TASK-13 | | #436 | TASK-21 |
| #442 | TASK-14 | | #430 | TASK-17 |
| #443 | TASK-15 | | #432 | TASK-18 |
| #444 | TASK-16 | | #434 | TASK-19 |

Each task carries a `gh-<n>` backlink ref to its (now closed) origin issue; each issue was closed with a comment pointing back at its task.

## Scope

Explicit `stack-control:` issues + Spec Kit feature issues (roadmap 006, spec-governance 004, document-primitives 005). dw-lifecycle / scope-discovery / deskwork issues were left untouched (operator-confirmed boundary).
