### PR TITLE
govern-030-hardening: point-fix burndown + seam-pass reframing

### DIFF
--- a/plugins/stack-control/.claude/rules/audit-barrage-is-stochastic-defense-in-depth.md
+++ b/plugins/stack-control/.claude/rules/audit-barrage-is-stochastic-defense-in-depth.md
@@ -1,0 +1,40 @@
+# The audit-barrage is STOCHASTIC defense-in-depth — deterministic concerns belong to the compiler/test floor
+
+The governance mechanism (the cross-model audit-barrage) aims for **stochastic correctness, not deterministic correctness**. It is a layer of **defense in depth** that sits ON TOP of two deterministic layers — a **compiler** and **high-coverage tests** — and exists to catch what those layers structurally cannot. Putting a deterministic concern *into* the stochastic layer is a layer confusion and produces strictly-worse results than the layer that already owns it.
+
+## The layer model (internalize this)
+
+| Layer | Kind | Owns |
+|---|---|---|
+| **Compiler** (`tsc --noEmit`, etc.) | deterministic | interface contracts: removed/renamed exports, changed signatures/arity, changed required shapes — across the WHOLE program, including breaks in files this change did not touch |
+| **High-coverage tests** | deterministic | behavioral regressions — does the code still do what it must |
+| **Audit-barrage** (cross-model review) | **stochastic** | what types and tests CANNOT express: logic that compiles and passes but is wrong, design smells, missing cases, contradictions, prose defects. Its value is *genetic diversity of failure modes*, not re-deriving decidable facts. |
+
+The compiler and tests are the **floor** the barrage stands on. The barrage's job is the open-ended, non-decidable layer — precisely the part where a single deterministic check can't give you confidence and you want N independent stochastic perspectives instead.
+
+## The rule
+
+1. **Never put a deterministic, decidable check into the audit-barrage layer.** If a question has a closed, computable answer (does it type-check? does this test pass? does this export still resolve?), it belongs to the compiler or the test suite — NOT a heuristic inside the barrage. The barrage is for questions that do *not* reduce to a deterministic check.
+
+2. **Interface contracts are the compiler's job.** A removed/renamed export, a changed required signature/arity, or a changed required shape is a *compile error* in a typed language — caught completely, across the whole program (so a break in an UNCHANGED consumer is caught too), with zero false positives. Do not reimplement any slice of this as a regex/heuristic in the governance layer. A diff-scoped heuristic is strictly weaker than whole-program type checking: it carries both false positives and false negatives the compiler does not.
+
+3. **The deterministic floor is a precondition, not a peer.** A green typecheck + test run should be the floor a graduation decision stands on. The stochastic barrage adds defense in depth on top of a green floor; it is not a substitute for compiling or testing, and it must not be asked to *approximate* them.
+
+4. **For compiler-less material, the heuristic is a FALLBACK, not the default.** Untyped Python, shell, markdown, etc. have no compiler floor. A diff-level interface heuristic can earn its keep there as a best-effort fallback — but it is explicitly a fallback for the no-compiler case, never the mechanism you reach for when a compiler exists.
+
+## How to apply
+
+- **Before adding any check to the governance/barrage layer, ask: is this question decidable by a compiler or a test?** If yes, it does not belong in the barrage — wire the compiler/test as the floor instead.
+- **When a barrage finding is something a compiler would have caught** (a "this export is gone / this signature changed" class), treat it as evidence the deterministic floor is missing or not gating — fix the floor, don't harden the heuristic.
+- **When tempted to make a diff-scoped checker "smarter"** (read more files, track more cases) to catch a contract break, stop: that is the compiler's job done worse. Add/strengthen the compiler gate instead.
+
+## Anti-patterns to refuse
+
+- A regex/heuristic in the governance layer that reimplements type-checking, name-resolution, or signature-compatibility (the **seam pass** is the canonical example — see `multi:gap/retire-seam-pass-interface-check`).
+- Treating the audit-barrage as a deterministic gate ("it found 0 interface breaks, so the interfaces are safe") — it is stochastic; deterministic safety comes from the compiler/test floor.
+- Building a feature to close a "gap" in a heuristic checker when the gap only exists because the heuristic looks at a diff instead of the whole program — the compiler has no such gap. (This is exactly why the seam "unchanged-consumer" feature was NOT built; the reframing dissolved it.)
+- Asking the barrage to compensate for an absent compile/test gate.
+
+## Why this rule exists
+
+Written 2026-06-22. Mid-burndown of `multi:feature/govern-030-hardening`, the agent had hardened the cross-chunk **seam pass** (a regex-over-diff interface checker) and proposed building an "unchanged-consumer detection" feature to close its false-negative gap. The operator pointed out this is what a compiler does in a typed language — and that the seam pass had confused the layers: it put a deterministic interface-contract concern into the stochastic barrage. The operator's framing, verbatim: *"the governance mechanism of the audit barrage aims for stochastic correctness, not deterministic correctness. It is a layer of defense in depth supported by high-coverage testing and a compiler."* Under that reframing the seam pass's interface-check collapses to redundancy (the compiler dominates it) and the "gap" vanishes by construction. This rule records the layer model so future agents don't re-confuse the stochastic layer with the deterministic floor. Cross-ref: thesis (*"stochastic correctness (cross-model audit-barrage) as the teeth"*), `stack-control-thesis.md`; roadmap node `multi:gap/retire-seam-pass-interface-check`.

--- a/plugins/stack-control/DEVELOPMENT-NOTES.md
+++ b/plugins/stack-control/DEVELOPMENT-NOTES.md
@@ -2,21 +2,24 @@
 
 ---
 
-## 2026-06-22: <!-- session title -->
+## 2026-06-22 (late): bookkeeping-hardening verified in v0.53.1 + umbrella shipped (paperwork close-out)
 
-**Goal:** <!-- compose: what we set out to do -->
+**Goal:** Operator released v0.53.1 (containing this session's bookkeeping-hardening work) and asked to validate the installed release and close out the relevant paperwork. A short close-out tail after the main session + the first session-end.
 
 **Accomplished:**
-- <!-- compose -->
+- **Validated the 6 fixes against the formally-installed v0.53.1 release** (bare `stackctl` = cache, the adopter surface): `audit-runs list|prune` ships and works (296 dirs / 115.6 MB; prune would free 96.8 MB; mutual-exclusion guard exits 2); `backlog done` persists `Closed: <reason>` to the task notes on disk (self-demonstrating — TASK-297's own closure note is present); session-end's journal anchor surfaced 9 progressed items (the TASK-39 bug reported 0); `check-front-door` = 64 ops OK. This satisfies the issue-closure discipline (verified in a formally-installed release), so the 13 closures are now release-backed.
+- **Advanced the umbrella roadmap node** `multi:feature/bookkeeping-hardening` `planned → shipped`; `roadmap reconcile` clean (0 drift / 0 orphan / 0 unresolved).
 
 **Didn't Work:**
-- <!-- compose -->
+- Nothing this increment.
 
 **Course Corrections:**
-- <!-- compose -->
+- None. Straight validate-then-close-out, as asked.
 
 **Insights:**
-- <!-- compose -->
+- **The release closed the discipline loop the "close all 13 now" call had left open.** Closing the backlog items mid-session rested on commits + tests; v0.53.1 then made them genuinely *release-verified* — the proper bar. The paperwork (node → shipped) was honest to defer until a real install existed, then cheap to finish.
+- **Validate on the installed cache, not source.** The adopter-meaningful check is what `claude plugin install` delivers (bare `stackctl` = v0.53.1), not `./bin/stackctl` (source) — packaging is UX.
+- Noted (unrelated): `/reload-plugins` reported 1 load error; the `audit-runs` skill loaded fine, so it's not from this work — flagged for a `/doctor` look.
 
 **Quantitative (auto-derived from git; verify before publishing):**
 - Commits: 1

--- a/plugins/stack-control/DEVELOPMENT-NOTES.md
+++ b/plugins/stack-control/DEVELOPMENT-NOTES.md
@@ -2,6 +2,37 @@
 
 ---
 
+## 2026-06-22: <!-- session title -->
+
+**Goal:** <!-- compose: what we set out to do -->
+
+**Accomplished:**
+- <!-- compose -->
+
+**Didn't Work:**
+- <!-- compose -->
+
+**Course Corrections:**
+- <!-- compose -->
+
+**Insights:**
+- <!-- compose -->
+
+**Quantitative (auto-derived from git; verify before publishing):**
+- Commits: 10
+  - Merge remote-tracking branch 'origin/main' into feature/stack-control
+  - chore(backlog): close the 13 bookkeeping-hardening items; capture govern-diff friction
+  - fix(bookkeeping): address audit-barrage findings on the session diff
+  - feat(audit-runs): add `stackctl audit-runs list|prune` retention verb (TASK-425)
+  - docs(backlog): document tooling-friction routing — upstream defects go outward (TASK-16)
+  - docs(define): wire link-spec into the node-exists branch (TASK-407)
+  - fix(session-end): anchor the journal window at the previous session-end (TASK-39)
+  - fix(backlog): persist closure reason to task notes; clean up done-test tmp dirs
+  - chore: release v0.53.0
+  - Merge pull request #495 from audiocontrol-org/feature/stack-control
+- Files changed: 56
+- Backlog touched: TASK-16, TASK-23, TASK-244, TASK-297, TASK-378, TASK-39, TASK-407, TASK-425, TASK-443
+
 ## 2026-06-22 (pm): Backlog cleanup applied — 46 closed, 9 re-scoped, 6 uncertains resolved, bookkeeping umbrella created
 
 **Goal:** Act on the backlog-cleanup-review-2026-06-22.md work-list produced by the prior session (orientation menu pick #2): apply the dispositions (close the resolved/moot, re-scope the partials), then drive out the remaining uncertainty rather than leaving it parked. No code; this is records hygiene on the slush store + the roadmap DAG.

--- a/plugins/stack-control/DEVELOPMENT-NOTES.md
+++ b/plugins/stack-control/DEVELOPMENT-NOTES.md
@@ -2,24 +2,30 @@
 
 ---
 
-## 2026-06-22: <!-- session title -->
+## 2026-06-22 (evening): bookkeeping-hardening umbrella — 6 fixed + 7 verified-resolved, governed, shipped (PR #496)
 
-**Goal:** <!-- compose: what we set out to do -->
+**Goal:** Take up the `multi:feature/bookkeeping-hardening` umbrella (the 13 small gaps/bugs in stack-control's own bookkeeping tooling the prior session grouped). Per operator selection, work each as a **point fix** (RED-first TDD → commit → push, no spec/govern), all 13 by category. It expanded into: govern the session diff (operator request), close all 13, open + merge a PR, run session-end.
 
 **Accomplished:**
-- <!-- compose -->
+- **6 items genuinely fixed, RED-first:** TASK-297 (`backlog done` persists `--reason` to durable task notes), TASK-378 (done-test tmp-dir leak), TASK-39 (session-end journal window anchors at the previous session-end — robust to a pushed-up upstream that collapsed the merge-base to HEAD), TASK-407 (`/stack-control:define` node-exists branch wires `workflow link-spec`), TASK-16 (tooling-friction routing docs), TASK-425 (new `stackctl audit-runs list|prune` retention verb + skill — the barrage run dirs had grown to 295 dirs / 115 MB with no GC).
+- **7 items verified already-resolved** by the shipped 027/028 features (confirmed in source + passing tests, then closed): TASK-23/38/299 (028 backlog verbs), TASK-244 (node now has `spec:`), TASK-298 (`approve-design` marker verb), TASK-442 (uniform `--help`), TASK-21 (edge-aware archival, FR-017/T077).
+- **Governed the session diff** (operator request): fired the cross-model audit-barrage over `8602a319..HEAD` (claude + codex, 2/2 emitted). 5 findings; fixed 4 (incl. a real HIGH — a stale 1-arg `close` mock in `promote.test.ts` that tsc couldn't see because `tests/` is outside the tsc include), dismissed 1 false positive (the "empty closure note" can't occur — `backlog done` requires a non-empty `--reason`).
+- **Closed all 13 umbrella items** in the backlog with evidence reasons; **captured TASK-443** (govern is spec-coupled → barraging a non-spec diff needed hand-assembled payload).
+- **Shipped:** full suite 2472/2472, `check-front-door` 64 ops, tsc clean → opened PR #496 (brought the branch current with `main` first to avoid a v0.53.0 → 0.52.2 version regression) → merged to `main` after CI green (11m17s).
 
 **Didn't Work:**
-- <!-- compose -->
+- **`govern --mode implement` cannot run on a non-spec session diff.** It is structurally coupled to a spec feature (resolves a feature root + writes to that feature's `audit-log.md`); a multi-subsystem bookkeeping diff with no spec and no `spec:` on its umbrella node has nothing to anchor to. Realizing "govern the session diff" meant hand-assembling the audit-barrage payload (diff → 7-key vars.json → `audit-barrage-render` → `audit-barrage --prompt-file`). Captured as TASK-443.
 
 **Course Corrections:**
-- <!-- compose -->
+- **Zero rework.** The operator's turns were scope/direction decisions, not corrections: "point fixes" (framing), "did you run governance?" (a *check* — I answered honestly that I had not, per the point-fix scoping rule, and did NOT reflexively run it; the operator then chose "govern the whole session diff"), "close all 13", "capture the friction", "open a PR", "merge when green". [PROCESS] One mild note: I surfaced the closure question before the operator's governance preference was known — sequencing, not a wrong approach.
 
 **Insights:**
-- <!-- compose -->
+- **The umbrella was mostly already-resolved-but-not-closed.** 7 of 13 were implemented by the 027/028 features which never closed the backlog items they were seeded from — the exact node↔spec-linkage / closure-isn't-structural gap the umbrella names, demonstrated by the umbrella itself. The real engineering was 6 items; the rest was verify-and-close.
+- **session-end's own fix verified itself live.** Running `session-end` to record THIS session exercised the TASK-39 journal-anchor fix: it surfaced 9 progressed backlog items instead of the "0 commits / no backlog touched" the bug produced. The close ceremony that records the session is the one this session fixed.
+- **`govern` has a missing front door.** There's no first-class "audit an arbitrary/non-spec diff" entry — the cross-model barrage is only reachable through the spec-coupled `govern`. Surfaced precisely when trying to audit a bookkeeping diff that isn't a spec feature (TASK-443).
 
 **Quantitative (auto-derived from git; verify before publishing):**
-- Commits: 10
+- Commits: 10 — but only **8 are this session** (7 work commits + the `git merge origin/main`); the other 2 (`chore: release v0.53.0`, `Merge pull request #495`) entered the `8602a319..HEAD` window via that merge (done to bring the long-lived branch current with `main`), not session work.
   - Merge remote-tracking branch 'origin/main' into feature/stack-control
   - chore(backlog): close the 13 bookkeeping-hardening items; capture govern-diff friction
   - fix(bookkeeping): address audit-barrage findings on the session diff

--- a/plugins/stack-control/DEVELOPMENT-NOTES.md
+++ b/plugins/stack-control/DEVELOPMENT-NOTES.md
@@ -2,6 +2,28 @@
 
 ---
 
+## 2026-06-22: <!-- session title -->
+
+**Goal:** <!-- compose: what we set out to do -->
+
+**Accomplished:**
+- <!-- compose -->
+
+**Didn't Work:**
+- <!-- compose -->
+
+**Course Corrections:**
+- <!-- compose -->
+
+**Insights:**
+- <!-- compose -->
+
+**Quantitative (auto-derived from git; verify before publishing):**
+- Commits: 1
+  - roadmap(bookkeeping-hardening): advance umbrella to shipped — verified in v0.53.1
+- Files changed: 1
+- Backlog touched: (none)
+
 ## 2026-06-22 (evening): bookkeeping-hardening umbrella — 6 fixed + 7 verified-resolved, governed, shipped (PR #496)
 
 **Goal:** Take up the `multi:feature/bookkeeping-hardening` umbrella (the 13 small gaps/bugs in stack-control's own bookkeeping tooling the prior session grouped). Per operator selection, work each as a **point fix** (RED-first TDD → commit → push, no spec/govern), all 13 by category. It expanded into: govern the session diff (operator request), close all 13, open + merge a PR, run session-end.

--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -601,7 +601,7 @@ Folded-in roadmap gaps (now `part-of` this umbrella, defers cleared since 030 la
 - multi:gap/govern-doc-aware-audit-lens — orthogonal prose-nitpick lens
 
 ## multi:feature/bookkeeping-hardening
-- status: planned
+- status: shipped
 - part-of: multi:feature/lifecycle-industrialization
 Umbrella for the small gaps + bugs in stack-control's own bookkeeping tooling — the verbs and skills that maintain the project's records (the backlog store, the roadmap DAG curation, the session-end journal derivation, the node↔spec linkage, audit-run retention). These are defects in the EXISTING bookkeeping surface, complementary to the new mechanization features under the parent lifecycle-industrialization node. Detail lives in the backlog; this node is the work-breakdown. Surfaced + grouped during the 2026-06-22 backlog cleanup (docs/backlog-cleanup-review-2026-06-22.md).
 

--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -530,6 +530,11 @@ Lift must auto-close findings fixed in-loop. 0.52.2's FR-016 cross-run signature
 - ref: offing-ff761162
 Documentation phases ring far longer than code. A 2-task doc phase (a README + ~40 lines of seam-contract comments) took 9 cross-model rounds to converge: the auditors kept finding wording corners on forward-looking contract prose ('near-infinite phrase-more-precisely surface'), amplified by out-of-window false-HIGHs and fix-induced channel growth. The shipped severity-determinism/dampener does not stop prose nitpicking. Fix, two levers: (a) a doc/prose-aware audit lens that, when the payload is predominantly markdown prose, flags only SUBSTANTIVE doc defects (factually wrong, contradicts code, missing required content, broken example/link) and suppresses wording/phrasing/style nits; (b) implement-mode diminishing-returns plateau auto-detect that surfaces an 'override recommended' verdict (findings shifting to wording altitude / fix-induced growth / oscillation) instead of grinding. Source: offing 0.52.2 dogfood ff761162 (2026-06-21).
 
+## multi:gap/retire-seam-pass-interface-check
+- status: planned
+- part-of: multi:feature/govern-030-hardening
+The cross-chunk seam pass reimplements interface-contract checking (removed/renamed export, changed arity, changed required shape) with a regex over diff lines. For a strongly-typed backend the COMPILER already answers every one of these completely — it checks the whole program, not a diff, so it also catches a break in an UNCHANGED consumer (a removed export still called by a file this change didn't touch). The seam pass is therefore redundant where a compiler exists, and strictly weaker: it produced false "failing test" findings and carries a false-negative gap (the unchanged consumer it cannot see — the former "seam-unchanged-consumer / disk-reading" idea). This is a layer confusion — interface contracts are a DETERMINISTIC concern owned by the compiler + high-coverage-test floor, NOT the STOCHASTIC audit-barrage layer (see `.claude/rules/audit-barrage-is-stochastic-defense-in-depth.md`). Reframing: make a green typecheck + test run the deterministic floor the barrage stands on, and RETIRE the seam pass's interface-checking (or scope it to compiler-less backends — untyped Python, shell, markdown). Under this reframing the unchanged-consumer "gap" vanishes by construction, and this session's seam-pass interface hardening (multi-line signatures, function-typed params, changed-required-shape, plus surfacing seam findings) is mooted — correct given the seam pass exists, dead weight once it is retired. Supersedes the seam-unchanged-consumer bullet in the umbrella breakdown. Source: operator reframing 2026-06-22.
+
 ## multi:gap/govern-hunkblocks-uncommitted-empty
 - status: cancelled
 - deferred-until: govern-whole-feature-chunked-payload lands; govern-at-end audits committed work, so the per-phase staleness treadmill this targets is moot — re-weigh then
@@ -571,11 +576,11 @@ Make govern-at-end the DEFAULT govern direction and make it scale. Chunk the who
 - status: in-flight
 Umbrella for the 030 chunked-end-govern dogfood follow-ups + the deferred govern hardening folded in. 030 shipped (0.53.0, PR #495) via override at the diminishing-returns plateau; these are the dispositioned residuals, gathered here as the curated next epic. Detail lives in the backlog (slush); this node is the work-breakdown.
 
-Seam-pass hardening (the cross-chunk contract backstop — final gate before a converged whole-feature record):
-- TASK-426 (-07) multi-line exported function signatures missed
-- TASK-427 (-08) consumers unchanged in the diff missed (use the import/coupling graph, not diff text)
-- TASK-431 (-19) `changed-required-shape` declared in the schema but never implemented
-- TASK-438 (-30) required function-typed params treated as optional
+Seam-pass hardening (shipped this session) — NOTE: the whole seam-pass interface-check is now slated for RETIREMENT as redundant with the compiler; see `multi:gap/retire-seam-pass-interface-check`. The fixes below are correct given the seam pass exists, but become moot once it is retired:
+- TASK-426 (-07) multi-line exported function signatures missed — DONE
+- seam-unchanged-consumer (was TASK-427 / -08): consumers unchanged in the diff are invisible to the seam pass → REFRAMED. The compiler already catches unchanged consumers; do NOT build disk-reading into the seam pass. Superseded by `multi:gap/retire-seam-pass-interface-check`.
+- TASK-431 (-19) `changed-required-shape` never implemented — DONE
+- TASK-438 (-30) required function-typed params treated as optional — DONE
 
 Govern pipeline correctness / edges:
 - TASK-435 (-27) default diff base falls back to HEAD~1 when only origin/main exists

--- a/plugins/stack-control/specs/015-audit-protocol-convergence/contracts/incremental-audit.md
+++ b/plugins/stack-control/specs/015-audit-protocol-convergence/contracts/incremental-audit.md
@@ -1,5 +1,11 @@
 # Contract: Incremental per-phase audit unit + payload exclusion (threads 3/4; FR-006/007/008/009)
 
+> **STATUS — SUPERSEDED (specs/030 clean break; TASK-128).** This contract describes the **per-phase** audit model. It no longer matches the code:
+> - **021** removed the inclusion-based `resolveComposingFeatureUnit` (the FR-008 composing-unit primitive) — whole-feature composition moved to exclusion-based scoping in `subcommands/govern.ts` (`resolveImplementExclusion` + `filterDiffScope`).
+> - **030** then **retired the per-phase audit model entirely**: `incremental-audit.ts`, `payload-implement.ts`, `resolvePhaseUnit`, and `resolveComposingFeatureUnit` are deleted. Implement-mode govern audits the **whole committed `governedSha`..HEAD diff**, chunked by coupling into envelope-sized chunks (specs/030 `end-govern-pipeline.ts`), and rejects `--phase` / `--checkpoint` (no per-phase path exists). The `## Phase N:` colon-only header grammar described below was also superseded by the 021 digit-led colon/dash/em-dash/bare grammar before the per-phase model itself was retired.
+>
+> Retained as the historical 015/021 design record. For the current model see [specs/030-chunked-end-govern/spec.md](../../030-chunked-end-govern/spec.md) and [contracts/govern-cli.md](../../030-chunked-end-govern/contracts/govern-cli.md).
+
 Shrinks the audit unit from whole-feature to a completed tasks.md phase, and removes the self-referential generator from the rendered payload.
 
 ## `incremental-audit.ts` — unit resolution (D6; FR-007)

--- a/plugins/stack-control/specs/030-chunked-end-govern/contracts/fix-fanout.md
+++ b/plugins/stack-control/specs/030-chunked-end-govern/contracts/fix-fanout.md
@@ -1,5 +1,7 @@
 # Contract: fix-fanout (parallel worktree-isolated fix dispatch)
 
+> **STATUS — DEFERRED (TASK-424).** The autonomous worktree fix-fanout (FR-009) is **not wired**: the end-govern runtime omits `applyFixes` (operator decision 2026-06-22), so the pipeline surfaces `override-eligible` and the **agent-in-the-loop** fixes the findings and re-governs. This contract is the captured design for the deferred backend; the `makeFixFanout` builder + `dispatchFixSubagents`/`mergeFixWorktrees` primitives exist and are tested, but no runtime path injects them yet. Wiring is tracked as **TASK-424**.
+
 Applies findings grouped by chunk via worktree-isolated fix-subagents in parallel, merges back to the feature branch, and surfaces what it cannot resolve. Autonomous (apply + commit), capability-not-vendor (Principle IX), fail-loud (Principle V).
 
 ## Input

--- a/plugins/stack-control/specs/030-chunked-end-govern/contracts/govern-cli.md
+++ b/plugins/stack-control/specs/030-chunked-end-govern/contracts/govern-cli.md
@@ -19,7 +19,7 @@ End-govern resolves the feature base anchor, audits the whole committed diff in 
 | `--at <dir>` | KEPT | the installation anchor (FR-010 invariant; default = nearest-enclosing). |
 | `--override <reason>` | KEPT | the 029 US4 short-circuit graduation with an attributable reason (a blank reason fails loud). |
 | `--phase <id>` | **REMOVED** | passing it is an **unknown-flag usage error** — clean break, no legacy accept (FR-017, US2 Scenario 1). |
-| `--checkpoint` / `GOVERN_CHECKPOINT` | **REMOVED** | unknown flag / ignored-then-error var — no per-phase checkpoint path exists (FR-017, TASK-125). |
+| `--checkpoint` / `GOVERN_CHECKPOINT` | **REMOVED (implement mode)** | rejected loud (FATAL) in implement mode — no per-phase checkpoint path exists (FR-017, TASK-125). SPEC mode retains the `--checkpoint` label as a legitimate spec-governance input (FR-029), so the tokens still appear in `src/`. |
 
 ## Base anchor resolution (FR-001)
 
@@ -44,7 +44,7 @@ The run **never** terminates with `boundary-too-large` (FR-002 — that terminal
 
 ## Invariants (testable)
 
-- Invoking `--phase` or setting `GOVERN_CHECKPOINT` is a clean usage error (no silent accept) — US2 Scenario 1.
+- In implement mode, invoking `--phase` or setting `GOVERN_CHECKPOINT` / `--checkpoint` is a clean usage error (no silent accept) — US2 Scenario 1. (Spec mode keeps `--checkpoint`, FR-029.)
 - No `phase-checkpoints/*.json` is written by any path — US2 Scenario 3.
 - A feature of any committed-diff size reaches a graduation decision (never `boundary-too-large`) — US1 / SC-001.
 - The graduate gate consults only the whole-feature convergence record — US2 Scenario 2.

--- a/plugins/stack-control/specs/030-chunked-end-govern/quickstart.md
+++ b/plugins/stack-control/specs/030-chunked-end-govern/quickstart.md
@@ -52,14 +52,14 @@ stackctl govern --mode implement --at <fixture-installation>
 **Run / grep.**
 ```
 stackctl govern --mode implement --phase 2 --at <fixture>      # expect: unknown-flag usage error
-GOVERN_CHECKPOINT=x stackctl govern --mode implement --at <fixture>   # expect: unknown var (no silent accept)
-grep -rn "allPhaseCheckpointsCurrent\|all-phase-checkpoints-current\|phase-checkpoints\|GOVERN_CHECKPOINT\|--checkpoint" src/   # expect: zero hits
+GOVERN_CHECKPOINT=x stackctl govern --mode implement --at <fixture>   # expect: implement-mode FATAL (no silent accept)
+grep -rn "allPhaseCheckpointsCurrent" src/ | grep -v __tests__   # expect: zero hits (deleted; clean-break-absence.test.ts asserts it stays gone)
 ```
 
 **Expect.**
-- `--phase` / `GOVERN_CHECKPOINT` are clean usage errors, not legacy-accepted (FR-017, [govern-cli.md](./contracts/govern-cli.md)).
-- The grep returns **zero** per-phase-surface hits (SC-002 = 0 remaining surfaces).
-- No `phase-checkpoints/*.json` is written by any govern run (US2 Scenario 3).
+- In **implement mode**, `--phase` and `GOVERN_CHECKPOINT` / `--checkpoint` are clean usage errors, not legacy-accepted (FR-017, [govern-cli.md](./contracts/govern-cli.md)).
+- The live per-phase checkpoint criterion (`allPhaseCheckpointsCurrent`) is gone — the grep returns **zero** hits (SC-002 = 0 remaining live per-phase criterion). NOTE: `--checkpoint` / `GOVERN_CHECKPOINT` / `phase-checkpoints` themselves are **not** zero in `src/` and must not be — SPEC mode retains the `--checkpoint` label (FR-029), implement mode rejects them with a loud FATAL, and `phase-checkpoints` survives only as a payload-exclusion path string. Grepping those tokens for zero hits is the drift TASK-433 corrected.
+- No `phase-checkpoints/*.json` is **written** by any govern run (US2 Scenario 3).
 - The graduate gate passes on the whole-feature record alone ([graduate-gate.md](./contracts/graduate-gate.md), US2 Scenario 2).
 
 ---

--- a/plugins/stack-control/specs/030-chunked-end-govern/spec.md
+++ b/plugins/stack-control/specs/030-chunked-end-govern/spec.md
@@ -24,7 +24,7 @@ The actors are the **operator** (runs `govern` / `execute` and owns graduation) 
 
 ### Session 2026-06-21
 
-- Q: When the chunked audit finds issues, does govern apply+commit fixes itself or propose them? → A: **Autonomous apply + commit** — fix-fanout applies fixes in worktrees, commits to the feature branch, and re-audits unattended; only fix-subagent failures and unresolvable merges surface to the operator.
+- Q: When the chunked audit finds issues, does govern apply+commit fixes itself or propose them? → A: **Autonomous apply + commit** — fix-fanout applies fixes in worktrees, commits to the feature branch, and re-audits unattended; only fix-subagent failures and unresolvable merges surface to the operator. *(Superseded 2026-06-22: the autonomous fix-fanout is DEFERRED — `applyFixes` is unwired, the pipeline surfaces `override-eligible` and the agent-in-the-loop fixes + re-governs. Wiring tracked as TASK-424; US5 is the captured design.)*
 - Q: How is the feature-base anchor for the `governedSha`..HEAD diff determined? → A: **Reuse the 029 US5 `governedSha` anchor** resolved at feature start; an explicit `--diff-base` overrides.
 - Q: What backstops termination if a coupling cycle keeps the touched set from shrinking? → A: **Hard max-round cap as a backstop** — the shrinking touched-set + dampener is the norm; on hitting the cap, STOP and surface for operator override (never loop forever).
 - Q: What does the seam pass count as a substantive contract break (vs a compatible change it must not flag)? → A: **Cross-boundary breakage only** — removed/renamed exported symbol, changed arity, or changed required shape consumed across a chunk boundary; ignore compatible additions and internal-only changes.
@@ -106,7 +106,9 @@ After the chunked audit produces findings and they are fixed, only the chunks wh
 
 ---
 
-### User Story 5 - Industrialized parallel fix (Priority: P2)
+### User Story 5 - Industrialized parallel fix (Priority: P2) — DEFERRED (TASK-424)
+
+> **DEFERRED.** The autonomous worktree fix-fanout is not wired: the end-govern runtime omits `applyFixes` (operator decision 2026-06-22), so the pipeline surfaces `override-eligible` and the agent-in-the-loop fixes + re-governs. The `makeFixFanout` builder and its primitives exist and are tested; no runtime path injects them yet. Wiring is tracked as TASK-424. The story below is the captured design.
 
 Findings are grouped by chunk and fixed by worktree-isolated fix-subagents running in parallel under a concurrency cap; results merge back to the feature branch. A conflicting pair serializes; an unresolvable merge surfaces to the operator. A fix-subagent failure isolates that chunk and the run continues, surfacing the failure at reconcile. A lane outage degrades that round per existing behavior.
 
@@ -216,7 +218,7 @@ The implement-mode `govern` CLI **drives `end-govern-pipeline.runEndGovern`** as
 **Audit, fix, convergence**
 
 - **FR-008**: Govern MUST audit chunks in parallel (chunks × lanes) under a concurrency cap bounded by fleet negotiation.
-- **FR-009**: Govern MUST fix findings grouped by chunk via worktree-isolated fix-subagents running in parallel under a configurable concurrency cap, then merge results to the feature branch. Fixing is **autonomous**: govern applies AND commits the fixes unattended (no propose-only / operator-applies step); only fix-subagent failures (FR-011) and unresolvable merges (FR-010) surface to the operator.
+- **FR-009** *(DEFERRED — TASK-424)*: Govern fixes findings grouped by chunk via worktree-isolated fix-subagents running in parallel under a configurable concurrency cap, then merges results to the feature branch. Fixing is **autonomous**: govern applies AND commits the fixes unattended (no propose-only / operator-applies step); only fix-subagent failures (FR-011) and unresolvable merges (FR-010) surface to the operator. **Status:** the autonomous backend is **not wired** — `applyFixes` is omitted from the runtime (operator decision 2026-06-22), so the pipeline surfaces `override-eligible` and the agent-in-the-loop fixes + re-governs; the `makeFixFanout` builder + primitives (FR-010/FR-011 behavior) exist and are tested. Wiring is TASK-424.
 - **FR-010**: When two chunks' fixes touch a shared file, govern MUST serialize the conflicting pair rather than merge blindly; an unresolvable merge MUST be surfaced to the operator (Constitution Principle V — fail loud, no fabricated resolution).
 - **FR-011**: A fix-subagent failure MUST isolate its chunk, allow other chunks to continue, and be surfaced at reconcile.
 - **FR-012**: After fixes, govern MUST re-audit only the chunks whose files a fix touched (the touched set), and the touched set MUST be coupling-correct (a fix to a file coupled into another chunk includes that chunk).

--- a/plugins/stack-control/src/__tests__/govern/chunked-govern-artifacts-doctor.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/chunked-govern-artifacts-doctor.test.ts
@@ -50,6 +50,51 @@ describe('030 T059 — chunked-govern-artifacts doctor rule (FR-021, SC-006)', (
     }
   });
 
+  // TASK-437 — a persisted chunk-set must list the chunks it governed. end-govern
+  // FATALs on an empty scope BEFORE writing a record, so a chunk-set artifact with a
+  // missing / empty / non-array `chunks` field is corrupt, not "valid with zero chunks".
+  it('TASK-437 flags a chunk-set artifact MISSING its chunks field', async () => {
+    const root = setup();
+    try {
+      writeFileSync(
+        join(root, '.stack-control', 'govern', 'chunk-sets', 'impl__nofield.json'),
+        JSON.stringify({ splitClusterMarkers: [] }),
+      );
+      const findings = await check({ repoRoot: root });
+      expect(findings.some((f) => f.severity === 'error' && /chunks/.test(f.message))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('TASK-437 flags a chunk-set artifact with an EMPTY chunks array', async () => {
+    const root = setup();
+    try {
+      writeFileSync(
+        join(root, '.stack-control', 'govern', 'chunk-sets', 'impl__empty.json'),
+        JSON.stringify({ chunks: [], splitClusterMarkers: [] }),
+      );
+      const findings = await check({ repoRoot: root });
+      expect(findings.some((f) => f.severity === 'error' && /empty/i.test(f.message))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('TASK-437 flags a chunk-set artifact whose chunks field is not an array', async () => {
+    const root = setup();
+    try {
+      writeFileSync(
+        join(root, '.stack-control', 'govern', 'chunk-sets', 'impl__nonarray.json'),
+        JSON.stringify({ chunks: { id: 'c1' }, splitClusterMarkers: [] }),
+      );
+      const findings = await check({ repoRoot: root });
+      expect(findings.some((f) => f.severity === 'error' && /chunks/.test(f.message))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('reports nothing for a clean installation (no artifacts)', async () => {
     const root = setup();
     try {

--- a/plugins/stack-control/src/__tests__/govern/convergence-record-io.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/convergence-record-io.test.ts
@@ -1,0 +1,58 @@
+// TASK-109 (re-aimed from the deleted per-phase writer to the surviving whole-feature
+// writer) — writeWholeFeatureConvergenceRecord writes a temp file then renames it
+// atomically. A crash between write and rename leaves an orphan `<path>.<uuid>.tmp`
+// sibling; across repeated crashes these accumulate in the convergence dir. The
+// writer must REAP stale temp siblings so the dir never litters torn temp files.
+
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  writeWholeFeatureConvergenceRecord,
+  readWholeFeatureConvergenceRecord,
+} from '../../govern/chunk-artifacts.js';
+import { convergenceRecordPath } from '../../govern/convergence-record.js';
+import type { WholeFeatureConvergenceRecord } from '../../govern/chunk-artifacts.js';
+
+function record(root: string): WholeFeatureConvergenceRecord {
+  return {
+    version: 1,
+    mode: 'impl',
+    item: 'multi:feature/x',
+    governedShaBase: 'b',
+    headSha: 'h',
+    chunkIds: ['c1'],
+    rounds: 1,
+    liftedFindings: [],
+    closedInLoopFindings: [],
+    seamResult: { boundaryPairs: [], findings: [], suppressedCompatible: 0 },
+    splitClusterRefs: [],
+    outcome: 'converged',
+    anchorRoot: root,
+  };
+}
+
+describe('TASK-109 — convergence record write reaps orphan torn temp files', () => {
+  it('removes a stale .tmp sibling and leaves exactly the real record', () => {
+    const root = mkdtempSync(join(tmpdir(), 'conv-io-'));
+    try {
+      const path = convergenceRecordPath(root, 'impl', 'multi:feature/x');
+      const dir = dirname(path);
+      mkdirSync(dir, { recursive: true });
+      // Simulate a torn temp left by a crash between write and rename.
+      const orphan = `${path}.deadbeef-orphan.tmp`;
+      writeFileSync(orphan, '{ partial');
+      expect(existsSync(orphan)).toBe(true);
+
+      writeWholeFeatureConvergenceRecord(root, record(root));
+
+      const leftovers = readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+      expect(leftovers, 'no torn temp files may remain after a successful write').toEqual([]);
+      // The real record is present and valid.
+      expect(readWholeFeatureConvergenceRecord(root, 'multi:feature/x').outcome).toBe('converged');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/stack-control/src/__tests__/govern/coupling-graph.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/coupling-graph.test.ts
@@ -20,6 +20,30 @@ describe('030 T010 — coupling graph (FR-003, R1)', () => {
     expect(hasEdge(g, 'src/a/x.ts', 'src/b/z.ts', 'dir')).toBe(false);
   });
 
+  it('TASK-430 — pairs a test file with its implementing source by name, across directories, with no diffs', () => {
+    // A RED-first test under __tests__ and its source under src/govern share a stem
+    // (seam-pass). They are in DIFFERENT directories and there are NO diffs, so neither
+    // the dir-adjacency nor the diff-xref baseline pairs them — only the name-based
+    // test↔source signal keeps them in one chunk, so the model auditing the test sees
+    // the implementing source (not a stale "FAILS today" comment in isolation).
+    const g = buildCouplingGraph({
+      changedFiles: ['src/govern/seam-pass.ts', 'src/__tests__/govern/seam-pass.test.ts'],
+    });
+    expect(
+      hasEdge(g, 'src/govern/seam-pass.ts', 'src/__tests__/govern/seam-pass.test.ts', 'test-source'),
+      'a test must be coupled to its same-stem source regardless of directory',
+    ).toBe(true);
+  });
+
+  it('TASK-430 — does NOT pair a test with an unrelated-stem source', () => {
+    const g = buildCouplingGraph({
+      changedFiles: ['src/govern/other.ts', 'src/__tests__/govern/seam-pass.test.ts'],
+    });
+    expect(
+      hasEdge(g, 'src/govern/other.ts', 'src/__tests__/govern/seam-pass.test.ts', 'test-source'),
+    ).toBe(false);
+  });
+
   it('adds a diff cross-reference edge when one file diff mentions another changed file', () => {
     const fileDiffs = new Map<string, string>([
       ['src/a.ts', 'import { foo } from "./b.js";'],

--- a/plugins/stack-control/src/__tests__/govern/end-govern-message.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/end-govern-message.test.ts
@@ -1,0 +1,73 @@
+// TASK-440 (RED first) — seam-pass findings can drive a non-converged
+// (override-eligible) outcome while liftedFindings is empty. The operator-facing
+// "implementation NOT done" message must SURFACE those seam breaks (kind + symbol),
+// else the operator sees "0 open findings" + a blocked run and cannot tell what
+// blocked. The renderer is pure so it is testable without process.exit.
+
+import { describe, expect, it } from 'vitest';
+import { renderEndGovernNotDoneMessage } from '../../govern/end-govern-message.js';
+import type { WholeFeatureConvergenceRecord } from '../../govern/chunk-artifacts.js';
+
+function record(over: Partial<WholeFeatureConvergenceRecord>): WholeFeatureConvergenceRecord {
+  return {
+    version: 1,
+    mode: 'impl',
+    item: 'multi:feature/x',
+    governedShaBase: 'b',
+    headSha: 'h',
+    chunkIds: ['c1', 'c2'],
+    rounds: 1,
+    liftedFindings: [],
+    closedInLoopFindings: [],
+    seamResult: { boundaryPairs: [], findings: [], suppressedCompatible: 0 },
+    splitClusterRefs: [],
+    outcome: 'override-eligible',
+    anchorRoot: '/install',
+    ...over,
+  };
+}
+
+describe('TASK-440 — end-govern NOT-done message surfaces seam findings', () => {
+  it('names the seam break (kind + symbol) when seam findings blocked the run', () => {
+    const r = record({
+      liftedFindings: [],
+      seamResult: {
+        boundaryPairs: [],
+        suppressedCompatible: 0,
+        findings: [{ kind: 'removed-export', symbol: 'foo', consumedAcross: true, severity: 'HIGH' }],
+      },
+    });
+    const msg = renderEndGovernNotDoneMessage(r);
+    expect(msg).toMatch(/removed-export/);
+    expect(msg).toMatch(/foo/);
+    expect(msg).toMatch(/seam/i);
+  });
+
+  it('reports the seam-finding count alongside the open-finding count (no misleading "0 open")', () => {
+    const r = record({
+      seamResult: {
+        boundaryPairs: [],
+        suppressedCompatible: 0,
+        findings: [
+          { kind: 'changed-arity', symbol: 'bar', consumedAcross: true, severity: 'HIGH' },
+          { kind: 'changed-required-shape', symbol: 'Cfg', consumedAcross: true, severity: 'HIGH' },
+        ],
+      },
+    });
+    const msg = renderEndGovernNotDoneMessage(r);
+    expect(msg).toMatch(/2 .*seam/i);
+    expect(msg).toMatch(/bar/);
+    expect(msg).toMatch(/Cfg/);
+  });
+
+  it('omits a seam section entirely when there are no seam findings', () => {
+    const msg = renderEndGovernNotDoneMessage(record({ outcome: 'override-eligible' }));
+    expect(msg).not.toMatch(/seam/i);
+    expect(msg).toMatch(/NOT done/);
+  });
+
+  it('keeps the degraded-fleet advice when the outcome is degraded-fleet-surfaced', () => {
+    const msg = renderEndGovernNotDoneMessage(record({ outcome: 'degraded-fleet-surfaced' }));
+    expect(msg).toMatch(/degraded/i);
+  });
+});

--- a/plugins/stack-control/src/__tests__/govern/fix-noop-not-converged.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/fix-noop-not-converged.test.ts
@@ -1,0 +1,49 @@
+// TASK-439 (RED first) — a no-op fix must NOT converge with unfixed findings.
+// When applyFixes returns SUCCESS but changedFiles:[] (the fix subagent "succeeded"
+// yet changed nothing), the touched set is empty, so the loop previously set
+// openFindings=[] and broke — reconciling to `converged` and marking the still-open
+// findings closed-in-loop. A fix that changed nothing left the findings unfixed:
+// the run must surface `fix-failure-surfaced`, never graduate. UNREACHABLE in
+// production today (applyFixes deferred, TASK-424) but guarded here.
+
+import { describe, expect, it } from 'vitest';
+import { runEndGovern, type EndGovernDeps } from '../../govern/end-govern-pipeline.js';
+import type { DiffScope } from '../../govern/payload-diff-scope.js';
+import type { Finding } from '../../govern/chunk-artifacts.js';
+
+const finding = (id: string): Finding => ({ id, title: id, severity: 'HIGH' });
+
+describe('TASK-439 — a no-op fix surfaces fix-failure, never converges', () => {
+  it('does NOT mark findings closed when the fix changed nothing', async () => {
+    const scopeDiff = (): DiffScope => ({
+      base: 'b',
+      head: 'h',
+      files: ['a.ts'],
+      fileDiffs: new Map<string, string>([['a.ts', 'a'.repeat(100)]]),
+    });
+
+    const deps: EndGovernDeps = {
+      scopeDiff,
+      resolveEnvelope: () => 100_000,
+      auditChunk: async () => ({ findings: [finding('AUDIT-1')], degraded: false }),
+      planContext: () => 'PLAN',
+      // The fix "succeeds" (no failed chunks, no unresolvable merges) but changes nothing.
+      applyFixes: async () => ({ changedFiles: [], fixCommits: [] }),
+    };
+
+    const result = await runEndGovern(
+      { installationRoot: '/root', item: 'multi:feature/x', base: 'b', head: 'h' },
+      deps,
+    );
+
+    expect(result.record.outcome, 'a no-op fix must not graduate').toBe('fix-failure-surfaced');
+    expect(
+      result.record.liftedFindings.map((f) => f.id),
+      'the unfixed finding stays SURFACED (lifted), not silently closed-in-loop',
+    ).toContain('AUDIT-1');
+    expect(
+      result.record.closedInLoopFindings.map((f) => f.id),
+      'an unfixed finding must NOT be recorded as closed-in-loop',
+    ).not.toContain('AUDIT-1');
+  });
+});

--- a/plugins/stack-control/src/__tests__/govern/payload-diff-base.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/payload-diff-base.test.ts
@@ -61,6 +61,32 @@ describe('030 — resolveImplementDiffBase (whole-feature default)', () => {
     }
   });
 
+  it('resolves the fork point via origin/main when it is the only default-branch ref (TASK-435)', () => {
+    // A worktree/fresh-clone shape: no local `main`/`master`, and `refs/remotes/origin/HEAD`
+    // is unset — the ONLY ref to the default branch is the remote-tracking `origin/main`.
+    // The buggy resolver returns HEAD~1 (scoping one commit); it must instead find the
+    // merge-base with origin/main (the whole feature span).
+    const repo = mkdtempSync(join(tmpdir(), 'diff-base-origin-'));
+    git(repo, 'init', '-q', '-b', 'feature/x');
+    writeFileSync(join(repo, 'README.md'), 'seed\n');
+    commitAll(repo, 'chore: seed');
+    const forkPoint = git(repo, 'rev-parse', 'HEAD');
+    // Point a remote-tracking ref at the fork point; do NOT create a local main or origin/HEAD.
+    git(repo, 'update-ref', 'refs/remotes/origin/main', forkPoint);
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src/a.ts'), 'export const a = 1;\n');
+    commitAll(repo, 'feat: a');
+    writeFileSync(join(repo, 'src/b.ts'), 'export const b = 2;\n');
+    commitAll(repo, 'feat: b');
+    try {
+      const base = resolveImplementDiffBase(repo, undefined);
+      expect(base).toBe(forkPoint); // the merge-base via origin/main, not HEAD~1
+      expect(base).not.toBe('HEAD~1');
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to HEAD~1 on the default branch itself (no feature fork point)', () => {
     const repo = setupMain();
     writeFileSync(join(repo, 'src.ts'), 'x\n');

--- a/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
@@ -238,6 +238,61 @@ describe('030 — rename-aware committed-diff scoping (TASK-429 / TASK-47)', () 
   });
 });
 
+// TASK-441 (restores the outer-tree payload-leak invariant deleted with the
+// installation-anchor integration test in T085) — govern anchors at the INSTALLATION.
+// When the installation is a SUBDIR of the git root, a committed or untracked file in
+// the OUTER tree (outside the installation subtree) must NEVER enter the audited scope
+// — `--relative` keeps both the committed arm and the untracked fold installation-scoped.
+describe('030 — scope is installation-anchored; the outer tree never leaks (TASK-441)', () => {
+  it('excludes a committed OUTER-tree file and keeps paths installation-relative', () => {
+    const repo = setup(); // git root
+    const install = join(repo, 'plugins', 'sc'); // installation = a subdir
+    mkdirSync(join(install, 'src'), { recursive: true });
+    const base = head(repo);
+    // ONE commit touching BOTH trees.
+    writeFileSync(join(repo, 'outer-change.txt'), 'outer changed\n');
+    writeFileSync(join(install, 'src/inner.ts'), 'export const inner = 1;\n');
+    commitAll(repo, 'feat: change both trees');
+    const h = head(repo);
+    try {
+      const scope = scopeCommittedDiff(install, base, h);
+      expect(scope.files.some((f) => f.endsWith('src/inner.ts')), 'inner file is in scope').toBe(true);
+      expect(scope.files, 'outer-tree file must NOT leak into scope').not.toContain('outer-change.txt');
+      expect(
+        [...scope.files].some((f) => f.includes('outer-change')),
+        'no outer-tree path under any spelling',
+      ).toBe(false);
+      // Path is installation-relative (NOT prefixed by the installation subdir).
+      expect(scope.files).toContain('src/inner.ts');
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('untracked fold enumerates only the installation subtree (no outer leak)', () => {
+    const repo = setup();
+    const install = join(repo, 'plugins', 'sc');
+    mkdirSync(join(install, 'src'), { recursive: true });
+    const base = head(repo);
+    writeFileSync(join(install, 'src/committed.ts'), 'x\n');
+    commitAll(repo, 'feat: committed inner');
+    const h = head(repo);
+    // Untracked files in BOTH trees.
+    writeFileSync(join(repo, 'u-outer.ts'), 'export const leak = 1;\n');
+    writeFileSync(join(install, 'u-inner.ts'), 'export const folded = 1;\n');
+    try {
+      const scope = scopeCommittedDiff(install, base, h);
+      expect(scope.files, 'inner untracked file is folded').toContain('u-inner.ts');
+      expect(scope.files, 'outer untracked file must NOT leak').not.toContain('u-outer.ts');
+      expect([...scope.files].some((f) => f.includes('u-outer')), 'no outer untracked under any spelling').toBe(
+        false,
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
 // AUDIT-20260622-02 — the end-govern pipeline's scopeDiff dropped ALL payload
 // exclude paths: it called scopeCommittedDiff (no exclusion args) so spec docs,
 // contracts, and the feature's own audit-log flowed into the audited surface.

--- a/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
@@ -336,7 +336,7 @@ describe('030 — diff-scope exclusion (AUDIT-20260622-02)', () => {
     expect(filterDiffScope(scope, [])).toBe(scope);
   });
 
-  it('resolveImplementExclusion yields the own + other-feature audit-logs and caller excludePaths', () => {
+  it('resolveImplementExclusion excludes the OWN audit-log, WHOLE other-feature roots, and caller excludePaths (TASK-428)', () => {
     const root = '/install';
     const ex = resolveImplementExclusion(
       root,
@@ -344,10 +344,36 @@ describe('030 — diff-scope exclusion (AUDIT-20260622-02)', () => {
       ['/install/specs/030-feat', '/install/specs/029-other'],
       ['/install/.stack-control/backlog'],
     );
+    // Own feature: only its audit-log is excluded — its CODE is still audited.
     expect(ex.excludeDiffRels).toContain('specs/030-feat/audit-log.md');
-    expect(ex.excludeDiffRels).toContain('specs/029-other/audit-log.md');
+    // TASK-428: another feature's WHOLE root is excluded (not just its audit-log.md),
+    // so an unrelated parked scaffold can't enter the current feature's payload.
+    expect(ex.excludeDiffRels).toContain('specs/029-other');
+    expect(ex.excludeDiffRels).not.toContain('specs/029-other/audit-log.md');
     expect(ex.excludeDiffRels).toContain('.stack-control/backlog');
     // The feature's own root is NOT double-listed as an "other" feature.
     expect(ex.otherFeatureRels).not.toContain('specs/030-feat');
+  });
+
+  it('TASK-428 — a whole other-feature root drops its parked scaffold via filterDiffScope', () => {
+    const ex = resolveImplementExclusion(
+      '/install',
+      '/install/specs/030-feat',
+      ['/install/specs/030-feat', '/install/specs/002-unrelated'],
+      [],
+    );
+    const scope = {
+      base: 'B',
+      head: 'H',
+      files: ['specs/030-feat/src/app.ts', 'specs/002-unrelated/scaffold.md'],
+      fileDiffs: new Map([
+        ['specs/030-feat/src/app.ts', 'a'],
+        ['specs/002-unrelated/scaffold.md', 'b'],
+      ]),
+    };
+    const filtered = filterDiffScope(scope, ex.excludeDiffRels);
+    // The current feature's code stays; the unrelated feature's scaffold is dropped.
+    expect(filtered.files).toContain('specs/030-feat/src/app.ts');
+    expect(filtered.files).not.toContain('specs/002-unrelated/scaffold.md');
   });
 });

--- a/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
@@ -202,6 +202,42 @@ describe('030 T021 — payload-diff-scope (FR-023)', () => {
   });
 });
 
+// TASK-429 (restores the rename-aware coverage deleted with assembleImplementPayload
+// in T085) — a pure tree-move within scope must PAIR as a rename, not emit a full
+// delete + full add. Without forced `-M` an endpoint diff across a relocation ships
+// the whole file body TWICE (doubled → oversized chunks), the exact TASK-47 failure.
+// The scope must NOT depend on the operator's diff.renames config — it forces -M.
+describe('030 — rename-aware committed-diff scoping (TASK-429 / TASK-47)', () => {
+  it('pairs an in-scope tree-move as a rename even when diff.renames=false', () => {
+    const repo = setup();
+    // A substantial, uniquely-marked file at the original path.
+    const body = `${Array.from({ length: 40 }, (_, i) => `export const RENAME_MARKER_${i} = ${i} * 7;`).join('\n')}\n`;
+    writeFileSync(join(repo, 'src/original.ts'), body);
+    commitAll(repo, 'feat: add original');
+    const base = head(repo);
+    // Pure tree-move (100% similarity), then disable git's default rename detection.
+    git(repo, 'mv', 'src/original.ts', 'src/relocated.ts');
+    commitAll(repo, 'refactor: relocate original -> relocated');
+    git(repo, 'config', 'diff.renames', 'false');
+    const h = head(repo);
+    try {
+      const scope = scopeCommittedDiff(repo, base, h);
+      const all = [...scope.fileDiffs.values()].join('\n');
+      // Paired as a rename: the diff carries the rename headers...
+      expect(all, 'tree-move must pair as a rename').toMatch(/rename from src\/original\.ts/);
+      expect(all).toMatch(/rename to src\/relocated\.ts/);
+      // ...and NOT the file body twice (a paired rename of unchanged content ships
+      // zero +/- body hunks; without -M the marker appears as both a - and a +).
+      expect(all, 'no doubled added body').not.toMatch(/^\+export const RENAME_MARKER_/m);
+      expect(all, 'no doubled deleted body').not.toMatch(/^-export const RENAME_MARKER_/m);
+      // The OLD path is not a separate full-deletion scoped entry.
+      expect(scope.files).not.toContain('src/original.ts');
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
 // AUDIT-20260622-02 — the end-govern pipeline's scopeDiff dropped ALL payload
 // exclude paths: it called scopeCommittedDiff (no exclusion args) so spec docs,
 // contracts, and the feature's own audit-log flowed into the audited surface.

--- a/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
@@ -100,6 +100,52 @@ describe('030 T021 — payload-diff-scope (FR-023)', () => {
     }
   });
 
+  // TASK-436 — the untracked-fold is a convenience-fold (not the committed govern
+  // target). A LARGE untracked file must keep its PATH in scope (FR-027 "path
+  // preserved, bytes withheld") but must NOT carry its full body into the audit
+  // payload, else a generated/scratch file bloats every barrage lane.
+  it('TASK-436 withholds the body of an OVERSIZED untracked file but preserves its path', () => {
+    const repo = setup();
+    const base = head(repo);
+    writeFileSync(join(repo, 'src/committed.ts'), 'a\n');
+    commitAll(repo, 'feat: committed');
+    const h = head(repo);
+    const huge = `${'a'.repeat(2 * 1024 * 1024)}\n`; // ~2 MiB, safely over any per-file budget
+    writeFileSync(join(repo, 'src/huge.generated.ts'), huge);
+    try {
+      const scope = scopeCommittedDiff(repo, base, h);
+      expect(scope.files, 'path preserved in scope').toContain('src/huge.generated.ts');
+      const body = scope.fileDiffs.get('src/huge.generated.ts') ?? '';
+      expect(Buffer.byteLength(body), 'oversized body must be withheld, not folded whole').toBeLessThan(
+        4096,
+      );
+      expect(body, 'withheld note explains why').toMatch(/withheld/i);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  // TASK-436 — a BINARY untracked file carries no auditable source. Its path is
+  // preserved in scope but its body is withheld (never the raw bytes / full blob).
+  it('TASK-436 withholds the body of a BINARY untracked file but preserves its path', () => {
+    const repo = setup();
+    const base = head(repo);
+    writeFileSync(join(repo, 'src/committed.ts'), 'a\n');
+    commitAll(repo, 'feat: committed');
+    const h = head(repo);
+    // A buffer with NUL bytes — git detects this as binary in `git diff --no-index`.
+    writeFileSync(join(repo, 'asset.bin'), Buffer.from([0, 1, 2, 0, 255, 0, 42, 0]));
+    try {
+      const scope = scopeCommittedDiff(repo, base, h);
+      expect(scope.files, 'path preserved in scope').toContain('asset.bin');
+      const body = scope.fileDiffs.get('asset.bin') ?? '';
+      expect(body, 'binary body withheld with a note').toMatch(/withheld/i);
+      expect(body, 'note names the binary reason').toMatch(/binary/i);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   // Regression: the installation root is a SUBDIR of the git root (the monorepo
   // layout — `.stack-control` lives at plugins/stack-control while the git root is
   // the repo above). `git diff --name-only` emits git-root-relative paths; running

--- a/plugins/stack-control/src/__tests__/govern/seam-pass-hardening.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/seam-pass-hardening.test.ts
@@ -1,0 +1,152 @@
+// 030 hardening (govern-030-hardening umbrella) — seam-pass cluster regressions.
+// RED-first: each test pins a real cross-boundary break the seam pass currently
+// suppresses. Pairs with TASK-426 (multi-line signatures), TASK-438 (function-typed
+// params miscounted as optional), TASK-431 (changed-required-shape never implemented).
+
+import { describe, expect, it } from 'vitest';
+import { runSeamPass } from '../../govern/seam-pass.js';
+import type { Chunk } from '../../govern/chunk-artifacts.js';
+
+const chunk = (id: string, files: readonly string[]): Chunk => ({
+  id,
+  files,
+  splitCluster: false,
+  renderedBytes: 0,
+});
+
+describe('TASK-426 — seam pass parses multi-line exported function signatures', () => {
+  it('flags a 1→2 changed-arity break when the signature spans multiple diff lines', () => {
+    // `wire` gains a REQUIRED `opts: Options` param. Both signatures are written
+    // multi-line (one param per line) — the buggy line-by-line scan sees only
+    // `export function wire(` with an unbalanced paren and drops the symbol entirely,
+    // so the real 1→2 arity increase is never compared.
+    const aDiff = [
+      '-export function wire(',
+      '-  handler: Handler',
+      '-): void {}',
+      '+export function wire(',
+      '+  handler: Handler,',
+      '+  opts: Options',
+      '+): void {}',
+    ].join('\n');
+    const bDiff = '+  wire(handler);';
+    const fileDiffs = new Map<string, string>([
+      ['a.ts', aDiff],
+      ['b.ts', bDiff],
+    ]);
+
+    const result = runSeamPass({
+      chunks: [chunk('chunk-a', ['a.ts']), chunk('chunk-b', ['b.ts'])],
+      splitClusterMarkers: [],
+      fileDiffs,
+    });
+
+    const arityBreaks = result.findings.filter((f) => f.kind === 'changed-arity' && f.symbol === 'wire');
+    expect(
+      arityBreaks,
+      'a multi-line signature gaining a required param consumed across a boundary must be flagged',
+    ).toHaveLength(1);
+  });
+});
+
+describe('TASK-438 — seam arity counts a required function-typed param', () => {
+  it('counts a newly-added required callback param toward arity (no => default confusion)', () => {
+    // `subscribe` gains a REQUIRED callback param `cb: (e) => void` after its existing
+    // `topic` param. The buggy countRequired() sees `=>` in the callback type, matches
+    // `p.includes('=')`, and discards the new callback as if it were defaulted — so both
+    // sides count as arity 1 and the real 1→2 cross-boundary break is silently missed.
+    const aDiff = [
+      '-export function subscribe(topic: string): void {}',
+      '+export function subscribe(topic: string, cb: (e: number) => void): void {}',
+    ].join('\n');
+    const bDiff = '+  subscribe("t");';
+    const fileDiffs = new Map<string, string>([
+      ['a.ts', aDiff],
+      ['b.ts', bDiff],
+    ]);
+
+    const result = runSeamPass({
+      chunks: [chunk('chunk-a', ['a.ts']), chunk('chunk-b', ['b.ts'])],
+      splitClusterMarkers: [],
+      fileDiffs,
+    });
+
+    const arityBreaks = result.findings.filter((f) => f.kind === 'changed-arity' && f.symbol === 'subscribe');
+    expect(
+      arityBreaks,
+      'a required param added after a function-typed param must count toward arity',
+    ).toHaveLength(1);
+  });
+
+  it('still suppresses a genuinely defaulted param (source-compatible)', () => {
+    // Adding a DEFAULTED param after a callback is source-compatible — must NOT flag.
+    const aDiff = [
+      '-export function emit(cb: (e: number) => void): void {}',
+      '+export function emit(cb: (e: number) => void, tag: string = "x"): void {}',
+    ].join('\n');
+    const bDiff = '+  emit(handler);';
+    const fileDiffs = new Map<string, string>([
+      ['a.ts', aDiff],
+      ['b.ts', bDiff],
+    ]);
+
+    const result = runSeamPass({
+      chunks: [chunk('chunk-a', ['a.ts']), chunk('chunk-b', ['b.ts'])],
+      splitClusterMarkers: [],
+      fileDiffs,
+    });
+
+    expect(result.findings.filter((f) => f.symbol === 'emit')).toHaveLength(0);
+  });
+});
+
+describe('TASK-431 — seam pass emits changed-required-shape for interface/type', () => {
+  it('flags a new REQUIRED interface field consumed across a boundary', () => {
+    // `Config` gains a required `region: string`. A cross-chunk consumer that builds a
+    // Config object without it now breaks, but the impl parses interfaces as null
+    // (non-function) and treats the change as source-compatible.
+    const aDiff = [
+      '-export interface Config { host: string }',
+      '+export interface Config { host: string; region: string }',
+    ].join('\n');
+    const bDiff = '+  const c: Config = { host: "h" };';
+    const fileDiffs = new Map<string, string>([
+      ['a.ts', aDiff],
+      ['b.ts', bDiff],
+    ]);
+
+    const result = runSeamPass({
+      chunks: [chunk('chunk-a', ['a.ts']), chunk('chunk-b', ['b.ts'])],
+      splitClusterMarkers: [],
+      fileDiffs,
+    });
+
+    const shapeBreaks = result.findings.filter(
+      (f) => f.kind === 'changed-required-shape' && f.symbol === 'Config',
+    );
+    expect(
+      shapeBreaks,
+      'a new required interface field consumed across a boundary must be flagged',
+    ).toHaveLength(1);
+  });
+
+  it('does NOT flag a new OPTIONAL interface field (source-compatible)', () => {
+    const aDiff = [
+      '-export interface Opts { a: string }',
+      '+export interface Opts { a: string; b?: number }',
+    ].join('\n');
+    const bDiff = '+  const o: Opts = { a: "x" };';
+    const fileDiffs = new Map<string, string>([
+      ['a.ts', aDiff],
+      ['b.ts', bDiff],
+    ]);
+
+    const result = runSeamPass({
+      chunks: [chunk('chunk-a', ['a.ts']), chunk('chunk-b', ['b.ts'])],
+      splitClusterMarkers: [],
+      fileDiffs,
+    });
+
+    expect(result.findings.filter((f) => f.symbol === 'Opts')).toHaveLength(0);
+  });
+});

--- a/plugins/stack-control/src/govern/chunk-artifacts.ts
+++ b/plugins/stack-control/src/govern/chunk-artifacts.ts
@@ -7,8 +7,8 @@
 //
 // Entities trace to specs/030-chunked-end-govern/data-model.md.
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { convergenceRecordPath } from './convergence-record.js';
 
@@ -275,7 +275,18 @@ export function writeWholeFeatureConvergenceRecord(
   record: WholeFeatureConvergenceRecord,
 ): string {
   const path = convergenceRecordPath(installationRoot, 'impl', record.item);
-  mkdirSync(dirname(path), { recursive: true });
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  // TASK-109: reap orphan torn temp siblings from prior crashes (a crash between the
+  // write and the rename below leaves a `<base>.<uuid>.tmp`). Reaping before we write a
+  // fresh temp bounds the litter to at most one in-flight temp per write. (Concurrent
+  // govern on the SAME (mode,item) is unsupported — the record is one-per-(mode,item).)
+  const base = basename(path);
+  const escaped = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const tmpRe = new RegExp(`^${escaped}\\.[^.]+\\.tmp$`);
+  for (const f of readdirSync(dir)) {
+    if (tmpRe.test(f)) rmSync(join(dir, f), { force: true });
+  }
   const tmp = `${path}.${randomUUID()}.tmp`;
   writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`);
   renameSync(tmp, path);

--- a/plugins/stack-control/src/govern/cluster-payload/coupling-graph.ts
+++ b/plugins/stack-control/src/govern/cluster-payload/coupling-graph.ts
@@ -5,7 +5,7 @@
 // Implemented in Phase 3 (T016).
 
 /** The provenance of a coupling edge (R1 signals). */
-export type CouplingSignal = 'dir' | 'diff-xref' | 'ts-import';
+export type CouplingSignal = 'dir' | 'diff-xref' | 'ts-import' | 'test-source';
 
 /** A directed coupling edge between two changed files, with its signal provenance. */
 export interface CouplingEdge {
@@ -37,6 +37,16 @@ function posixDirname(p: string): string {
 function posixBasename(p: string): string {
   const i = p.lastIndexOf('/');
   return i === -1 ? p : p.slice(i + 1);
+}
+
+/** The stem of a test file (`foo.test.ts` → `foo`, `bar.spec.tsx` → `bar`), or undefined if not a test. */
+function testStem(file: string): string | undefined {
+  return /^(.+)\.(?:test|spec)\.[cm]?[jt]sx?$/.exec(posixBasename(file))?.[1];
+}
+
+/** The stem of a source file (basename without its TS/JS extension): `seam-pass.ts` → `seam-pass`. */
+function sourceStem(file: string): string {
+  return posixBasename(file).replace(/\.[cm]?[jt]sx?$/, '');
 }
 
 /** Reference tokens that a diff mentioning file B might use to refer to it (path / basename / ESM .js swap). */
@@ -73,6 +83,20 @@ export function buildCouplingGraph(input: CouplingInput): CouplingGraph {
           edges.push({ from: a, to: b, signal: 'diff-xref' });
         }
       }
+    }
+  }
+
+  // Universal baseline 3 (TASK-430): pair a test file with its implementing source by
+  // NAME (`foo.test.ts` ↔ `foo.ts`), independent of directory and diff text, so the
+  // chunker keeps them in the SAME chunk. A RED-first test split from its source makes
+  // the model auditing the test-only chunk read stale "FAILS today" TDD comments and
+  // report a false failing-test finding (the 030 dogfood meta-finding).
+  for (const t of files) {
+    const stem = testStem(t);
+    if (stem === undefined) continue;
+    for (const s of files) {
+      if (s === t || testStem(s) !== undefined) continue; // source side only
+      if (sourceStem(s) === stem) edges.push({ from: t, to: s, signal: 'test-source' });
     }
   }
 

--- a/plugins/stack-control/src/govern/end-govern-message.ts
+++ b/plugins/stack-control/src/govern/end-govern-message.ts
@@ -1,0 +1,42 @@
+// 030 hardening (TASK-440) — the operator-facing "implementation NOT done" message
+// for a non-converged end-govern run. Pure (no I/O, no process.exit) so it is unit
+// testable; govern-arms.ts writes the returned string to stderr. Surfaces the
+// cross-chunk SEAM breaks that can drive an `override-eligible` outcome while
+// `liftedFindings` is empty — without this, a seam-blocked run printed "0 open
+// finding(s)" and the operator could not see what blocked.
+
+import type { SeamFinding, WholeFeatureConvergenceRecord } from './chunk-artifacts.js';
+
+/** One-line human summary of a seam break: `removed-export 'foo' (consumed across a boundary)`. */
+function describeSeamFinding(f: SeamFinding): string {
+  const across = f.consumedAcross ? ' (consumed across a chunk boundary)' : '';
+  return `${f.kind} '${f.symbol}'${across}`;
+}
+
+/**
+ * Render the "implementation NOT done" message for a non-converged convergence
+ * record. Reports the open-finding count, the chunk/round counts, the SEAM breaks
+ * (when any), and outcome-appropriate next-step advice. A degraded-fleet outcome is a
+ * reachability problem, not a findings problem, so it points at fleet reachability
+ * (AUDIT-20260622-10) rather than "fix the findings".
+ */
+export function renderEndGovernNotDoneMessage(record: WholeFeatureConvergenceRecord): string {
+  const advice =
+    record.outcome === 'degraded-fleet-surfaced'
+      ? `the audit fleet was degraded for the convergence-determining round (a quiet round from ` +
+        `fewer lanes is not full cross-model convergence). Ensure every configured model CLI is ` +
+        `installed/reachable & re-govern, or record --override to accept the weakened audit.`
+      : `Fix the surfaced findings & re-govern, or record --override.`;
+
+  const seam = record.seamResult.findings;
+  const seamLine =
+    seam.length > 0
+      ? ` Plus ${seam.length} cross-chunk seam break(s): ${seam.map(describeSeamFinding).join('; ')}.`
+      : '';
+
+  return (
+    `govern: implementation NOT done — end-govern reconciled to '${record.outcome}' ` +
+    `(${record.liftedFindings.length} open finding(s) over ${record.chunkIds.length} chunk(s), ` +
+    `${record.rounds} round(s)).${seamLine} ${advice}\n`
+  );
+}

--- a/plugins/stack-control/src/govern/end-govern-pipeline.ts
+++ b/plugins/stack-control/src/govern/end-govern-pipeline.ts
@@ -168,6 +168,15 @@ export async function runEndGovern(input: EndGovernInput, deps: EndGovernDeps): 
       terminal = 'fix-failure-surfaced'; // FR-011 — failure isolated + surfaced at reconcile
       break;
     }
+    // TASK-439: a fix that reports SUCCESS but changed nothing (changedFiles:[]) is a
+    // no-op — the open findings it was meant to address are still open. Without this
+    // guard the empty touched-set below sets openFindings=[] and the run reconciles to
+    // `converged`, marking the unfixed findings closed-in-loop. Surface fix-failure
+    // instead — a no-op fix never graduates. (We reach here only with open findings.)
+    if (fix.changedFiles.length === 0) {
+      terminal = 'fix-failure-surfaced';
+      break;
+    }
     const touched = computeTouchedSet({
       round: round + 1,
       chunks: partition.chunks,

--- a/plugins/stack-control/src/govern/govern-arms.ts
+++ b/plugins/stack-control/src/govern/govern-arms.ts
@@ -31,6 +31,7 @@ import { runEndGovern } from './end-govern-pipeline.js';
 import { makeEndGovernRuntime } from './end-govern-runtime.js';
 import { writeWholeFeatureConvergenceRecord } from './chunk-artifacts.js';
 import { liftEndGovernFindingsOnce } from './lift-once.js';
+import { renderEndGovernNotDoneMessage } from './end-govern-message.js';
 import type { ConvergenceOutcome } from './convergence-types.js';
 import type { LaneCapabilityProfile } from './lane-capabilities.js';
 import type { Installation } from '../config/types.js';
@@ -330,20 +331,11 @@ export async function runImplementArm(ctx: GovernRunContext): Promise<void> {
   }
 
   if (record.outcome !== 'converged') {
-    // AUDIT-20260622-10: a degraded-fleet outcome is not a findings problem — the
-    // run was quiet because fewer lanes than the configured fleet produced it, so
-    // "fix the findings" advice would mislead. Point at fleet reachability instead.
-    const advice =
-      record.outcome === 'degraded-fleet-surfaced'
-        ? `the audit fleet was degraded for the convergence-determining round (a quiet round from ` +
-          `fewer lanes is not full cross-model convergence). Ensure every configured model CLI is ` +
-          `installed/reachable & re-govern, or record --override to accept the weakened audit.`
-        : `Fix the surfaced findings & re-govern, or record --override.`;
-    process.stderr.write(
-      `govern: implementation NOT done — end-govern reconciled to '${record.outcome}' ` +
-        `(${record.liftedFindings.length} open finding(s) over ${record.chunkIds.length} chunk(s), ` +
-        `${record.rounds} round(s)). ${advice}\n`,
-    );
+    // TASK-440: surface the cross-chunk SEAM breaks too — they can drive an
+    // override-eligible outcome while liftedFindings is empty, so without them the
+    // operator saw "0 open finding(s)" and could not see what blocked. AUDIT-20260622-10:
+    // a degraded-fleet outcome points at fleet reachability, not "fix the findings".
+    process.stderr.write(renderEndGovernNotDoneMessage(record));
     emitTerminalOutcome('blocked');
     process.exit(1);
   }

--- a/plugins/stack-control/src/govern/payload-diff-scope.ts
+++ b/plugins/stack-control/src/govern/payload-diff-scope.ts
@@ -143,11 +143,17 @@ function gitTry(root: string, args: readonly string[]): string | undefined {
   return out.length > 0 ? out : undefined;
 }
 
-/** The repo's default branch ref, best-effort: origin/HEAD → `main` → `master` → undefined. */
+/**
+ * The repo's default branch ref, best-effort: origin/HEAD → local `main`/`master` →
+ * remote-tracking `origin/main`/`origin/master` → undefined. The remote-tracking
+ * candidates cover the worktree / fresh-clone shape where origin/HEAD is unset and no
+ * LOCAL default branch exists — there `origin/main` is the only ref to the fork point,
+ * and missing it silently scoped the diff to HEAD~1 (TASK-435).
+ */
 function resolveDefaultBranch(gitRoot: string): string | undefined {
   const sym = gitTry(gitRoot, ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD']);
   if (sym !== undefined) return sym.replace(/^refs\/remotes\//, ''); // e.g. origin/main
-  for (const candidate of ['main', 'master']) {
+  for (const candidate of ['main', 'master', 'origin/main', 'origin/master']) {
     if (gitTry(gitRoot, ['rev-parse', '--verify', '--quiet', candidate]) !== undefined) return candidate;
   }
   return undefined;

--- a/plugins/stack-control/src/govern/payload-diff-scope.ts
+++ b/plugins/stack-control/src/govern/payload-diff-scope.ts
@@ -66,8 +66,13 @@ export function resolveImplementExclusion(
   const excludePathRels =
     featureRoot !== undefined ? (excludePaths ?? []).map(relify).filter(inRepo) : [];
   const excludeDiffRels = [
+    // The feature's OWN root: exclude only its audit-log (self-reference generator) —
+    // its code is the audit target and must stay in scope.
     ...(featureInside ? [`${featureRel}/audit-log.md`] : []),
-    ...otherFeatureRels.map((root) => `${root}/audit-log.md`),
+    // TASK-428: every OTHER in-repo feature root is excluded WHOLE (not just its
+    // audit-log.md), so an unrelated parked scaffold (e.g. specs/002/scaffold.md) can't
+    // enter the current feature's chunked payload and generate false findings.
+    ...otherFeatureRels,
     ...excludePathRels,
   ];
   return {

--- a/plugins/stack-control/src/govern/payload-diff-scope.ts
+++ b/plugins/stack-control/src/govern/payload-diff-scope.ts
@@ -184,6 +184,27 @@ function lines(out: string): string[] {
   return out.split('\n').map((s) => s.trim()).filter((s) => s.length > 0);
 }
 
+/**
+ * Per-file byte budget for the untracked-fold. An untracked working-tree file is a
+ * convenience-fold, not the committed govern target; a file whose `--no-index` diff
+ * exceeds this is almost certainly generated/scratch, not hand-written source the
+ * operator wants audited inline. Bytes over the budget are withheld (TASK-436).
+ */
+const UNTRACKED_FOLD_MAX_BYTES = 1024 * 1024; // 1 MiB
+
+/**
+ * The bounded, VISIBLE placeholder substituted for a binary or oversized untracked
+ * file's diff body — the FR-027 "path preserved, bytes withheld" contract: the file
+ * stays listed in scope (never silently dropped) but its body never bloats the audit
+ * payload. Carries no `+/-export` lines, so the seam pass raises no false break on it.
+ */
+function untrackedWithheldNote(file: string, binary: boolean, bytes: number): string {
+  const reason = binary
+    ? 'binary (no auditable source)'
+    : `${bytes} bytes exceeds the ${UNTRACKED_FOLD_MAX_BYTES}-byte untracked-fold budget`;
+  return `[untracked file ${file}: diff body withheld — ${reason}. Path preserved in scope; bytes withheld from the audit payload.]\n`;
+}
+
 /** Scope the committed base..HEAD diff (plus untracked-fold) into an inclusion-based DiffScope. */
 export function scopeCommittedDiff(installationRoot: string, base: string, head: string): DiffScope {
   const fileDiffs = new Map<string, string>();
@@ -215,7 +236,13 @@ export function scopeCommittedDiff(installationRoot: string, base: string, head:
   // non-ASCII names stay literal UTF-8.
   for (const f of lines(git(installationRoot, ['ls-files', '--others', '--exclude-standard']))) {
     if (fileDiffs.has(f)) continue;
-    fileDiffs.set(f, gitDiffNoIndex(installationRoot, ['--', '/dev/null', f]));
+    const d = gitDiffNoIndex(installationRoot, ['--', '/dev/null', f]);
+    // Guard the convenience-fold against payload bloat (TASK-436): a binary file (no
+    // auditable source) or one whose diff exceeds the per-file budget keeps its PATH in
+    // scope but withholds its BODY — the FR-027 path-preserved/bytes-withheld contract.
+    const binary = /^Binary files /m.test(d);
+    const oversized = Buffer.byteLength(d) > UNTRACKED_FOLD_MAX_BYTES;
+    fileDiffs.set(f, binary || oversized ? untrackedWithheldNote(f, binary, Buffer.byteLength(d)) : d);
     files.push(f);
   }
 

--- a/plugins/stack-control/src/govern/payload-diff-scope.ts
+++ b/plugins/stack-control/src/govern/payload-diff-scope.ts
@@ -221,8 +221,30 @@ export function scopeCommittedDiff(installationRoot: string, base: string, head:
   // byte-identical to the render's committed-diff arm, so the chunk scope it produces
   // matches the render's pathScope filter exactly. (Single-rooted repo: the installation
   // and the git toplevel coincide, so `--relative` is a no-op there.)
+  // Rename detection up front (`-M`), INDEPENDENT of the operator's diff.renames
+  // config (TASK-429 / TASK-47): a pure tree-move pairs as a single rename stanza
+  // instead of a full delete + full add. Without it, an endpoint diff across a
+  // relocation ships the whole file body twice → doubled bytes → oversized chunks.
+  const renamedNewToOld = new Map<string, string>(); // new path → old path
+  const renamedOldPaths = new Set<string>();
+  for (const line of lines(git(installationRoot, ['diff', '-M', '--relative', '--name-status', base, head]))) {
+    const m = /^R\d*\t(.+)\t(.+)$/.exec(line);
+    if (m && m[1] !== undefined && m[2] !== undefined) {
+      renamedNewToOld.set(m[2], m[1]);
+      renamedOldPaths.add(m[1]);
+    }
+  }
+
   for (const f of lines(git(installationRoot, ['diff', '--relative', '--name-only', base, head]))) {
-    fileDiffs.set(f, git(installationRoot, ['diff', '--relative', base, head, '--', f]));
+    if (renamedOldPaths.has(f)) continue; // OLD side of a rename — covered by the paired stanza
+    const old = renamedNewToOld.get(f);
+    // For a renamed NEW path, diff the pair under `-M` so it renders as a rename (body
+    // only for any content delta); otherwise the standard per-file diff.
+    const d =
+      old !== undefined
+        ? git(installationRoot, ['diff', '-M', '--relative', base, head, '--', old, f])
+        : git(installationRoot, ['diff', '--relative', base, head, '--', f]);
+    fileDiffs.set(f, d);
     files.push(f);
   }
 

--- a/plugins/stack-control/src/govern/seam-pass.ts
+++ b/plugins/stack-control/src/govern/seam-pass.ts
@@ -102,31 +102,166 @@ function splitTopLevelParams(paramList: string): string[] {
   return params;
 }
 
-/** Count required params (not optional `?`, not defaulted `=`). */
+/**
+ * Count required params (not optional `?`, not defaulted `=`). A function-typed
+ * param (`cb: (e: number) => void`) carries an `=>` arrow whose `=` must NOT be
+ * read as a default assignment — strip arrows before the default check, else a
+ * required callback param is silently dropped from the arity (TASK-438).
+ */
 function countRequired(paramList: string): number {
   return splitTopLevelParams(paramList)
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
-    .filter((p) => !p.includes('=') && !p.split(':')[0]?.trim().endsWith('?')).length;
+    .filter((p) => !p.replace(/=>/g, '').includes('=') && !p.split(':')[0]?.trim().endsWith('?')).length;
 }
 
-/** Parse exported symbols on `+` or `-` diff lines → name → required-param count (null for non-functions). */
-function parseExports(diffText: string, sign: '+' | '-'): Map<string, number | null> {
-  const map = new Map<string, number | null>();
+/**
+ * Extract the brace-delimited body of an interface/type literal, starting at the
+ * index of its opening `{`, by scanning to the MATCHING `}`. Returns the inner text
+ * (without the outer braces), or null if unbalanced (header truncated mid-body).
+ */
+function extractBraceBody(body: string, openBraceIdx: number): string | null {
+  let depth = 0;
+  let start = -1;
+  for (let i = openBraceIdx; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '{') {
+      if (depth === 0 && start === -1) start = i + 1;
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) return start === -1 ? '' : body.slice(start, i);
+    }
+  }
+  return null;
+}
+
+/** Split an interface/type body into member declarations on TOP-LEVEL `;` / `,` / newline. */
+function splitTopLevelMembers(bodyText: string): string[] {
+  const out: string[] = [];
+  let dp = 0;
+  let da = 0;
+  let db = 0;
+  let dk = 0;
+  let cur = '';
+  const flush = (): void => {
+    if (cur.trim().length > 0) out.push(cur.trim());
+    cur = '';
+  };
+  for (const ch of bodyText) {
+    if ((ch === ';' || ch === ',' || ch === '\n') && dp === 0 && da === 0 && db === 0 && dk === 0) {
+      flush();
+      continue;
+    }
+    if (ch === '(') dp++;
+    else if (ch === ')') {
+      if (dp > 0) dp--;
+    } else if (ch === '<') da++;
+    else if (ch === '>') {
+      if (da > 0) da--;
+    } else if (ch === '{') db++;
+    else if (ch === '}') {
+      if (db > 0) db--;
+    } else if (ch === '[') dk++;
+    else if (ch === ']') {
+      if (dk > 0) dk--;
+    }
+    cur += ch;
+  }
+  flush();
+  return out;
+}
+
+/**
+ * Names of the REQUIRED members of an interface/type body (skip optional `?:` members,
+ * index/call signatures, and anything not led by a plain identifier — conservative,
+ * so an unparseable member is never read as a new required field).
+ */
+function requiredFieldsOf(bodyText: string): string[] {
+  const fields: string[] = [];
+  for (const seg of splitTopLevelMembers(bodyText)) {
+    const m = /^([A-Za-z0-9_$]+)(\??)/.exec(seg);
+    if (!m || m[1] === undefined) continue;
+    if (m[2] !== '?') fields.push(m[1]);
+  }
+  return fields;
+}
+
+/** An exported symbol's seam-relevant shape: a function arity, an interface/type's required fields, or other. */
+type ExportSig =
+  | { readonly kind: 'fn'; readonly required: number }
+  | { readonly kind: 'shape'; readonly requiredFields: readonly string[] }
+  | { readonly kind: 'other' };
+
+/**
+ * Parse exported symbols on `+` or `-` diff lines → name → seam signature. Function
+ * and interface/type signatures may span MULTIPLE contiguous same-sign diff lines
+ * (TASK-426/431): accumulate continuation lines until the param list / brace body
+ * balances before measuring it.
+ */
+function parseExports(diffText: string, sign: '+' | '-'): Map<string, ExportSig> {
+  const map = new Map<string, ExportSig>();
+  const bodies: string[] = [];
   for (const line of diffText.split('\n')) {
-    if (!line.startsWith(sign)) continue;
-    const body = line.slice(1).trim();
+    if (line.startsWith(sign)) bodies.push(line.slice(1));
+  }
+  for (let i = 0; i < bodies.length; i++) {
+    const first = bodies[i];
+    if (first === undefined) continue;
+    const body = first.trim();
+
     const fn = FN_HEAD.exec(body);
     if (fn && fn[1] !== undefined) {
       const openParenIdx = (fn.index ?? 0) + fn[0].length - 1; // index of the `(`
-      const paramList = extractParamList(body, openParenIdx);
-      if (paramList !== null) {
-        map.set(fn[1], countRequired(paramList));
-        continue;
+      let joined = body;
+      let paramList = extractParamList(joined, openParenIdx);
+      let j = i;
+      while (paramList === null && j + 1 < bodies.length) {
+        const next = bodies[++j];
+        if (next === undefined) break;
+        joined += `\n${next}`;
+        paramList = extractParamList(joined, openParenIdx);
       }
+      if (paramList !== null) {
+        map.set(fn[1], { kind: 'fn', required: countRequired(paramList) });
+        i = j;
+      }
+      continue;
     }
+
     const decl = DECL.exec(body);
-    if (decl && decl[1] !== undefined) map.set(decl[1], null);
+    if (!decl || decl[1] === undefined) continue;
+    const keyword = /^export\s+(?:async\s+)?(const|let|var|class|interface|type|enum)\b/.exec(body)?.[1];
+    if (keyword === 'interface' || keyword === 'type') {
+      let joined = body;
+      let braceIdx = joined.indexOf('{');
+      let j = i;
+      while (braceIdx === -1 && j + 1 < bodies.length) {
+        const next = bodies[++j];
+        if (next === undefined) break;
+        joined += `\n${next}`;
+        braceIdx = joined.indexOf('{');
+      }
+      if (braceIdx !== -1) {
+        let shapeBody = extractBraceBody(joined, braceIdx);
+        while (shapeBody === null && j + 1 < bodies.length) {
+          const next = bodies[++j];
+          if (next === undefined) break;
+          joined += `\n${next}`;
+          shapeBody = extractBraceBody(joined, braceIdx);
+        }
+        if (shapeBody !== null) {
+          map.set(decl[1], { kind: 'shape', requiredFields: requiredFieldsOf(shapeBody) });
+          i = j;
+          continue;
+        }
+      }
+      // No brace body (union/primitive type alias) — no required-shape semantics.
+      map.set(decl[1], { kind: 'other' });
+      i = j;
+      continue;
+    }
+    map.set(decl[1], { kind: 'other' });
   }
   return map;
 }
@@ -170,8 +305,8 @@ export function runSeamPass(input: SeamPassInput): SeamResult {
   let suppressedCompatible = 0;
 
   for (const c of input.chunks) {
-    const removed = new Map<string, number | null>();
-    const added = new Map<string, number | null>();
+    const removed = new Map<string, ExportSig>();
+    const added = new Map<string, ExportSig>();
     for (const f of c.files) {
       const d = input.fileDiffs.get(f) ?? '';
       for (const [n, r] of parseExports(d, '-')) removed.set(n, r);
@@ -181,15 +316,26 @@ export function runSeamPass(input: SeamPassInput): SeamResult {
     for (const name of names) {
       const inRem = removed.has(name);
       const inAdd = added.has(name);
-      const remReq = removed.get(name) ?? null;
-      const addReq = added.get(name) ?? null;
+      const remSig = removed.get(name);
+      const addSig = added.get(name);
 
       let kind: SeamFinding['kind'] | null = null;
       let compatibleChange = false;
       if (inRem && !inAdd) kind = 'removed-export';
-      else if (inRem && inAdd) {
-        if (remReq !== null && addReq !== null && addReq > remReq) kind = 'changed-arity';
-        else compatibleChange = true; // signature touched but source-compatible
+      else if (inRem && inAdd && remSig !== undefined && addSig !== undefined) {
+        if (remSig.kind === 'fn' && addSig.kind === 'fn') {
+          if (addSig.required > remSig.required) kind = 'changed-arity';
+          else compatibleChange = true; // arity unchanged or narrowed — source-compatible
+        } else if (remSig.kind === 'shape' && addSig.kind === 'shape') {
+          // A required field present in the new shape but NOT required in the old one
+          // (brand-new, or optional→required) breaks a cross-boundary consumer.
+          const wasRequired = new Set(remSig.requiredFields);
+          if (addSig.requiredFields.some((field) => !wasRequired.has(field))) {
+            kind = 'changed-required-shape';
+          } else compatibleChange = true;
+        } else {
+          compatibleChange = true; // kind changed / not seam-relevant — stay conservative
+        }
       }
 
       const consumed = consumedInOtherChunk(name, c.id, chunkText);

--- a/plugins/stack-control/src/scope-discovery/doctor-rules/chunked-govern-artifacts.ts
+++ b/plugins/stack-control/src/scope-discovery/doctor-rules/chunked-govern-artifacts.ts
@@ -66,7 +66,35 @@ export const check: DoctorRuleCheck = async (opts: DoctorRuleOptions): Promise<r
       findings.push({ rule: RULE_ID, severity: 'error', message: `chunk-set artifact ${f} is not an object` });
       continue;
     }
-    const rawChunks = Array.isArray(raw['chunks']) ? raw['chunks'] : [];
+    // A persisted chunk-set MUST list the chunks it governed. end-govern FATALs on an
+    // empty scope BEFORE writing a record (end-govern-pipeline AUDIT-20260622-23), so a
+    // missing / empty / non-array `chunks` field is corrupt — not "valid, zero chunks"
+    // (TASK-437). Previously both fields silently defaulted to [] and passed doctor.
+    if (!Array.isArray(raw['chunks'])) {
+      findings.push({
+        rule: RULE_ID,
+        severity: 'error',
+        message: `chunk-set artifact ${f} is missing a valid 'chunks' array — a persisted chunk-set must list the chunks it governed.`,
+      });
+      continue;
+    }
+    if (raw['chunks'].length === 0) {
+      findings.push({
+        rule: RULE_ID,
+        severity: 'error',
+        message: `chunk-set artifact ${f} has an EMPTY 'chunks' array — end-govern FATALs on a zero-chunk scope, so a persisted empty chunk-set is corrupt; re-run end-govern to regenerate it.`,
+      });
+      continue;
+    }
+    if (raw['splitClusterMarkers'] !== undefined && !Array.isArray(raw['splitClusterMarkers'])) {
+      findings.push({
+        rule: RULE_ID,
+        severity: 'error',
+        message: `chunk-set artifact ${f} has a non-array 'splitClusterMarkers' field — it must be an array of markers (or absent).`,
+      });
+      continue;
+    }
+    const rawChunks = raw['chunks'];
     const rawMarkers = Array.isArray(raw['splitClusterMarkers']) ? raw['splitClusterMarkers'] : [];
     const chunkIds = new Set<string>();
     let shapeOk = true;


### PR DESCRIPTION
## Summary

Burns down the **`govern-030-hardening`** umbrella — the dispositioned residuals from the 030 chunked-end-govern dogfood — and reframes the seam-pass design after an operator review.

16 targeted bug fixes, each RED-first (a test that exercises the bug, then the fix), committed one-per-task. Per the project's workflow-protocol scope rule these are point fixes, so no govern/audit-barrage was run.

## Fixes by cluster

**Seam-pass interface detection** (see reframing below — these are correct but slated for retirement):
- multi-line exported function signatures were dropped (unbalanced-paren scan)
- required function-typed (callback) params miscounted as optional (`=>` read as a default `=`)
- `changed-required-shape` declared in the schema but never implemented for interfaces/types
- cross-chunk seam breaks now surfaced in the operator-facing "NOT done" message (were invisible behind "0 open findings")

**Govern pipeline correctness / edges:**
- diff base resolves via remote-tracking `origin/main` when it's the only default-branch ref (was silently scoping to `HEAD~1`)
- untracked-fold guards against binary + oversized files (FR-027 path-preserved / bytes-withheld)
- doctor rejects chunk-set artifacts with missing / empty / non-array `chunks`
- a no-op fix (`changedFiles: []`) surfaces `fix-failure-surfaced` instead of converging with unfixed findings marked closed
- rename-aware committed-diff scoping, independent of the operator's `diff.renames` config (a tree-move no longer doubles the body)
- whole other-feature roots excluded from the implement payload (an unrelated parked scaffold can no longer enter scope) — operator design call
- test↔source coupling in the chunker keeps a `*.test.ts` and its implementing source in one chunk (kills the false "failing test" finding) — operator design call
- restored the outer-tree payload-leak regression guard

**Re-target:** torn-temp-file reap on the whole-feature convergence-record writer (re-aimed from the deleted per-phase writer).

**Doc reconciliation:** checkpoint mode-scoping (implement rejects / spec retains), the autonomous fix-fanout deferral, and the superseded 015 incremental-audit contract.

## Reframing — seam pass is redundant with the compiler

An operator review established that the seam pass reimplements interface-contract checking (removed/renamed export, changed arity, changed required shape) with a regex over diff lines — which for a strongly-typed backend the **compiler** already does completely and across the whole program, including breaks in **unchanged** consumers. The audit-barrage is a **stochastic** defense-in-depth layer on top of the compiler + high-coverage tests; putting a deterministic interface check inside it is a layer confusion.

- New roadmap node `multi:gap/retire-seam-pass-interface-check` captures the reframing (retire the interface check / make compile + tests the deterministic floor; the "unchanged-consumer" gap dissolves by construction rather than getting a disk-reading feature built for it).
- New rule `.claude/rules/audit-barrage-is-stochastic-defense-in-depth.md` records the layer model.

Honest note: this means the seam-pass interface hardening in this PR is slated to be retired as redundant. The fixes are correct given the seam pass exists; they become moot once it's retired. Everything else (pipeline correctness, doc reconciliation, and the chunker test↔source coupling) is independent of the seam pass and stands.

## Verification

- Full suite green: **382 files / 2496 tests** pass.
- `tsc --noEmit` clean except the pre-existing unrelated `src/release/portable.ts` failure (tracked separately).

## Note on scope

The branch also carries 5 prior-session documentation commits (session narratives + a roadmap bookkeeping advance for `bookkeeping-hardening`) that were never merged to `main`; they ride along in this PR.

The backlog tasks for the 16 fixes remain open — closure waits for verification in a formally-installed release.
