### PR TITLE
feat(stack-control): mechanical terminal closure of resolved backlog items (023)

### DIFF
--- a/plugins/stack-control/.specify/feature.json
+++ b/plugins/stack-control/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/022-parseable-lifecycle-workflow"
+  "feature_directory": "specs/024-lifecycle-compass"
 }

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-136 - Document-the-end-to-end-stack-control-lifecycle-workflow-for-governing-a-project.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-136 - Document-the-end-to-end-stack-control-lifecycle-workflow-for-governing-a-project.md
@@ -3,10 +3,10 @@ id: TASK-136
 title: >-
   Parseable, deterministic stack-control lifecycle workflow that drives items
   through phases (not just documentation)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-15 20:50'
-updated_date: '2026-06-15 20:55'
+updated_date: '2026-06-16 04:49'
 labels:
   - agent-found
   - 'type:gap'

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-19 - Governance-graduation-has-no-on-disk-record-roadmap-reconcile-falls-back-to-tasks-completion-as-the-shipped-signal.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-19 - Governance-graduation-has-no-on-disk-record-roadmap-reconcile-falls-back-to-tasks-completion-as-the-shipped-signal.md
@@ -3,10 +3,10 @@ id: TASK-19
 title: >-
   Governance graduation has no on-disk record; roadmap reconcile falls back to
   tasks-completion as the shipped signal
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-10 18:33'
-updated_date: '2026-06-11 00:55'
+updated_date: '2026-06-16 04:49'
 labels:
   - agent-found
   - 'type:gap'

--- a/plugins/stack-control/CLAUDE.md
+++ b/plugins/stack-control/CLAUDE.md
@@ -1,8 +1,8 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-specs/022-parseable-lifecycle-workflow/plan.md
+specs/024-lifecycle-compass/plan.md
 Verification scenarios and the design record live in:
-specs/022-parseable-lifecycle-workflow/spec.md
-specs/022-parseable-lifecycle-workflow/quickstart.md
+specs/024-lifecycle-compass/spec.md
+specs/024-lifecycle-compass/quickstart.md
 <!-- SPECKIT END -->

--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -372,3 +372,15 @@ The centerpiece: a PARSEABLE, DETERMINISTIC lifecycle workflow that drives items
 - ref: TASK-137
 Add a roadmap reparent verb to move an existing part-of / depends-on edge between nodes (no mutation verb does this today; re-parenting requires hand-editing the governed ROADMAP.md). Shape: roadmap reparent <id> --part-of <target> | --depends-on <target> [--remove <target>], dry-run then --apply, graph-revalidating (refuse cycle/dangling/self), zero-write-on-failure. Promoted from TASK-137.
 
+## impl:feature/terminal-closure
+- status: in-flight
+- part-of: multi:feature/lifecycle-industrialization
+- spec: specs/023-terminal-closure
+Mechanical terminal closure: roadmap close-related closes a terminal item's recorded closes:/ref: backlog ids in one deterministic move.
+
+## multi:feature/lifecycle-compass
+- status: in-flight
+- design: docs/superpowers/specs/2026-06-16-lifecycle-compass-design.md
+- part-of: multi:feature/lifecycle-industrialization
+Make the lifecycle un-skippable: a workflow 'compass' primitive that orients an agent against a roadmap item and diffs intended action vs allowed phase, embedded as the precondition of every lifecycle skill (real refusals, not reports). Includes the supporting fixes (capture fused to authoring; govern feature-resolution from the spec pointer not the branch slug; TASK-83) so the gates are enforceable.
+

--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -381,6 +381,7 @@ Mechanical terminal closure: roadmap close-related closes a terminal item's reco
 ## multi:feature/lifecycle-compass
 - status: in-flight
 - design: docs/superpowers/specs/2026-06-16-lifecycle-compass-design.md
+- design-approved: 2026-06-16
 - part-of: multi:feature/lifecycle-industrialization
 Make the lifecycle un-skippable: a workflow 'compass' primitive that orients an agent against a roadmap item and diffs intended action vs allowed phase, embedded as the precondition of every lifecycle skill (real refusals, not reports). Includes the supporting fixes (capture fused to authoring; govern feature-resolution from the spec pointer not the branch slug; TASK-83) so the gates are enforceable.
 

--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -362,6 +362,7 @@ One-move backlog->roadmap promotion: given a backlog item, PROPOSE the roadmap n
 - depends-on: design:feature/roadmap-protocol, design:feature/document-primitives
 - part-of: multi:feature/lifecycle-industrialization
 - ref: TASK-136
+- closes: TASK-19
 The centerpiece: a PARSEABLE, DETERMINISTIC lifecycle workflow that drives items through phases — not just a WORKFLOW.md doc. Apply the roadmap-protocol pattern to the process itself: a governed grammar-parsed workflow document (phases, per-phase entry/exit gates, the verb/skill executing each phase) plus an engine that, given an item, knows its current phase, the gate conditions to advance, and deterministically drives it to the next phase or reports why it's blocked. The human-readable WORKFLOW.md is one rendering of the parseable source of truth. Reuses document-primitives (governed parseable-doc engine) + roadmap-protocol grammar/DAG reasoning. Promoted from TASK-136.
 
 ## impl:gap/roadmap-reparent-verb

--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -380,6 +380,7 @@ Mechanical terminal closure: roadmap close-related closes a terminal item's reco
 
 ## multi:feature/lifecycle-compass
 - status: in-flight
+- spec: specs/024-lifecycle-compass
 - design: docs/superpowers/specs/2026-06-16-lifecycle-compass-design.md
 - design-approved: 2026-06-16
 - part-of: multi:feature/lifecycle-industrialization

--- a/plugins/stack-control/docs/superpowers/specs/2026-06-16-lifecycle-compass-design.md
+++ b/plugins/stack-control/docs/superpowers/specs/2026-06-16-lifecycle-compass-design.md
@@ -1,0 +1,187 @@
+# Design Record: Lifecycle Compass — making the workflow un-skippable
+
+**Roadmap item**: `multi:feature/lifecycle-compass` (part-of `multi:feature/lifecycle-industrialization`)
+**Date**: 2026-06-16
+**Status**: in design (awaiting operator approval)
+
+## problem-domain
+
+The 022 parseable-lifecycle-workflow engine derives an item's phase from artifacts
+and *reports* gate state — but it **enforces nothing** (FR-010: "gates evaluated and
+REPORTED but MUST NOT be enforced as refusals"). A lifecycle that can be bypassed
+guarantees nothing; it narrates whatever state happens to exist.
+
+This was not theoretical. While dogfooding, the agent built feature 023
+(terminal-closure) the wrong way: **idea → wrote `spec.md` → wrote code → opened a
+PR, with no roadmap node ever created.** The workflow was blind to the whole
+feature. The orphan spec dir was caught only because the agent *happened* to run
+`roadmap reconcile`. The workflow proved useless precisely when it mattered.
+
+The operator's framing is the governing constraint:
+
+> **Compliance cannot depend on operator vigilance OR on agent discipline. It must
+> be mechanical — or it does not exist.**
+
+This is the thesis restated: *you don't fix "insane, hyperintelligent toddlers" by
+yelling (rules); you fix them with environmental design that makes the failure
+state mechanically impossible.* Rules already told the agent to follow the
+lifecycle. The agent skipped anyway. So "add more rules / be more careful" is a
+non-solution.
+
+The disease has two holes, plus a compounding blocker:
+
+- **Entry is not required.** Feature work can proceed with no roadmap node (an
+  orphan). Nothing makes capture the mandatory first step.
+- **Order is not required.** Even with a node, phases can be skipped — gates only
+  report.
+- **The back half cannot even run** (so a gate that required it would block *all*
+  work, not enforce a step). Verified this session: `govern --mode implement` on
+  the session-pinned branch `feature/stack-control` derives the feature slug from
+  the branch (`stack-control`), looks for `specs/<NNN>-stack-control`, finds
+  nothing, and **FATALs "feature not found"** — for *every* spec on the branch. The
+  `after_implement` hook passes no `--feature`. And even with `--feature`, TASK-83
+  crashes the payload assembler on `/stack-control:*` backtick spans (022 hit
+  exactly this). So `governing → shipped` — the mechanical back half 022 was built
+  to deliver — is unreachable; features dead-end at `governing` or get
+  hand-advanced to `shipped`, the discretionary step the feature was built to kill.
+
+The net: **the workflow is a passive observer, not a driver.** It cannot pull work
+onto the rail (orphans) and cannot push it off the end (govern unreachable).
+
+## solution-space
+
+The centerpiece is the operator's idea: a **compass** — a primitive an agent
+invokes against a roadmap item that orients it in the lifecycle and lets it **diff
+what it is about to do against the workflow state**. The design turns that single
+primitive into the one enforcement brain every lifecycle surface consults.
+
+- **Alternative A — Compass primitive as the single enforcement brain, embedded as
+  the precondition of every lifecycle skill (CHOSEN).**
+  `workflow compass <item> [--intent <action>]` does two jobs from one
+  implementation: (1) **orient** — derive the phase, name the *one* legitimate next
+  action (the phase's work skill + next transition), show the gate state; (2)
+  **diff** — given `--intent`, classify the intended action's phase and return a
+  verdict against the live state: `on-course` (intent = legitimate next),
+  `ahead` (intent belongs to a *later* phase — the agent is skipping; names the
+  jumped step), `behind` (earlier phase — re-entry/redundant; allow-with-note), or
+  `off-rail` (no node / side-state — refuse). The verdict is also an **exit code**.
+  Every lifecycle skill (`define`, `execute`, the `after_implement` govern hook,
+  `ship`, `release`, `session-end`) opens with `workflow compass <item> --intent
+  <this-skill>`; a non-zero verdict is a **hard refusal**. The agent doesn't have to
+  *remember* to orient — the skill it runs orients for it and refuses if it's
+  off-rail. One brain, every surface consults it; the lifecycle rules live in
+  exactly one tested place.
+  *Why chosen:* it is the operator's tool idea made load-bearing; it is DRY (no
+  per-skill gate drift); it travels with the plugin install (skills + CLI verb, per
+  `enforcement-lives-in-skills.md`); and it directly kills the demonstrated failure
+  (intent=`write spec`, phase=`planned` → `ahead`, names skipped `open-design`).
+
+- **Alternative B — Scatter bespoke gate checks into each skill (REJECTED).** Each
+  skill hand-codes its own precondition. Rejected: N copies of the lifecycle rules
+  drift out of sync (the same single-source-of-truth lesson 022's governed
+  WORKFLOW.md already encodes); a new phase or criterion means editing N skills.
+
+- **Alternative C — Git-hook / CI enforcement (REJECTED).** A pre-commit/pre-push
+  hook or a CI gate that refuses non-compliant work. Rejected: violates
+  `.claude/rules/enforcement-lives-in-skills.md` (dw-lifecycle enforcement is never
+  wired into git hooks — adopters get discipline from the plugin install, not hooks
+  they wire themselves) and the project's no-CI-test-infra rule (CI is brutally
+  slow). It also wouldn't travel with the plugin.
+
+- **Alternative D — Strengthen the rules / CLAUDE.md telling the agent to follow
+  the workflow (REJECTED).** Rejected outright: this *is* the "yelling" the thesis
+  rejects, and it is exactly what just failed — the agent had the rules and skipped
+  anyway. Documentation is not a mechanism.
+
+- **Alternative E — An operator review gate (REJECTED as primary).** The operator
+  reviews each transition for compliance. Rejected per the governing constraint:
+  the operator must not be the vigilance. (Operator approval remains a *recorded
+  judgment input* for specific gates like `design-approved`, but it is never the
+  mechanism that keeps the agent on-rail.)
+
+## decisions
+
+1. **One primitive, two uses.** `stackctl workflow compass <item> [--intent
+   <action>] [--json]` returns a verdict (`on-course` | `ahead` | `behind` |
+   `off-rail`) + a machine-readable report; the verdict maps to an exit code so a
+   skill body can gate on it. Bare (no `--intent`) it is the agent's orientation
+   map.
+2. **The compass is the single enforcement brain.** Every lifecycle skill embeds
+   `workflow compass <item> --intent <this-skill>` as its opening precondition;
+   non-zero ⇒ refuse loud with the compass's reason. The rules live once.
+3. **Capture is fused to authoring.** Authoring a spec creates the roadmap node in
+   the same atomic move (no spec dir without a node). An orphan spec dir is a hard
+   error the compass reports (`off-rail`), not a reconcile footnote.
+4. **Gates become refusals (retire FR-010 report-only).** The compass verdict has
+   teeth; the embedding skills enforce. (Whether the retirement is global or phased
+   during migration is an open question below.)
+5. **Govern is made runnable** as a prerequisite: resolve the feature from the
+   item's spec pointer / the SPECKIT marker, not the branch slug (the
+   session-pinned-branch FATAL), so the `after_implement` hook and `execute` can
+   actually govern; fold in TASK-83 (backtick-scope crash). A gate cannot enforce a
+   step that cannot run.
+6. **Intent is matched mechanically.** The compass maps a known skill/verb name to
+   the phase it belongs to (enumerated, not NL-guessed) and diffs against the
+   derived current phase + the legitimate transition. Free-form NL intent, if
+   supported, is advisory only.
+7. **`compass` is a new verb, not an overload of `workflow next`.** `next` previews
+   the next move; `compass` adds the intent-diff, the verdict, and the gating exit
+   code — a distinct contract.
+8. **The honest boundary is recorded, not hidden.** The mechanism makes *the agent*
+   (which follows its skills) unable to skip. A human with raw `git`/`gh` can always
+   override. That is acceptable: the threat model is agent drift, not a deliberate
+   human bypass.
+
+## open-questions
+
+(Carried to the spec — captured, not cut.)
+
+- **Intent vocabulary.** The exact enumerated action/skill → phase mapping, and how
+  strictly an unknown intent is treated (refuse vs advisory).
+- **Capture-fusion mechanics.** Does `/stack-control:define` / `/speckit-specify`
+  create the node directly, or a mandatory pre-step? Interaction with the
+  session-pinned branch and the `specs/<NNN>-<slug>` numbering. How the node id is
+  derived from the spec slug (and vice-versa) so the compass, govern, and
+  close-related share one identity (relates to TASK-139, the basename-collision).
+- **FR-010 retirement scope.** Global flip to refusals, or phased (enforce the
+  entry + back-half gates first, keep mid-pipeline advisory during migration)?
+- **Legacy migration.** The 21+ shipped nodes and in-flight items: is the orphan
+  gate retroactive (require backfill) or grandfathered for terminal items? (The
+  terminal-status derivation fix already reports them `shipped`.)
+- **Sequencing of the prerequisites.** Are the govern-resolution fix + TASK-83
+  folded into this feature's spec, or shipped as prerequisite fixes first so the
+  compass's back-half gates are enforceable on landing? (They block enforceability;
+  they likely lead.)
+- **Where the govern feature-identity resolves from** when a session-pinned branch
+  carries many features: the item's `spec:` pointer, the SPECKIT marker, or an
+  explicit `--feature` the workflow always supplies. (Touches the canonical
+  feature-identity question across govern/workflow/roadmap.)
+- **What "intent" the non-lifecycle path declares.** When an agent is about to write
+  code or a file directly (not via a skill), there is no verb to embed the compass
+  in — the backstop is that the *finishing* skills (ship/release/session-end) refuse
+  without the evidence chain. Is that backstop sufficient, or is a lighter
+  always-on orientation nudge wanted at session-start?
+
+## provenance
+
+- **Origin**: operator session 2026-06-16, discovered while dogfooding specs/022
+  (parseable-lifecycle-workflow) and specs/023 (terminal-closure). The agent shipped
+  023 entirely off-rail (no node), which exposed the workflow's uselessness in
+  practice; `workflow status` on the just-created 023 node then surfaced the
+  `governing → shipped` dead-end.
+- **Operator corrections that shaped this** (verbatim intent): "the workflow is
+  useless because you skipped a step"; "the operator shouldn't have to be vigilant
+  about keeping the agent workflow compliant"; and the compass tool idea — "a
+  'compass' function the agent can invoke against a roadmap item that orients the
+  agent in the workflow so it can diff what it is trying to do against the workflow
+  state."
+- **Builds on**: specs/022-parseable-lifecycle-workflow (the engine + derivation +
+  gate-eval this extends); the thesis (`THESIS.md` /
+  `stack-control-thesis.md` — environmental design makes failure states impossible);
+  `.claude/rules/enforcement-lives-in-skills.md` (no git-hook enforcement);
+  `.claude/rules/agent-discipline.md`.
+- **Verified blockers referenced**: the `govern --mode implement` "feature
+  'stack-control' not found" FATAL on the session-pinned branch (reproduced this
+  session); TASK-83 / AUDIT-20260614-28 (backtick scope extraction crashes the
+  assembler); TASK-139 (convergence-record basename collision — the same
+  feature-identity question).

--- a/plugins/stack-control/grammars/roadmap.peg
+++ b/plugins/stack-control/grammars/roadmap.peg
@@ -19,6 +19,7 @@ edgeFields:
   - { name: design,          references: external, acyclic: false, blocking: false }
   - { name: design-approved, references: prose,    acyclic: false, blocking: false }
   - { name: analyze-clean,   references: prose,    acyclic: false, blocking: false }
+  - { name: closes,          references: prose,    acyclic: false, blocking: false }
 reconciliationHook:
   kind: glob
   source: "specs/*/spec.md"

--- a/plugins/stack-control/specs/023-terminal-closure/spec.md
+++ b/plugins/stack-control/specs/023-terminal-closure/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Mechanical terminal closure of resolved backlog items
+
+**Codename**: `impl/terminal-closure` (part-of `multi:feature/lifecycle-industrialization`)
+
+**Feature Branch**: `feature/stack-control` (session-pinned)
+
+**Created**: 2026-06-16
+
+**Status**: Draft
+
+## Context
+
+When a roadmap item reaches a terminal state (`shipped` / `cancelled` / `retired`),
+the backlog items that item *resolved* should be closed — mechanically, in one
+move, with no agent discretion. Today that closure is manual: the operator (or the
+agent) hand-closes items one at a time, which is exactly the surface for the
+failure modes this feature kills — closing the wrong item, claiming closure that
+didn't happen (fabrication), forgetting an item, or asking a flurry of "should I /
+how should I" questions instead of just doing it.
+
+The mechanism does **not** fire automatically (it is an explicit operator move),
+but once fired it is **deterministic**: the set of items to close is a *recorded
+fact* on the roadmap node, never inferred from titles, greps, or agent judgment.
+
+## Ratified design decisions (2026-06-16, settled — do not relitigate)
+
+1. **Explicit links only.** The items a feature resolves are recorded in a `closes:`
+   field on the roadmap node (a comma-list of backlog ids) plus the node's
+   originating `ref:`. Closure operates on **exactly** that set. It never
+   title-matches, greps, or infers "related." If an id is not in `closes:`/`ref:`,
+   it is not touched.
+2. **Resolves ≠ found-during.** Bugs/gaps *discovered* while building a feature are
+   NOT auto-added to `closes:` — they are unfinished work and stay open by
+   construction. Only the items the feature actually delivered go in `closes:`.
+3. **Terminal-gated.** `close-related` refuses loud unless the item's roadmap status
+   is one of the grammar's terminal statuses (`shipped`/`cancelled`/`retired`).
+4. **Dry-run first.** Default lists exactly what would close + the recorded links it
+   read; `--apply` closes them. Idempotent — re-running closes nothing new.
+5. **No fabrication.** Closure shells the configured backlog backend; an unknown id
+   or a backend error fails loud. The verb never reports a close it didn't perform.
+
+## User Scenarios & Testing
+
+### User Story 1 - One mechanical move closes a terminal item's resolved backlog (P1) 🎯 MVP
+
+The operator runs `stackctl roadmap close-related <item>` on a terminal item and the
+backlog items that item resolved (its `closes:` list + `ref:`) are closed in one
+deterministic move.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `shipped` node with `closes: TASK-A, TASK-B` and `ref: TASK-C`, **When**
+   `close-related <item> --apply` runs, **Then** TASK-A/B/C are set to `Done` and the
+   verb reports each closed id; re-running closes nothing new (idempotent).
+2. **Given** the same node, **When** `close-related <item>` runs without `--apply`,
+   **Then** it lists exactly TASK-A/B/C as *would-close* and writes nothing.
+3. **Given** a non-terminal node (`planned`/`in-flight`), **When** `close-related` runs,
+   **Then** it refuses loud (the item has not reached a terminal state).
+4. **Given** a `closes:` id the backend does not know, **When** `--apply` runs, **Then**
+   it fails loud naming the id (never a silent skip, never a fabricated success).
+5. **Given** a node with no `closes:`/`ref:`, **When** `close-related` runs, **Then** it
+   reports "no recorded resolved items" and closes nothing.
+
+## Requirements
+
+- **FR-001**: A roadmap node MUST support a `closes:` field — a list of backlog ids the
+  feature resolves on terminal closure — read by the node reader alongside `ref:`.
+- **FR-002**: `roadmap close-related <item>` MUST refuse loud unless `<item>`'s status is
+  a grammar-declared terminal status (`shipped`/`cancelled`/`retired`).
+- **FR-003**: It MUST close EXACTLY the union of the node's `closes:` ids and `ref:` id —
+  never an id derived from title-matching, greps, or judgment.
+- **FR-004**: It MUST default to a dry-run (writing nothing) and apply only under `--apply`.
+- **FR-005**: It MUST be idempotent — closing an already-`Done` item is a no-op reported as
+  already-closed, not an error.
+- **FR-006**: Closure MUST go through the configured backlog backend (set status `Done`); an
+  unknown id or backend error MUST fail loud — the verb never reports an unperformed close.
+- **FR-007**: The backlog backend MUST expose a `close(id)` operation that sets an item's
+  status to the terminal `Done` via the real binary, failing loud on a non-zero exit.
+
+## Success Criteria
+
+- **SC-001**: For a terminal node with N recorded resolved ids, `--apply` closes exactly
+  those N (no more, no fewer) and a dry-run names exactly those N — 100% of fixture cases.
+- **SC-002**: A non-terminal node is refused 100% of the time; an unknown id fails loud 100%
+  of the time; no fixture path reports a close that did not occur.
+- **SC-003**: Re-running `--apply` on an already-closed set is a clean no-op (idempotent).
+
+## Assumptions
+
+- The backlog backend (`backlog.md`) supports status transition via `task edit <id> -s Done`.
+- The `closes:` set is recorded as part of the feature's work (reviewable in the roadmap
+  diff), not synthesized at close time — that recording is what makes the close safe.

--- a/plugins/stack-control/specs/023-terminal-closure/tasks.md
+++ b/plugins/stack-control/specs/023-terminal-closure/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Mechanical terminal closure of resolved backlog items
+
+**Tests**: TDD mandatory — every behavior lands RED→GREEN.
+
+- [X] T001 Add the `closes:` edge field to `grammars/roadmap.peg` + project `closes: readonly string[]` on `WorkItem` in `src/roadmap/roadmap-model.ts` (FR-001). RED: a node with `- closes: TASK-A, TASK-B` projects `closes=['TASK-A','TASK-B']`.
+- [X] T002 Add `close(id)` to `BacklogBackend` in `src/backlog/backend.ts` — `backlog task edit <id> -s Done --plain`; non-zero exit → BacklogError (FR-006/FR-007). RED: shells the right args; throws on unknown id.
+- [X] T003 Implement `roadmap close-related <item>` in `src/subcommands/roadmap.ts`: terminal-gate (FR-002), gather `closes:` ∪ `ref:` (FR-003), dry-run/`--apply` (FR-004), idempotent (FR-005), fail-loud per-id (FR-006). RED: CLI tests for the acceptance scenarios.
+- [ ] T004 Run the targeted + umbrella vitest; then record `closes: TASK-136, TASK-19` on the 022 node and run `close-related --apply` to close them (the feature's first use in anger).

--- a/plugins/stack-control/specs/023-terminal-closure/tasks.md
+++ b/plugins/stack-control/specs/023-terminal-closure/tasks.md
@@ -5,4 +5,4 @@
 - [X] T001 Add the `closes:` edge field to `grammars/roadmap.peg` + project `closes: readonly string[]` on `WorkItem` in `src/roadmap/roadmap-model.ts` (FR-001). RED: a node with `- closes: TASK-A, TASK-B` projects `closes=['TASK-A','TASK-B']`.
 - [X] T002 Add `close(id)` to `BacklogBackend` in `src/backlog/backend.ts` — `backlog task edit <id> -s Done --plain`; non-zero exit → BacklogError (FR-006/FR-007). RED: shells the right args; throws on unknown id.
 - [X] T003 Implement `roadmap close-related <item>` in `src/subcommands/roadmap.ts`: terminal-gate (FR-002), gather `closes:` ∪ `ref:` (FR-003), dry-run/`--apply` (FR-004), idempotent (FR-005), fail-loud per-id (FR-006). RED: CLI tests for the acceptance scenarios.
-- [ ] T004 Run the targeted + umbrella vitest; then record `closes: TASK-136, TASK-19` on the 022 node and run `close-related --apply` to close them (the feature's first use in anger).
+- [X] T004 Run the targeted + umbrella vitest; then record `closes: TASK-136, TASK-19` on the 022 node and run `close-related --apply` to close them (the feature's first use in anger).

--- a/plugins/stack-control/specs/024-lifecycle-compass/checklists/requirements.md
+++ b/plugins/stack-control/specs/024-lifecycle-compass/checklists/requirements.md
@@ -13,8 +13,8 @@
 
 ## Requirement Completeness
 
-- [ ] No [NEEDS CLARIFICATION] markers remain — 3 remain (FR-004, FR-010, FR-015); resolved by `/speckit-clarify`
-- [x] Requirements are testable and unambiguous (excepting the 3 marked forks)
+- [x] No [NEEDS CLARIFICATION] markers remain — all 3 resolved (operator-confirmed 2026-06-16)
+- [x] Requirements are testable and unambiguous
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic
 - [x] All acceptance scenarios are defined
@@ -31,7 +31,6 @@
 
 ## Notes
 
-- 3 `[NEEDS CLARIFICATION]` markers remain by design — they are genuine operator forks
-  (intent vocabulary, FR-010 retirement scope, prerequisite sequencing) that the
-  dedicated `/speckit-clarify` step resolves next in the chain. The spec is otherwise
-  complete and validated.
+- All 3 forks (intent vocabulary, FR-010 retirement scope, prerequisite sequencing)
+  resolved by operator confirmation 2026-06-16 and encoded into the Clarifications
+  section + FR-004/FR-010/FR-015. Spec is complete and ready for `/speckit-plan`.

--- a/plugins/stack-control/specs/024-lifecycle-compass/checklists/requirements.md
+++ b/plugins/stack-control/specs/024-lifecycle-compass/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Lifecycle Compass — an un-skippable workflow
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain — 3 remain (FR-004, FR-010, FR-015); resolved by `/speckit-clarify`
+- [x] Requirements are testable and unambiguous (excepting the 3 marked forks)
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (the capture-everything surface; first-slice scoping is FR-015's explicit clarification)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 3 `[NEEDS CLARIFICATION]` markers remain by design — they are genuine operator forks
+  (intent vocabulary, FR-010 retirement scope, prerequisite sequencing) that the
+  dedicated `/speckit-clarify` step resolves next in the chain. The spec is otherwise
+  complete and validated.

--- a/plugins/stack-control/specs/024-lifecycle-compass/spec.md
+++ b/plugins/stack-control/specs/024-lifecycle-compass/spec.md
@@ -62,8 +62,21 @@ open questions.
 
 ### Session 2026-06-16
 
-(Reserved — to be populated by `/speckit-clarify`. The open forks are surfaced as
-`[NEEDS CLARIFICATION]` markers in Requirements below and in Assumptions.)
+- Q: Is the compass intent vocabulary a fixed enumeration, or free-form NL mapped
+  heuristically? → A: **Fixed enumeration of lifecycle skill/verb names; an unknown
+  intent refuses (fail-loud).** A heuristic NL→phase mapping would reintroduce the
+  agent-judgment the feature exists to remove; the verdict must be mechanical.
+- Q: Is the FR-010 report-only retirement global or phased? → A: **Phased — enforce
+  the entry gate (orphan/capture) and the back-half `governing → shipped` gate first;
+  mid-pipeline gates stay advisory in the *engine's* `advance` path.** Order is still
+  enforced mid-pipeline by the compass embedded in the skills (US2/FR-006); FR-010 is
+  only about the engine's own advance path, and a global flip risks blocking legit
+  in-flight work before the govern fixes are proven.
+- Q: Do the govern-runnability + canonical-identity fixes ship as separate
+  prerequisite features, or fold into this spec? → A: **One spec — but the
+  govern-runnability fixes (FR-011/FR-012) and the canonical identity (FR-013) are the
+  FIRST task phases**, so the compass enforcement builds on an already-runnable govern
+  ("can't enforce a step that can't run").
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -251,11 +264,10 @@ own item.
   node / a terminal side-state).
 - **FR-003**: The verdict MUST be exposed as a process exit code (zero = proceed,
   non-zero = refuse) so a skill body can gate on it without parsing prose.
-- **FR-004**: An intended action that the compass does not recognize MUST fail loud
-  (treated as a refusal), never silently classified as `on-course`. [NEEDS
-  CLARIFICATION: is the intent vocabulary a fixed enumeration of lifecycle
-  skill/verb names, with anything else refused — or is a free-form natural-language
-  intent accepted and mapped heuristically (advisory only)?]
+- **FR-004**: The intent vocabulary MUST be a fixed enumeration of lifecycle
+  skill/verb names, each mapped to the phase it belongs to. An intended action not in
+  the enumeration MUST fail loud (treated as a refusal), never silently classified as
+  `on-course` and never mapped heuristically. *(Clarified 2026-06-16.)*
 - **FR-005**: The compass MUST be read-only (writing nothing; identical output on
   re-run with no on-disk change).
 
@@ -280,11 +292,12 @@ own item.
 
 **Gates are refusals**
 
-- **FR-010**: The workflow's enforced gates MUST be refusals, not reports — retiring
-  the 022 v1 report-only posture where enforcement applies. [NEEDS CLARIFICATION:
-  is the report-only retirement global (all gates refuse) or phased (enforce the
-  entry gate + the back-half `governing → shipped` gate first; keep mid-pipeline
-  gates advisory during migration)?]
+- **FR-010**: The report-only retirement MUST be phased: the **entry gate**
+  (orphan/capture, US3) and the back-half **`governing → shipped`** gate are enforced
+  as refusals first; mid-pipeline gates remain advisory in the engine's own `advance`
+  path during migration. Mid-pipeline ORDER is still enforced by the compass embedded
+  in the skills (FR-006) — FR-010 governs only the engine's advance path.
+  *(Clarified 2026-06-16.)*
 
 **Govern runnable (prerequisite)**
 
@@ -310,11 +323,11 @@ own item.
 
 **Scope / sequencing**
 
-- **FR-015**: [NEEDS CLARIFICATION: do the govern-runnability fixes (FR-011/FR-012)
-  and the canonical-identity change (FR-013) ship as prerequisite features *ahead* of
-  the compass + embedding, or are they folded into this single spec's implementation?
-  They block enforceability of the back-half gate, so they must land no later than the
-  enforcement that depends on them.]
+- **FR-015**: The govern-runnability fixes (FR-011/FR-012) and the canonical-identity
+  change (FR-013) MUST be the FIRST implementation phases of this spec — the compass +
+  skill embedding (FR-001/FR-006) build on an already-runnable, identity-consistent
+  govern. They are not separate features, but they sequence first because the
+  back-half gate's enforceability depends on them. *(Clarified 2026-06-16.)*
 
 ### Key Entities
 
@@ -353,12 +366,9 @@ own item.
 
 - **Capture everything; scope later.** Per the project's capture-don't-cut rule, this
   spec records the full surface (compass + embedding + capture-fusion + govern
-  runnability + canonical identity + report-only retirement). Which slices ship first
-  is a later, explicit operator-driven scoping pass — surfaced as FR-015's
-  clarification, not silently cut here.
-- **Intent vocabulary default** (pending FR-004 clarification): the intent is a fixed
-  enumeration of lifecycle skill/verb names; an unknown intent refuses (fail-loud).
-- **Capture-fusion mechanics default** (pending): the spec-authoring front door
+  runnability + canonical identity + report-only retirement). The sequencing within it
+  is settled by FR-015 (govern-runnability + identity lead).
+- **Capture-fusion mechanics** (default applied): the spec-authoring front door
   (`define` / `speckit-specify` path) creates the node; the node id derives from the
   canonical feature identity (FR-013) so it round-trips with the spec dir.
 - **Legacy migration** (default applied, not a blocking clarification): the

--- a/plugins/stack-control/specs/024-lifecycle-compass/spec.md
+++ b/plugins/stack-control/specs/024-lifecycle-compass/spec.md
@@ -1,0 +1,375 @@
+# Feature Specification: Lifecycle Compass — an un-skippable workflow
+
+**Codename**: `multi/lifecycle-compass` (part-of `multi:feature/lifecycle-industrialization`)
+
+**Feature Branch**: `feature/stack-control` (session-pinned; not a per-spec branch)
+
+**Created**: 2026-06-16
+
+**Status**: Draft
+
+**Input**: Author the spec from the approved design record at
+`plugins/stack-control/docs/superpowers/specs/2026-06-16-lifecycle-compass-design.md`
+(read it for the full reasoning, the weighed alternatives, and the verified
+blockers). This spec captures that design into Spec Kit form.
+
+## Context
+
+The 022 parseable-lifecycle-workflow engine derives an item's phase and *reports*
+gate state — but **enforces nothing** (FR-010: gates reported, never refused). A
+lifecycle that can be bypassed guarantees nothing. This was proven, not theorized:
+while dogfooding, the agent built feature 023 **idea → spec.md → code → PR with no
+roadmap node ever created** — the workflow was blind to the whole feature; the
+orphan was caught only because the agent happened to run `reconcile`.
+
+The governing operator constraint (the thesis applied):
+
+> **Compliance must be mechanical — it cannot depend on operator vigilance OR on
+> agent discipline.** You don't fix agents by yelling (rules); you make the failure
+> state mechanically impossible.
+
+This feature makes the workflow the **driver**, not a passive observer, via a single
+orientation-and-enforcement primitive — the **compass** — that every lifecycle skill
+consults, so an agent following its own skills cannot skip a step.
+
+### Originating inputs
+
+- The 022 engine (derivation, gate-eval, governed `WORKFLOW.md`) this extends.
+- **TASK-83 / AUDIT-20260614-28** — backtick code-span misread as a governed path
+  crashes the govern payload assembler (reproduced this session); a prerequisite.
+- **TASK-139** — convergence-record basename collision; the same feature-identity
+  question this feature must settle.
+
+## Ratified framing decisions (2026-06-16, settled — do not relitigate)
+
+These were operator decisions captured in the design record; they are inputs, not
+open questions.
+
+1. **Mechanical, not vigilant.** The mechanism may not rely on the operator watching
+   or the agent remembering. Enforcement lives in skill bodies + CLI verbs (per
+   `.claude/rules/enforcement-lives-in-skills.md`), never git hooks or CI.
+2. **The compass is the single enforcement brain.** One primitive, consulted by every
+   lifecycle skill — not per-skill bespoke gate logic (which would drift).
+3. **A gate cannot enforce a step that cannot run.** Making govern runnable on the
+   session-pinned branch (+ TASK-83) is in scope as a prerequisite, because the
+   back-half gate depends on it.
+4. **Honest boundary.** The mechanism makes the *agent* (which follows its skills)
+   unable to skip; a human with raw `git`/`gh` can override. This is acceptable — the
+   threat model is agent drift, not deliberate human bypass — and MUST be recorded,
+   not overclaimed.
+
+## Clarifications
+
+### Session 2026-06-16
+
+(Reserved — to be populated by `/speckit-clarify`. The open forks are surfaced as
+`[NEEDS CLARIFICATION]` markers in Requirements below and in Assumptions.)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The compass orients and diffs intended action (Priority: P1) 🎯 MVP
+
+An agent, about to act on a roadmap item, invokes the compass against that item with
+its intended action and gets a deterministic verdict on whether that action is the
+legitimate next move — *before* it acts, not after.
+
+**Why this priority**: This is the primitive every other story consumes. It has
+standalone value: even before any skill embeds it, an agent can self-orient and catch
+its own skips.
+
+**Independent Test**: Given fixture items at known artifact states, `compass <item>`
+reports the derived phase, the single legitimate next action, and the gate state;
+`compass <item> --intent <action>` returns `on-course` / `ahead` / `behind` /
+`off-rail` with a gating exit code, deterministically and read-only.
+
+**Acceptance Scenarios**:
+
+1. **Given** an item in `planned` and an intended action that belongs to a later
+   phase (e.g. authoring a spec), **When** the compass diffs it, **Then** it returns
+   `ahead`, **names the skipped step** (`open-design`), and exits non-zero.
+2. **Given** an item and the intended action that *is* its legitimate next move,
+   **When** the compass diffs it, **Then** it returns `on-course` and exits zero.
+3. **Given** an item with no roadmap node (an orphan spec dir), **When** the compass
+   runs, **Then** it returns `off-rail` and exits non-zero, naming the missing node.
+4. **Given** any item, **When** the compass runs twice with no on-disk change,
+   **Then** it writes nothing and produces identical output (read-only, deterministic).
+
+---
+
+### User Story 2 - Every lifecycle skill refuses an off-rail action (Priority: P1)
+
+Each lifecycle skill (`define`, `execute`, the `after_implement` govern hook, `ship`,
+`release`, `session-end`) opens by consulting the compass for its own item + intent;
+a non-zero verdict is a hard refusal naming the violated invariant. An agent following
+its skills therefore cannot skip a step.
+
+**Why this priority**: This is what turns the compass from an advisory map into the
+enforcement surface. Without it, the compass is just another report the agent can skip.
+
+**Independent Test**: Driving a lifecycle skill on an item whose compass verdict is
+`ahead`/`off-rail` refuses loud (non-zero, names the missing prior step) and performs
+none of the skill's work; on an `on-course` item it proceeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** an item in `planned` (no design record), **When** the agent invokes the
+   spec-authoring skill on it, **Then** the embedded compass verdict is `ahead` and
+   the skill refuses, naming the skipped `designing` step.
+2. **Given** an orphan spec dir (spec, no node), **When** any lifecycle skill resolves
+   it, **Then** the compass verdict is `off-rail` and the skill refuses.
+3. **Given** an item whose compass verdict is `on-course`, **When** the skill runs,
+   **Then** it proceeds normally (the gate is transparent on the happy path).
+
+---
+
+### User Story 3 - Capture is fused to authoring; orphans are impossible through the front door (Priority: P1)
+
+Authoring a spec creates its roadmap node in the same move. A spec dir cannot come to
+exist (through the supported path) without a node, and an orphan spec dir is a hard
+error the compass reports — not a `reconcile` footnote.
+
+**Why this priority**: The demonstrated failure was an orphan. Closing the front door
+to orphans is the entry-half of "un-skippable."
+
+**Independent Test**: Authoring a spec through the front door yields both a spec dir
+and a roadmap node at a consistent phase; a hand-created orphan spec dir is flagged as
+a hard error by the compass and by every verb that resolves specs.
+
+**Acceptance Scenarios**:
+
+1. **Given** the spec-authoring path, **When** a new spec is created, **Then** a
+   roadmap node referencing it exists at a consistent phase in the same operation.
+2. **Given** a spec dir with no roadmap node, **When** the compass (or any
+   spec-resolving verb) runs against it, **Then** it is a hard error (not a passive
+   reconcile note).
+
+---
+
+### User Story 4 - Govern is runnable on the session-pinned branch (Priority: P1)
+
+`govern` resolves the feature from the item's recorded spec pointer / the SPECKIT
+marker, not the branch slug — so it works on the long-lived `feature/stack-control`
+branch that carries many features — and TASK-83 no longer crashes the payload
+assembler. The back-half gate the compass enforces is therefore satisfiable.
+
+**Why this priority**: A gate cannot enforce a step that cannot run. Today
+`govern --mode implement` FATALs "feature not found" on this branch, and even with an
+explicit feature it crashes on `/stack-control:*` backtick spans. Without this, the
+`governing → shipped` gate would block all work instead of enforcing the step.
+
+**Independent Test**: On the session-pinned branch, `govern` for an item resolves its
+feature from the spec pointer / SPECKIT marker (no branch-slug FATAL) and assembles a
+payload without misreading a backtick skill-reference span as a governed path.
+
+**Acceptance Scenarios**:
+
+1. **Given** the session-pinned branch and an item with a `spec:` pointer, **When**
+   govern runs for that item, **Then** it resolves the feature without a branch-slug
+   "feature not found" FATAL.
+2. **Given** a spec/tasks doc containing a `` `/stack-control:define` `` backtick span,
+   **When** govern assembles the payload, **Then** the span is not treated as a
+   governed filesystem path (no "escapes the installation root" FATAL).
+
+---
+
+### User Story 5 - Gates are refusals, not reports (Priority: P2)
+
+The 022 v1 report-only posture (FR-010) is retired where enforcement applies: the
+compass verdict is enforced by the embedding skills, and the workflow's own
+`advance`/transition path refuses on an unmet gate rather than only reporting it.
+
+**Why this priority**: The teeth. Report-only is why skipping was free. P2 because the
+compass + skill embedding (US1/US2) already deliver enforcement at the skill surface;
+this story extends it into the engine's own advance path.
+
+**Independent Test**: An `advance`/transition with an unmet exit gate refuses loud
+(not merely prints the unmet criteria) on the enforced gates.
+
+**Acceptance Scenarios**:
+
+1. **Given** an item whose current-phase exit gate is unmet, **When** an enforced
+   transition is attempted, **Then** it refuses loud naming the unmet criteria.
+2. **Given** an item whose exit gate is met, **When** the transition runs, **Then** it
+   proceeds.
+
+---
+
+### User Story 6 - One canonical feature identity across compass, govern, and close-related (Priority: P2)
+
+The roadmap node, its spec dir, and govern's notion of "the feature" share **one
+canonical identity** so the compass, govern, the convergence record, and
+`close-related` all resolve the same item the same way — eliminating the
+basename-collision class (TASK-139) and the branch-slug mismatch (US4).
+
+**Why this priority**: The resolution bugs (US4) and the convergence-record collision
+(TASK-139) are the same root: three subsystems identify a feature three different ways
+(branch slug vs spec-dir basename vs node id). P2 because US4 delivers the immediate
+unblock; this story makes the identity principled rather than patched.
+
+**Independent Test**: Two items whose spec dirs share a basename do not collide on any
+identity-keyed artifact; the compass, govern, and `close-related` resolve each to its
+own item.
+
+**Acceptance Scenarios**:
+
+1. **Given** two items with distinct specs that share a spec-dir basename, **When**
+   each is governed, **Then** their convergence records do not collide.
+2. **Given** an item, **When** the compass, govern, and `close-related` resolve it,
+   **Then** all three agree on the same canonical identity.
+
+### Edge Cases
+
+- An item in a terminal side-state (`blocked`/`cancelled`/`retired`): the compass
+  reports the side-state and refuses linear advancement until inducted back.
+- A terminal `shipped` item: the compass reports it `shipped` (terminal); lifecycle
+  skills that author/advance refuse (there is no legitimate forward move).
+- An intended action the compass does not recognize (unknown intent): the compass MUST
+  fail loud (refuse) rather than guess a phase — an unrecognized action is not a
+  license to proceed. *(See FR-004 / clarification.)*
+- A lifecycle skill invoked with no item argument and no resolvable active item: the
+  compass cannot orient → the skill refuses loud, directing the agent to capture/name
+  the item.
+- The agent writes code/files directly (not via any skill): no verb embeds the compass
+  there, so the backstop is that the *finishing* skills (`ship`/`release`/
+  `session-end`) refuse without the full recorded evidence chain. *(Sufficiency of
+  this backstop is a clarification.)*
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**The compass primitive**
+
+- **FR-001**: The system MUST provide a `workflow compass <item>` orientation surface
+  that derives the item's current phase, names the single legitimate next action (the
+  phase's work skill + the next transition), and reports the current gate state —
+  read-only and deterministic.
+- **FR-002**: `workflow compass <item> --intent <action>` MUST classify the intended
+  action's phase and return a verdict against the live state: `on-course` (the
+  legitimate next move), `ahead` (the action belongs to a later phase — naming the
+  skipped step), `behind` (an earlier phase — re-entry/redundant), or `off-rail` (no
+  node / a terminal side-state).
+- **FR-003**: The verdict MUST be exposed as a process exit code (zero = proceed,
+  non-zero = refuse) so a skill body can gate on it without parsing prose.
+- **FR-004**: An intended action that the compass does not recognize MUST fail loud
+  (treated as a refusal), never silently classified as `on-course`. [NEEDS
+  CLARIFICATION: is the intent vocabulary a fixed enumeration of lifecycle
+  skill/verb names, with anything else refused — or is a free-form natural-language
+  intent accepted and mapped heuristically (advisory only)?]
+- **FR-005**: The compass MUST be read-only (writing nothing; identical output on
+  re-run with no on-disk change).
+
+**Enforcement embedding**
+
+- **FR-006**: Every lifecycle skill — at minimum `define`, `execute`, the
+  `after_implement` govern hook, `ship`, `release`, `session-end` — MUST open by
+  consulting the compass for its item with its own action as `--intent`, and MUST
+  refuse loud (performing none of its work) on a non-zero verdict, naming the violated
+  invariant.
+- **FR-007**: The lifecycle rules the compass enforces MUST live in exactly one place
+  (the compass + the governed `WORKFLOW.md`), not be re-encoded per skill.
+
+**Capture fusion (no orphans)**
+
+- **FR-008**: Authoring a new spec through the supported path MUST create the
+  corresponding roadmap node in the same operation; a spec dir MUST NOT be producible
+  through that path without a node.
+- **FR-009**: An orphan spec dir (a spec with no roadmap node) MUST be a hard error
+  reported by the compass and by every verb that resolves specs — not a passive
+  reconcile note.
+
+**Gates are refusals**
+
+- **FR-010**: The workflow's enforced gates MUST be refusals, not reports — retiring
+  the 022 v1 report-only posture where enforcement applies. [NEEDS CLARIFICATION:
+  is the report-only retirement global (all gates refuse) or phased (enforce the
+  entry gate + the back-half `governing → shipped` gate first; keep mid-pipeline
+  gates advisory during migration)?]
+
+**Govern runnable (prerequisite)**
+
+- **FR-011**: `govern` MUST resolve the feature from the item's recorded spec pointer
+  / the CLAUDE.md SPECKIT marker (not the branch slug), so it runs on the session-
+  pinned branch without a "feature not found" FATAL.
+- **FR-012**: The govern payload assembler MUST NOT misread a backtick code-span (e.g.
+  `` `/stack-control:define` ``) as a governed filesystem path (TASK-83); a
+  skill-reference span MUST NOT crash payload assembly.
+
+**Canonical identity**
+
+- **FR-013**: The roadmap node, its spec dir, and govern's feature notion MUST share
+  one canonical feature identity that the compass, govern, the convergence record, and
+  `close-related` all resolve through — eliminating the basename-collision class
+  (TASK-139) and the branch-slug mismatch.
+
+**Honest boundary**
+
+- **FR-014**: The system MUST NOT claim to prevent a deliberate human bypass (raw
+  `git`/`gh`); documentation MUST record that enforcement binds the agent (which
+  follows its skills), not a human with direct tooling.
+
+**Scope / sequencing**
+
+- **FR-015**: [NEEDS CLARIFICATION: do the govern-runnability fixes (FR-011/FR-012)
+  and the canonical-identity change (FR-013) ship as prerequisite features *ahead* of
+  the compass + embedding, or are they folded into this single spec's implementation?
+  They block enforceability of the back-half gate, so they must land no later than the
+  enforcement that depends on them.]
+
+### Key Entities
+
+- **Compass verdict**: the classification of an intended action against an item's live
+  phase — `on-course` | `ahead` | `behind` | `off-rail` — plus the named skipped step
+  (when `ahead`) and a gating exit code.
+- **Intent**: the action an agent declares it is about to take, mapped to the lifecycle
+  phase that action belongs to.
+- **Lifecycle skill precondition**: the embedded compass consultation that gates a
+  skill's execution.
+- **Canonical feature identity**: the single key the roadmap node, spec dir, govern,
+  convergence record, and `close-related` all resolve a feature through.
+- **Orphan spec dir**: a spec with no roadmap node — a hard error, not a passive note.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: For every fixture (item state × intended action), the compass returns
+  exactly one verdict, deterministically, with a matching exit code — 100% of cases;
+  a skip (`ahead`) always names the jumped step.
+- **SC-002**: An agent that follows the lifecycle skills cannot reach a later phase
+  without the prior phase's recorded evidence — every embedded-skill fixture refuses
+  an off-rail/ahead action and proceeds only on-course (no skill performs work on a
+  non-zero verdict).
+- **SC-003**: No spec dir can be produced through the supported authoring path without
+  a roadmap node; an orphan spec dir is a hard error in 100% of resolving-verb fixtures.
+- **SC-004**: On the session-pinned branch, govern resolves a feature and assembles a
+  payload (no branch-slug FATAL, no backtick-span crash) in 100% of governed fixtures,
+  including a spec containing a `/stack-control:*` backtick span.
+- **SC-005**: Two specs sharing a spec-dir basename never collide on any
+  identity-keyed artifact (convergence record, compass resolution).
+- **SC-006**: Re-running the demonstrated failure (author a feature without capture)
+  through the lifecycle skills is refused at the first skipped step — the 023-class
+  failure is mechanically impossible for an agent following its skills.
+
+## Assumptions
+
+- **Capture everything; scope later.** Per the project's capture-don't-cut rule, this
+  spec records the full surface (compass + embedding + capture-fusion + govern
+  runnability + canonical identity + report-only retirement). Which slices ship first
+  is a later, explicit operator-driven scoping pass — surfaced as FR-015's
+  clarification, not silently cut here.
+- **Intent vocabulary default** (pending FR-004 clarification): the intent is a fixed
+  enumeration of lifecycle skill/verb names; an unknown intent refuses (fail-loud).
+- **Capture-fusion mechanics default** (pending): the spec-authoring front door
+  (`define` / `speckit-specify` path) creates the node; the node id derives from the
+  canonical feature identity (FR-013) so it round-trips with the spec dir.
+- **Legacy migration** (default applied, not a blocking clarification): the
+  orphan-is-hard-error gate applies to new work; the 21+ already-shipped nodes (now
+  reported `shipped` via the terminal-status derivation fix) are grandfathered, and
+  existing in-flight items are reconciled (flagged for backfill), not refused
+  retroactively.
+- The 022 engine (derivation, gate-eval, governed `WORKFLOW.md`, the convergence
+  record) is the substrate this composes; the compass reuses derivation + gate-eval
+  rather than reimplementing phase logic.
+- Enforcement lives in skill bodies + CLI verbs (`enforcement-lives-in-skills.md`);
+  no git-hook or CI enforcement is introduced.
+- The honest boundary (FR-014) is a documentation requirement, not a capability gap to
+  close.

--- a/plugins/stack-control/src/__tests__/terminal-closure/close-related.test.ts
+++ b/plugins/stack-control/src/__tests__/terminal-closure/close-related.test.ts
@@ -1,0 +1,108 @@
+// 023 T003 — `roadmap close-related <item>` end-to-end: terminal-gated, closes
+// EXACTLY the recorded closes:/ref: ids via the real backlog backend, dry-run by
+// default, fail-loud per id, idempotent. Drives the CLI against a real installation
+// (roadmap + real backlog store) — never mocked.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCli } from '../_run-helpers.js';
+import { createBacklogBackend, BACKLOG_DONE_STATUS } from '../../backlog/backend.js';
+import { COMMITTED_CONFIG } from '../../../tests/backlog/helpers.js';
+
+let dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs = [];
+});
+
+interface Rig {
+  readonly root: string;
+  readonly backend: ReturnType<typeof createBacklogBackend>;
+  statusOf(id: string): string | undefined;
+}
+
+/** A fresh installation: .stack-control/config.yaml + a real backlog store. */
+function rig(): Rig {
+  const root = mkdtempSync(join(tmpdir(), 'close-rel-'));
+  dirs.push(root);
+  mkdirSync(join(root, '.stack-control', 'backlog'), { recursive: true });
+  writeFileSync(join(root, '.stack-control', 'config.yaml'), 'version: 1\n', 'utf8');
+  copyFileSync(COMMITTED_CONFIG, join(root, '.stack-control', 'backlog', 'config.yml'));
+  const backend = createBacklogBackend({ cwd: join(root, '.stack-control') });
+  return {
+    root,
+    backend,
+    statusOf: (id) => backend.list().find((i) => i.id === id)?.status,
+  };
+}
+
+function writeRoadmap(root: string, nodes: string): void {
+  writeFileSync(join(root, 'ROADMAP.md'), `---\ndoc-grammar: roadmap\n---\n\n# Roadmap\n\n${nodes}`, 'utf8');
+}
+
+describe('023 roadmap close-related', () => {
+  it('--apply closes exactly the recorded closes: ∪ ref: ids, and is idempotent', () => {
+    const r = rig();
+    const a = r.backend.create({ title: 'resolved A', labels: ['type:gap'] });
+    const b = r.backend.create({ title: 'resolved B', labels: ['type:gap'] });
+    const c = r.backend.create({ title: 'originating C', labels: ['type:gap'] });
+    const bystander = r.backend.create({ title: 'unrelated', labels: ['type:gap'] });
+    writeRoadmap(
+      r.root,
+      `## multi:feature/x\n\n- status: shipped\n- closes: ${a}, ${b}\n- ref: ${c}\n\nscope.\n`,
+    );
+
+    const apply = runCli(['roadmap', 'close-related', 'multi:feature/x', '--apply'], { cwd: r.root });
+    expect(apply.status).toBe(0);
+    expect(r.statusOf(a)).toBe(BACKLOG_DONE_STATUS);
+    expect(r.statusOf(b)).toBe(BACKLOG_DONE_STATUS);
+    expect(r.statusOf(c)).toBe(BACKLOG_DONE_STATUS); // the ref: id too
+    expect(r.statusOf(bystander)).not.toBe(BACKLOG_DONE_STATUS); // never touched
+
+    // Idempotent — re-running closes nothing new, reports already-closed.
+    const again = runCli(['roadmap', 'close-related', 'multi:feature/x', '--apply'], { cwd: r.root });
+    expect(again.status).toBe(0);
+    expect(again.stdout).toMatch(/already closed/);
+  });
+
+  it('dry-run lists the would-close ids and writes nothing', () => {
+    const r = rig();
+    const a = r.backend.create({ title: 'A', labels: ['type:gap'] });
+    writeRoadmap(r.root, `## multi:feature/x\n\n- status: shipped\n- closes: ${a}\n\nscope.\n`);
+    const dry = runCli(['roadmap', 'close-related', 'multi:feature/x'], { cwd: r.root });
+    expect(dry.status).toBe(0);
+    expect(dry.stdout).toMatch(/dry-run/);
+    expect(dry.stdout).toContain(a);
+    expect(r.statusOf(a)).not.toBe(BACKLOG_DONE_STATUS); // unchanged
+  });
+
+  it('refuses loud on a non-terminal item (FR-002)', () => {
+    const r = rig();
+    const a = r.backend.create({ title: 'A', labels: ['type:gap'] });
+    writeRoadmap(r.root, `## multi:feature/x\n\n- status: planned\n- closes: ${a}\n\nscope.\n`);
+    const res = runCli(['roadmap', 'close-related', 'multi:feature/x', '--apply'], { cwd: r.root });
+    expect(res.status).toBe(2);
+    expect(`${res.stderr}`).toMatch(/not a terminal status/);
+    expect(r.statusOf(a)).not.toBe(BACKLOG_DONE_STATUS); // nothing closed
+  });
+
+  it('fails loud on an unknown recorded id, closing nothing (FR-006 — no fabricated success)', () => {
+    const r = rig();
+    const a = r.backend.create({ title: 'real', labels: ['type:gap'] });
+    writeRoadmap(r.root, `## multi:feature/x\n\n- status: shipped\n- closes: ${a}, TASK-999999\n\nscope.\n`);
+    const res = runCli(['roadmap', 'close-related', 'multi:feature/x', '--apply'], { cwd: r.root });
+    expect(res.status).toBe(1);
+    expect(`${res.stderr}`).toMatch(/unknown backlog id/);
+    expect(r.statusOf(a)).not.toBe(BACKLOG_DONE_STATUS); // pre-flight refusal — nothing closed
+  });
+
+  it('reports nothing to close when no closes:/ref: is recorded', () => {
+    const r = rig();
+    writeRoadmap(r.root, `## multi:feature/x\n\n- status: shipped\n\nscope.\n`);
+    const res = runCli(['roadmap', 'close-related', 'multi:feature/x', '--apply'], { cwd: r.root });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/no recorded resolved items/);
+  });
+});

--- a/plugins/stack-control/src/__tests__/terminal-closure/units.test.ts
+++ b/plugins/stack-control/src/__tests__/terminal-closure/units.test.ts
@@ -1,0 +1,56 @@
+// 023 terminal-closure — unit coverage for the `closes:` node field (T001) and
+// the backend `close(id)` operation (T002). The backend tests drive the REAL
+// backlog binary against an isolated tmp project (never mocked — testing.md).
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadRoadmap } from '../../roadmap/roadmap-model.js';
+import { BUILTIN_GRAMMAR_DIR } from '../../subcommands/document-verb-shared.js';
+import { BacklogError, BACKLOG_DONE_STATUS, createBacklogBackend } from '../../backlog/backend.js';
+import { tmpBacklog } from '../../../tests/backlog/helpers.js';
+
+let dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs = [];
+});
+
+describe('023 T001 — the closes: node field', () => {
+  it('projects a comma-list of backlog ids onto WorkItem.closes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'closes-'));
+    dirs.push(root);
+    const doc = [
+      '---', 'doc-grammar: roadmap', '---', '', '# Roadmap', '',
+      '## multi:feature/x', '', '- status: shipped', '- closes: TASK-A, TASK-B, TASK-C', '- ref: TASK-D', '',
+      'scope.', '',
+      '## multi:feature/y', '', '- status: planned', '', 'no closes here.', '',
+    ].join('\n');
+    const path = join(root, 'ROADMAP.md');
+    writeFileSync(path, doc, 'utf8');
+    const model = loadRoadmap(path, { builtinGrammarDir: BUILTIN_GRAMMAR_DIR });
+    expect(model.byId.get('multi:feature/x')!.closes).toEqual(['TASK-A', 'TASK-B', 'TASK-C']);
+    expect(model.byId.get('multi:feature/x')!.ref).toBe('TASK-D');
+    expect(model.byId.get('multi:feature/y')!.closes).toEqual([]); // absent → empty
+  });
+});
+
+describe('023 T002 — backend close(id) (real binary)', () => {
+  it('sets an item status to Done and fails loud on an unknown id', () => {
+    const root = tmpBacklog();
+    dirs.push(root);
+    const backend = createBacklogBackend({ cwd: root });
+    const id = backend.create({ title: 'closable', labels: ['type:gap'] });
+    expect(backend.list().find((i) => i.id === id)!.status).not.toBe(BACKLOG_DONE_STATUS);
+
+    backend.close(id);
+    expect(backend.list().find((i) => i.id === id)!.status).toBe(BACKLOG_DONE_STATUS);
+
+    // Idempotent: closing an already-Done item is not an error.
+    expect(() => backend.close(id)).not.toThrow();
+
+    // Unknown id fails loud — never a silent no-op.
+    expect(() => backend.close('TASK-999999')).toThrow(BacklogError);
+  });
+});

--- a/plugins/stack-control/src/backlog/backend.ts
+++ b/plugins/stack-control/src/backlog/backend.ts
@@ -62,7 +62,14 @@ export interface BacklogBackend {
   /** Additively edit an existing item (add a label / append notes). Shells the
    * real binary; a non-zero exit (e.g. unknown id) throws BacklogError (D6). */
   edit(id: string, spec: EditSpec): void;
+  /** Close an item by setting its status to the terminal `Done` (023 FR-007).
+   * Shells the real binary; a non-zero exit (e.g. unknown id) throws BacklogError —
+   * never a silent no-op, never a fabricated success. */
+  close(id: string): void;
 }
+
+/** The terminal backlog status an item is moved to on closure. */
+export const BACKLOG_DONE_STATUS = 'Done';
 
 export interface BacklogBackendOptions {
   /** Working dir whose `backlog/` tree the binary operates on. */
@@ -262,6 +269,13 @@ export function createBacklogBackend(opts: BacklogBackendOptions): BacklogBacken
       if (spec.appendNotes !== undefined) args.push('--append-notes', spec.appendNotes);
       args.push('--plain');
       run(args); // non-zero (e.g. unknown id) → BacklogError, never a silent no-op
+    },
+
+    close(id: string): void {
+      // Set status to the terminal `Done` via the real binary. A non-zero exit
+      // (unknown id, backend error) throws BacklogError — the caller never reports
+      // a close it did not perform (023 FR-006/FR-007).
+      run(['task', 'edit', id, '-s', BACKLOG_DONE_STATUS, '--plain']);
     },
   };
 }

--- a/plugins/stack-control/src/roadmap/roadmap-model.ts
+++ b/plugins/stack-control/src/roadmap/roadmap-model.ts
@@ -29,6 +29,8 @@ export interface WorkItem {
   readonly designApproved: boolean;
   /** Recorded `speckit-analyze`-clean marker (022 FR-029) — the default `specifying → implementing` signal. */
   readonly analyzeClean: boolean;
+  /** Backlog ids this item resolves; closed mechanically on terminal closure (023 FR-001). */
+  readonly closes: readonly string[];
   /** The item's shape prose (body, sans the heading and the field bullets). */
   readonly scope: string;
 }
@@ -126,6 +128,12 @@ function toWorkItem(unit: Unit): WorkItem {
   const design = firstOrNull(edgeTargets(unit, 'design'));
   const designApproved = firstOrNull(edgeTargets(unit, 'design-approved'));
   const analyzeClean = firstOrNull(edgeTargets(unit, 'analyze-clean'));
+  // `closes` is a prose edge (single raw value) carrying a comma-list of backlog ids.
+  const closesRaw = firstOrNull(edgeTargets(unit, 'closes'));
+  const closes =
+    closesRaw === null
+      ? []
+      : closesRaw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
   return {
     identifier: unit.identifier,
     phase,
@@ -139,6 +147,7 @@ function toWorkItem(unit: Unit): WorkItem {
     design: design === null ? null : unquote(design),
     designApproved: markerTrue(designApproved),
     analyzeClean: markerTrue(analyzeClean),
+    closes,
     scope: scopeOf(unit),
   };
 }

--- a/plugins/stack-control/src/subcommands/roadmap.ts
+++ b/plugins/stack-control/src/subcommands/roadmap.ts
@@ -24,6 +24,8 @@ import {
 } from '../roadmap/mutations.js';
 import { globParent, reconcile } from '../roadmap/reconcile.js';
 import { loadRoadmap, type RoadmapModel } from '../roadmap/roadmap-model.js';
+import { createBacklogBackend, BacklogError, BACKLOG_DONE_STATUS } from '../backlog/backend.js';
+import { backlogRoot } from '../backlog/root.js';
 import { blockedReport, mermaid, readyList } from '../roadmap/views.js';
 import {
   failUsage,
@@ -68,6 +70,7 @@ const SUBACTION_SPECS: Readonly<Record<string, SubactionGrammar>> = {
   decompose: { valueFlags: ['into'], apply: true, clear: false, positionals: 1 },
   reclassify: { valueFlags: ['to'], apply: true, clear: false, positionals: 1 },
   defer: { valueFlags: ['until'], apply: true, clear: true, positionals: 1 },
+  'close-related': { valueFlags: [], apply: true, clear: false, positionals: 1 },
 };
 
 /** The union of every subaction's value-flag names, so the scanner can reject a
@@ -219,6 +222,59 @@ function emitReconcile(flags: Flags, opts: LoadOptions): void {
   for (const u of report.unresolved) process.stdout.write(`    - ${u}\n`);
 }
 
+/**
+ * `roadmap close-related <item>` (023) — mechanical terminal closure. Closes EXACTLY
+ * the backlog ids recorded on the node (`closes:` ∪ `ref:`) when the item is in a
+ * grammar-terminal status. Never title-matches or infers; dry-run by default;
+ * fail-loud per id; idempotent (an already-`Done` item is reported, not re-closed).
+ */
+function emitCloseRelated(model: RoadmapModel, flags: Flags): void {
+  const id = requireId(flags, 'close-related');
+  const item = model.byId.get(id);
+  if (item === undefined) failUsage('roadmap', `close-related: no item '${id}'`);
+  const terminal = model.doc.grammar.terminalStatuses;
+  if (!terminal.includes(item.status)) {
+    failUsage(
+      'roadmap',
+      `close-related: '${id}' is '${item.status}', not a terminal status (${terminal.join('/')}) — ` +
+        `loose ends are tied only once an item reaches a terminal state`,
+    );
+  }
+  // The resolved set is a RECORDED fact: closes: ∪ ref:. Never inferred (023 FR-003).
+  const targets = [...new Set([...item.closes, ...(item.ref !== null ? [item.ref] : [])])];
+  if (targets.length === 0) {
+    process.stdout.write(`roadmap close-related ${id}: no recorded resolved items (closes:/ref:); nothing to close\n`);
+    return;
+  }
+
+  const backend = createBacklogBackend({ cwd: backlogRoot() });
+  const statusById = new Map(backend.list().map((it) => [it.id, it.status]));
+  // Fail loud on any unknown id BEFORE applying anything (FR-006 — never a fabricated close).
+  const unknown = targets.filter((t) => !statusById.has(t));
+  if (unknown.length > 0) {
+    throw new BacklogError(`close-related: unknown backlog id(s) ${unknown.join(', ')} (recorded on '${id}' but absent from the backlog)`);
+  }
+
+  if (!flags.apply) {
+    process.stdout.write(`roadmap close-related ${id}: dry-run — would close (use --apply):\n`);
+    for (const t of targets) {
+      const already = statusById.get(t) === BACKLOG_DONE_STATUS;
+      process.stdout.write(`  - ${t}${already ? ' (already closed)' : ''}\n`);
+    }
+    return;
+  }
+
+  process.stdout.write(`roadmap close-related ${id}: closing resolved items\n`);
+  for (const t of targets) {
+    if (statusById.get(t) === BACKLOG_DONE_STATUS) {
+      process.stdout.write(`  - ${t}: already closed (no-op)\n`);
+      continue;
+    }
+    backend.close(t); // non-zero → BacklogError, never a fabricated success
+    process.stdout.write(`  - ${t}: closed -> ${BACKLOG_DONE_STATUS}\n`);
+  }
+}
+
 export async function runRoadmapCli(args: string[]): Promise<void> {
   const subaction = args[0];
   if (subaction === undefined || subaction.startsWith('--')) {
@@ -229,7 +285,7 @@ export async function runRoadmapCli(args: string[]): Promise<void> {
   if (SUBACTION_SPECS[subaction] === undefined) {
     failUsage(
       'roadmap',
-      `unknown subaction '${subaction}' (known: next, blocked, blocks, order, graph, add, advance, decompose, reclassify, defer, reconcile)`,
+      `unknown subaction '${subaction}' (known: next, blocked, blocks, order, graph, add, advance, decompose, reclassify, defer, reconcile, close-related)`,
     );
   }
   const scanned = scanFlags(args.slice(1));
@@ -277,6 +333,9 @@ export async function runRoadmapCli(args: string[]): Promise<void> {
       case 'reconcile':
         emitReconcile(flags, opts);
         return;
+      case 'close-related':
+        emitCloseRelated(loadRoadmap(flags.doc, opts), flags);
+        return;
     }
     // Exhaustiveness backstop (AUDIT-20260610-09): the pre-dispatch guard only
     // rejects subactions ABSENT from SUBACTION_SPECS. A subaction REGISTERED in
@@ -293,6 +352,10 @@ export async function runRoadmapCli(args: string[]): Promise<void> {
     if (err instanceof DocumentModelError) {
       process.stderr.write(`roadmap: ${err.message}\n`);
       process.exit(2);
+    }
+    if (err instanceof BacklogError) {
+      process.stderr.write(`roadmap: ${err.message}\n`);
+      process.exit(1);
     }
     throw err; // unexpected → dispatcher exits 1
   }


### PR DESCRIPTION
## Mechanical terminal closure of resolved backlog items (spec 023)

When a roadmap item reaches a terminal state, the backlog items it *resolved*
should close in **one deterministic move** — no agent discretion, no title-matching,
no fabricated closes, no flurry of "should I / how should I" questions. This builds
that mechanism. (Follows the dogfood that closed #477/#478 and left TASK-136/TASK-19
needing a non-manual way to close.)

### The mechanism — `stackctl roadmap close-related <item> [--apply]`

1. **Terminal-gated** — refuses loud unless `<item>`'s status is grammar-terminal
   (`shipped`/`cancelled`/`retired`). Loose ends are tied only once work is done.
2. **Explicit links only (the anti-fuckup core)** — closes EXACTLY the ids recorded
   on the node: `closes:` (a new comma-list field) ∪ `ref:`. It never title-matches,
   greps, or infers "related." Not in `closes:`/`ref:` → not touched.
3. **Resolves ≠ found-during** — bugs/gaps discovered while building a feature are
   not in `closes:`, so unfinished work stays open by construction.
4. **Dry-run first** — default lists exactly what would close; `--apply` closes via
   the configured backlog backend (`task edit <id> -s Done`). Idempotent.
5. **No fabrication** — pre-flight fails loud on any unknown id (closing nothing);
   the verb never reports a close it didn't perform.

### What's in it

- `closes:` roadmap node field (grammar edgeField + `WorkItem.closes[]`).
- `BacklogBackend.close(id)` → terminal `Done`, fail-loud on non-zero exit.
- `roadmap close-related` verb (terminal gate, exact-set, dry-run/`--apply`,
  idempotent, pre-flight unknown-id refusal).
- spec + tasks under `specs/023-terminal-closure`.

### Testing + first use in anger

- Umbrella: **247 files / 1632 tests green** — 7 new (closes-field projection,
  backend `close`, and 5 `close-related` CLI scenarios driven against the **real**
  backlog binary: exact-set, dry-run, terminal refusal, unknown-id fail-loud, empty).
- First use in anger: recorded `closes: TASK-19` on the shipped 022 node and ran
  `close-related --apply` — it closed exactly TASK-19 + TASK-136 (both delivered &
  verified in v0.48.1); TASK-83/130/138/139/140/141 stayed open by construction.
