### PR TITLE
fix(stack-control): retire obsolete prose-roadmap migration guard (green main)

### DIFF
--- a/plugins/stack-control/tests/roadmap/migration-presence.test.ts
+++ b/plugins/stack-control/tests/roadmap/migration-presence.test.ts
@@ -1,33 +1,19 @@
-// T049 (RED-first, US6, 006) — every real feature from the prose program
-// roadmap (its feature table) exists as an item in the migrated heading-keyed
-// ROADMAP.md, and the graph validates green (SC-005/FR-019/FR-020). Lossless
-// port, mirroring 005's DESIGN-INBOX migration presence guard.
+// Roadmap presence guards (originally T049, US6, 006). The one-time prose->
+// heading-keyed migration is complete; the prose source roadmap
+// (docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/stack-control-roadmap.md)
+// is deprecated and was deleted (2026-06-13). The lossless-port check that read
+// that prose source is retired with it — its job (verify nothing was lost in the
+// migration) is done and its source no longer exists. The remaining guards
+// validate the migrated ROADMAP.md directly.
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadRoadmap } from '../../src/roadmap/roadmap-model.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = resolve(here, '..', '..');
-const REPO_ROOT = resolve(PLUGIN_ROOT, '..', '..');
 const ROADMAP = resolve(PLUGIN_ROOT, 'ROADMAP.md');
-const PROSE = resolve(
-  REPO_ROOT,
-  'docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/stack-control-roadmap.md',
-);
-
-/** Codenames `<phase>/<slug>` from the prose roadmap's feature table rows. */
-function proseCodenames(): string[] {
-  const codes = new Set<string>();
-  for (const line of readFileSync(PROSE, 'utf8').split('\n')) {
-    if (!line.startsWith('| `')) continue; // table rows only
-    const m = /^\| `((?:design|plan|impl|multi)\/[a-z0-9-]+)`/.exec(line);
-    if (m) codes.add(m[1]!);
-  }
-  return [...codes];
-}
 
 describe('roadmap migration presence (T049)', () => {
   it('the migrated ROADMAP.md is heading-keyed and validates green', () => {
@@ -35,18 +21,6 @@ describe('roadmap migration presence (T049)', () => {
     expect(model.doc.grammar.id).toBe('roadmap');
     expect(model.doc.grammar.unit.kind).toBe('heading');
     expect(model.items.length).toBeGreaterThan(0);
-  });
-
-  it('every prose-table feature survives as an item (kind inserted into the identifier)', () => {
-    const model = loadRoadmap(ROADMAP, { builtinGrammarDir: resolve(PLUGIN_ROOT, 'grammars') });
-    const ids = model.items.map((i) => i.identifier);
-    const codes = proseCodenames();
-    expect(codes.length).toBeGreaterThanOrEqual(8); // sanity: the table parsed
-    for (const code of codes) {
-      const [phase, slug] = code.split('/');
-      const present = ids.some((id) => new RegExp(`^${phase}:[a-z]+/${slug}$`).test(id));
-      expect(present, `prose feature '${code}' missing from migrated ROADMAP.md`).toBe(true);
-    }
   });
 
   it('includes the self-seed (roadmap-protocol) and the deferred order-gating gap', () => {


### PR DESCRIPTION
## Green main: retire the obsolete prose-roadmap migration guard

`plugins/stack-control/tests/roadmap/migration-presence.test.ts` (T049) is a one-time guard that read the **prose** program roadmap at `docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/stack-control-roadmap.md` and asserted every feature survived into the migrated heading-keyed `plugins/stack-control/ROADMAP.md`.

That prose source is **deprecated and was deleted** (commit `168d966e`, 2026-06-13), so the guard now throws `ENOENT` and fails CI. The migration is complete and the source is intentionally gone, so the lossless-port check is retired with it. The two remaining guards still validate the migrated `ROADMAP.md` directly (heading-keyed + self-seed/order-gating items present).

### Why main was red
This was pre-existing breakage on `feature/design-control` (not a design-control change). PR #473 merged that branch's 270 commits into main and carried the broken test along; it merged despite the red `test` check because that check **isn't a required status check**, so auto-merge didn't block on it.

### Verification
Full stack-control workspace green: **222 files, 1476 tests pass** (was `1 failed | 1476 passed`).

### Follow-up (NOT in this hotfix — surfaced separately)
The same cleanup also deleted `stack-control-thesis.md` and left ~10 stale references to both deleted docs across the repo, including the **always-loaded** `.claude/rules/stack-control-succession.md`, which still cites the deleted thesis as *required reading* and the deleted roadmap as canonical. That wants a deliberate docs pass (and a decision on where the thesis content lives now) — kept out of this surgical CI fix.
