### PR TITLE
fix(stack-control): terminal-status derivation + 022 roadmap disposition

### DIFF
--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -357,7 +357,8 @@ Umbrella: industrialize the stack-control project lifecycle so the governing cer
 One-move backlog->roadmap promotion: given a backlog item, PROPOSE the roadmap node derived from it (phase/kind from labels, slug from title, status planned, candidate edges, ref=TASK-id, description from body), dry-run the node + linkage, and on --apply CREATE the node AND record the promote linkage atomically — removing the two hand steps (roadmap add + backlog promote) run for TASK-134. Preserves the record-only-promote intent (bidirectional navigability). Promoted from TASK-135.
 
 ## multi:feature/parseable-lifecycle-workflow
-- status: planned
+- status: shipped
+- spec: specs/022-parseable-lifecycle-workflow
 - depends-on: design:feature/roadmap-protocol, design:feature/document-primitives
 - part-of: multi:feature/lifecycle-industrialization
 - ref: TASK-136

--- a/plugins/stack-control/src/__tests__/workflow/phase-derivation.test.ts
+++ b/plugins/stack-control/src/__tests__/workflow/phase-derivation.test.ts
@@ -155,4 +155,16 @@ describe('US2 terminal side-states (T010)', () => {
       derivePhase(doc, base({ blocked: true, specPointer: 's', analyzeClean: true })),
     ).toEqual({ kind: 'side-state', id: 'blocked' });
   });
+
+  it('a node whose roadmap status is shipped derives the terminal shipped phase (operator-recorded fact, no convergence record needed)', () => {
+    const doc = loadWorkflowDoc(fixture().root);
+    // A historical feature: status shipped, spec set, tasks complete, but NO impl
+    // convergence record (it shipped under the old process). It must NOT mis-derive
+    // to 'governing' — the recorded shipped status is terminal (operator decision).
+    const r = derivePhase(
+      doc,
+      base({ status: 'shipped', specPointer: 's', analyzeClean: true, tasksComplete: true, implRecordConverged: false }),
+    );
+    expect(r).toEqual({ kind: 'phase', id: 'shipped' });
+  });
 });

--- a/plugins/stack-control/src/workflow/phase-derivation.ts
+++ b/plugins/stack-control/src/workflow/phase-derivation.ts
@@ -84,6 +84,16 @@ export function derivePhase(doc: WorkflowDoc, inputs: DerivationInputs): Derived
   const side = sideStateOf(inputs);
   if (side !== null) return side;
 
+  // A terminal roadmap status `shipped` is an operator-recorded fact that the item
+  // shipped (operator decision 2026-06-16) — derive the doc's terminal phase (its
+  // last phase) directly, rather than re-deriving from a convergence record that a
+  // pre-workflow process never wrote. This mirrors the recorded-fact discipline of
+  // `cancelled`/`retired` (handled by sideStateOf) and `analyze-clean:`/
+  // `design-approved:` markers: the operator records, derivation reads.
+  if (inputs.status?.toLowerCase() === 'shipped') {
+    return { kind: 'phase', id: doc.phases[doc.phases.length - 1]!.id };
+  }
+
   for (let i = doc.phases.length - 1; i >= 0; i--) {
     const phase = doc.phases[i]!;
     if (deriveHolds(phase.derive, inputs)) return { kind: 'phase', id: phase.id };


### PR DESCRIPTION
## Workflow terminal-status derivation + 022 roadmap disposition

Follow-up to #477 (the parseable lifecycle workflow engine, shipped in v0.48.0),
from dogfooding the workflow against this repo's own roadmap.

### What's in it

- **Engine fix — derive the terminal phase from roadmap `status: shipped`.**
  Dogfooding surfaced that 21 already-shipped features mis-derived to `governing`:
  derivation only treated `cancelled`/`retired` as terminal and otherwise required
  an impl convergence record, which the pre-workflow process never wrote.
  `derivePhase` now treats roadmap `status: shipped` as the operator-recorded
  terminal fact and derives the doc's terminal phase directly — the same
  recorded-fact discipline as `cancelled`/`retired` and the `analyze-clean:` /
  `design-approved:` markers. **No fabricated markers or back-filled convergence
  records.** (RED→GREEN; `phase-derivation.test.ts`.)

- **Roadmap disposition — `multi:feature/parseable-lifecycle-workflow` (022).**
  The 022 node was stale (status `planned`, no spec pointer) and `roadmap reconcile`
  flagged `specs/022-parseable-lifecycle-workflow` as an orphan. Dispositioned via
  the installed workflow verbs (`workflow link-spec` + `roadmap advance --to
  shipped`); reconcile now reports **0 orphans / 0 drift / 0 unresolved**.

### Effect on the roadmap

| | Before | After |
|---|---|---|
| 21 historical shipped features | mis-derived `governing` | `shipped` |
| 022 (the orphan) | `planned` (stale) | `shipped` |
| Not-started items | `planned` | `planned` (drivable via `workflow advance`) |

### Testing

- Workflow suite: 82 green. The change is additive; existing derivation totality /
  side-state / govern-record tests unaffected.

Operator decision (2026-06-16) chose this engine-side fix over back-filling 21
features' markers — the latter would fabricate workflow history that never happened.
