### PR TITLE
stack-control backlog hygiene: friction-issue point-fixes

### DIFF
--- a/plugins/stack-control/.stack-control/backlog/tasks/task-106 - AUDIT-20260614-75-—-Empty-rendered-phases-are-treated-as-invalid-instead-of-as-a-valid-zero-byte-boundary.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-106 - AUDIT-20260614-75-—-Empty-rendered-phases-are-treated-as-invalid-instead-of-as-a-valid-zero-byte-boundary.md
@@ -3,9 +3,10 @@ id: TASK-106
 title: >-
   AUDIT-20260614-75 — Empty rendered phases are treated as invalid instead of as
   a valid zero-byte boundary
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-14 18:32'
+updated_date: '2026-06-25 19:19'
 labels:
   - 'type:migrated-finding'
   - 'feature:audit-protocol-friction-burndown'
@@ -17,4 +18,8 @@ priority: medium
 ordinal: 106000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-108 (same empty/zero-byte phase-boundary defect from opposite directions; one boundary fix resolves both).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-113 - AUDIT-20260614-85-—-New-persisted-governance-artifacts-ship-without-any-matching-doctor-schema-surface.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-113 - AUDIT-20260614-85-—-New-persisted-governance-artifacts-ship-without-any-matching-doctor-schema-surface.md
@@ -3,9 +3,10 @@ id: TASK-113
 title: >-
   AUDIT-20260614-85 — New persisted governance artifacts ship without any
   matching doctor/schema surface
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-14 18:32'
+updated_date: '2026-06-25 19:19'
 labels:
   - 'type:migrated-finding'
   - 'feature:audit-protocol-friction-burndown'
@@ -17,10 +18,14 @@ priority: medium
 ordinal: 113000
 ---
 
-
-
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Re-scoped 2026-06-22: phase-checkpoints artifact cited in original finding was deleted by 030 US2 (moot). Surviving gap: fleet-knowledge.yaml ships with only light setup verification (verify.ts:44) and no full schema/doctor rule — same surviving gap as TASK-77. Confirm whether this is a dup of TASK-77; if so, close as dup. Otherwise scope to fleet-knowledge.yaml doctor rule + schema validation only.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-77 (same fleet-knowledge.yaml missing doctor/schema/migration surface; TASK-77 names 113 as the dup candidate).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-116 - Test-fixtures-are-not-hermetic-throwaway-git-repos-inherit-the-operators-commit.gpgsign-and-fail-in-keyless-CI.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-116 - Test-fixtures-are-not-hermetic-throwaway-git-repos-inherit-the-operators-commit.gpgsign-and-fail-in-keyless-CI.md
@@ -3,9 +3,10 @@ id: TASK-116
 title: >-
   Test fixtures are not hermetic: throwaway git repos inherit the operator's
   commit.gpgsign and fail in keyless CI
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-14 19:39'
+updated_date: '2026-06-25 19:53'
 labels:
   - agent-found
   - 'type:bug'
@@ -18,3 +19,9 @@ ordinal: 116000
 <!-- SECTION:DESCRIPTION:BEGIN -->
 ~20 test files (govern integration + session + scope-discovery) create throwaway tmpdir git repos with init+commit but do not disable signing. With a global commit.gpgsign=true (operator setup), these fixtures require an unlocked gpg key and fail in any keyless CI environment with 'gpg failed to sign the data'. Found during 021 burndown when the gpg-agent cache expired mid-session. Fixed the shared _isolation-harness.ts (commit.gpgsign=false + tag.gpgsign=false on fixture repos) but the inline git helpers in govern-orchestration, govern-loop-driver, govern-unresolvable-root, govern-payload-* , and tests/session/* still inherit signing. Add a shared hermetic-git test helper (init + no-sign config) and route all fixture repos through it.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit 28c62033): vitest hermetic git harness (GIT_CONFIG_GLOBAL/SYSTEM -> checked-in hermetic.gitconfig, gpgsign off) makes every throwaway-repo fixture keyless-CI safe; RED-first hermetic-git-fixtures.test.ts; full suite 414 files/2626 tests green.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-138 - Re-enable-spec-audit-barrage-in-the-default-workflow-once-the-spec-audit-protocol-kinks-are-worked-out.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-138 - Re-enable-spec-audit-barrage-in-the-default-workflow-once-the-spec-audit-protocol-kinks-are-worked-out.md
@@ -6,9 +6,11 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-06-16 00:57'
+updated_date: '2026-06-25 19:22'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 ordinal: 138000
 ---
@@ -18,3 +20,9 @@ ordinal: 138000
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Operator decision 2026-06-16: spec-document audit-barrage (govern --mode spec) was parked from the default workflow because the spec-audit protocol on spec documents still has kinks (vs implementation, where audit-barrage stays). 022 keeps the symmetric mode-keyed govern-convergence record MECHANISM but makes the spec-govern gate opt-in: specifying->implementing derives from speckit-analyze-clean by default; governing->shipped (impl-govern) stays required. This item tracks re-enabling the spec-govern gate as default-required once the spec-audit protocol is reliable. Related: TASK-136 (022 parseable-lifecycle-workflow), spec-audit-diminishing-returns rule.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:design:feature/spec-governance
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-150 - stack-control-needs-mechanical-anti-halting-enforcement-for-autonomous-spec-burndown.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-150 - stack-control-needs-mechanical-anti-halting-enforcement-for-autonomous-spec-burndown.md
@@ -6,8 +6,10 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-06-16 23:37'
+updated_date: '2026-06-25 19:22'
 labels:
   - 'type:imported-issue'
+  - promoted
 dependencies: []
 references:
   - gh-470
@@ -196,3 +198,9 @@ These are adjacent but distinct:
 
 Those focus on scoping/fleet/backfill ergonomics. This issue is about the deeper control-loop pathology: the protocol does not mechanically suppress autonomous halting once the burndown is underway.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:impl:feature/autonomous-loop
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-162 - capability-mediation-function-definition-BODY-over-matches-false-refusal-when-a-backend-name-leads-a-body-sub-command.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-162 - capability-mediation-function-definition-BODY-over-matches-false-refusal-when-a-backend-name-leads-a-body-sub-command.md
@@ -3,9 +3,10 @@ id: TASK-162
 title: >-
   capability mediation: function-definition BODY over-matches (false refusal)
   when a backend name leads a body sub-command
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-18 02:28'
+updated_date: '2026-06-25 19:19'
 labels:
   - agent-found
   - 'type:bug'
@@ -18,3 +19,9 @@ ordinal: 162000
 <!-- SECTION:DESCRIPTION:BEGIN -->
 src/capability/identity.ts: a function DEFINITION whose body names a backend after a ; — e.g. 'foo() { :; backlog list; }' — splits on ; into segments, and the body segment ['backlog','list'] resolves argv0='backlog' → matchCapability returns the capability → false refusal. Defining a function is not invoking the backend. The def NAME forms ('function backlog {…}', 'backlog() {…}') ARE handled (round 4). The remaining gap is a backend named INSIDE the body. Fixing needs function-body brace-tracking: on a function opener (NAME() or 'function NAME') skip tokens until the matching '}'. Deferred at the round-6 plateau (spec-audit-diminishing-returns) — it is a MEDIUM, rare false-refusal (no US3 backstop, but low frequency: defining a shell function whose body's first post-; command is a fronted backend). Documented in the identity.ts header limitation block. Found: 026 Phase-2 govern round 6, AUDIT-BARRAGE-codex-02. Anchor-unification / parser-hardening follow-on.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-163 (the bash tokenizer-extraction refactor is the precondition+unit for the BODY over-match fix; 163 enumerates 162 as its residual edge).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-188 - AUDIT-20260618-139-—-`-at`-consumes-a-following-flag-as-its-value-instead-of-rejecting-it.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-188 - AUDIT-20260618-139-—-`-at`-consumes-a-following-flag-as-its-value-instead-of-rejecting-it.md
@@ -3,9 +3,10 @@ id: TASK-188
 title: >-
   AUDIT-20260618-139 — `--at` consumes a following flag as its value instead of
   rejecting it
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-18 05:39'
+updated_date: '2026-06-25 20:13'
 labels:
   - 'type:migrated-finding'
   - 'feature:026-capability-interface-mediation'
@@ -17,4 +18,8 @@ priority: low
 ordinal: 188000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit pending-hash): reconcileVerb --at now rejects a following flag (startsWith('--')) instead of swallowing it into a false all-clean. RED-first capability-reconcile.test.ts; tsc green.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-296 - govern-clone-step-make-clone-DETECTION-language-aware-multilingual-jscpd-formats-not-just-TS-TSX.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-296 - govern-clone-step-make-clone-DETECTION-language-aware-multilingual-jscpd-formats-not-just-TS-TSX.md
@@ -6,9 +6,11 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-06-19 06:15'
+updated_date: '2026-06-25 19:26'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 ordinal: 296000
 ---
@@ -18,3 +20,9 @@ ordinal: 296000
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Follow-on to TASK-295 (the non-fatal-on-zero-files fix that unblocked non-TS adopters by making govern proceed). That fix left clone DETECTION TS/TSX-only: a non-TypeScript adopter (offing Bash/PHP/WordPress) gets govern working but no clone advisory at all. This item is the OTHER option the roadmap node impl:fix/govern-clone-step-language-agnostic listed: detect/extend jscpd --format so common adopter languages (php, bash, python, go, java, etc.) are actually scanned for duplication. Deferred by operator 2026-06-19 (chose non-fatal-only for the customer unblock). Blast radius to scope before doing: which formats to enable, per-adopter clones.yaml baseline churn when new non-TS groups surface, and whether format selection should auto-detect from the tree vs a fixed broad list.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:design:gap/scope-discovery-v2-expansion
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-339 - AUDIT-20260620-28-—-Integration-gap-`renderQuietSection`-degraded-branch-is-not-tested-through-the-render→parse-contract.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-339 - AUDIT-20260620-28-—-Integration-gap-`renderQuietSection`-degraded-branch-is-not-tested-through-the-render→parse-contract.md
@@ -3,9 +3,10 @@ id: TASK-339
 title: >-
   AUDIT-20260620-28 — Integration gap: `renderQuietSection` degraded branch is
   not tested through the render→parse contract
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-20 08:27'
+updated_date: '2026-06-25 19:19'
 labels:
   - 'type:migrated-finding'
   - 'feature:029-govern-operability'
@@ -17,4 +18,8 @@ priority: medium
 ordinal: 339000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-356 (one renderQuietSection render->parse integration test; 356 is the cross-model version carrying the concrete assertion).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-340 - AUDIT-20260620-29-—-Stale-comment-degraded0-findings-branch-above-already-records-nothing-is-wrong-after-fix-commit.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-340 - AUDIT-20260620-29-—-Stale-comment-degraded0-findings-branch-above-already-records-nothing-is-wrong-after-fix-commit.md
@@ -3,9 +3,10 @@ id: TASK-340
 title: >-
   AUDIT-20260620-29 — Stale comment: "degraded+0-findings branch above already
   records nothing" is wrong after fix commit
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-20 08:27'
+updated_date: '2026-06-25 19:19'
 labels:
   - 'type:migrated-finding'
   - 'feature:029-govern-operability'
@@ -17,4 +18,8 @@ priority: low
 ordinal: 340000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-351 (one stale-comment/JSDoc sync across audit-barrage-lift-render + audit-barrage-lift; 351 names both surfaces).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-342 - AUDIT-20260620-31-—-Stale-JSDoc-on-`renderQuietSection`-directly-contradicts-new-implementation.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-342 - AUDIT-20260620-31-—-Stale-JSDoc-on-`renderQuietSection`-directly-contradicts-new-implementation.md
@@ -3,9 +3,10 @@ id: TASK-342
 title: >-
   AUDIT-20260620-31 — Stale JSDoc on `renderQuietSection` directly contradicts
   new implementation
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-20 08:27'
+updated_date: '2026-06-25 19:19'
 labels:
   - 'type:migrated-finding'
   - 'feature:029-govern-operability'
@@ -17,4 +18,8 @@ priority: medium
 ordinal: 342000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-351 (same stale JSDoc/comment sync on renderQuietSection; folded into 351).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-354 - No-grounding-claude-sonnet-audit-lane-intermittently-times-out-420s-on-larger-per-phase-payloads-specs-029-phase-3-degraded-rounds-block-convergence.-Extended-thinking-vari.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-354 - No-grounding-claude-sonnet-audit-lane-intermittently-times-out-420s-on-larger-per-phase-payloads-specs-029-phase-3-degraded-rounds-block-convergence.-Extended-thinking-vari.md
@@ -5,10 +5,10 @@ title: >-
   larger per-phase payloads (specs/029 phase-3) -> degraded rounds block
   convergence. Extended-thinking varies run-to-run. Consider
   payload-scaled/adaptive per-lane timeout (US1 follow-on).
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-20 10:39'
-updated_date: '2026-06-20 10:39'
+updated_date: '2026-06-25 19:19'
 labels:
   - agent-found
   - 'type:gap'
@@ -16,10 +16,14 @@ dependencies: []
 ordinal: 354000
 ---
 
-
-
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Re-scoped 2026-06-22: per-phase payload framing is obsolete (per-phase govern deleted by 030). Surviving gap: the liveness window is not payload-scaled — whole-feature chunk payloads can be just as large as the per-phase payloads that triggered the timeout. timeout-derivation.ts scales the floor but not the liveness window; the fixed 300s window leaves extended-thinking models vulnerable on large chunks. Fix: scale the per-lane liveness window proportionally to estimated payload size (or adopt the adaptive mechanism that timeout_secs_per_kb already provides for floor). Near-duplicate of TASK-324 root (same file: timeout-derivation.ts); consider folding.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-324 (identical liveness-window-not-payload-scaled root in timeout-derivation; TASK-354 body itself proposes folding into 324).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-389 - tsc-noEmit-fails-on-src-release-portable.ts-Property-source-path-does-not-exist-on-type-object-~lines-100-107-on-a-clean-tree-—-typecheck-gate-not-green-pre-existing-unrel.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-389 - tsc-noEmit-fails-on-src-release-portable.ts-Property-source-path-does-not-exist-on-type-object-~lines-100-107-on-a-clean-tree-—-typecheck-gate-not-green-pre-existing-unrel.md
@@ -4,10 +4,10 @@ title: >-
   tsc --noEmit fails on src/release/portable.ts (Property source/path does not
   exist on type object, ~lines 100/107) on a clean tree — typecheck gate not
   green; pre-existing, unrelated to 029
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-21 01:28'
-updated_date: '2026-06-21 01:28'
+updated_date: '2026-06-25 19:47'
 labels:
   - agent-found
   - 'type:bug'
@@ -15,4 +15,8 @@ dependencies: []
 ordinal: 389000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit 37b0b615): isRecord guard narrows Codex marketplace source; tsc --noEmit green, release-portability.test.ts passing.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-409 - 030-analyze-F2-LOW-headSha-at-audit-time-ambiguous-as-fix-commits-advance-HEAD-mid-run.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-409 - 030-analyze-F2-LOW-headSha-at-audit-time-ambiguous-as-fix-commits-advance-HEAD-mid-run.md
@@ -6,7 +6,7 @@ title: >-
 status: Done
 assignee: []
 created_date: '2026-06-21 17:57'
-updated_date: '2026-06-25 19:19'
+updated_date: '2026-06-25 20:24'
 labels:
   - agent-found
   - 'type:gap'
@@ -26,4 +26,6 @@ data-model.md:119 headSha is HEAD at audit time, but FR-009 autonomous apply+com
 
 <!-- SECTION:NOTES:BEGIN -->
 Closed: Duplicate of TASK-450 (same convergence-record headSha fidelity: symbolic HEAD / mid-run HEAD advance). One headSha-resolved-at-audit-time fix closes both.
+
+Closed: Resolved with TASK-450 (commit eddcfdb4): specs/030 data-model.md now documents headSha as the concrete final-HEAD of base..headSha resolved at record-write time, removing the at-audit-time ambiguity. Implementation pins it via resolveHeadSha.
 <!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-409 - 030-analyze-F2-LOW-headSha-at-audit-time-ambiguous-as-fix-commits-advance-HEAD-mid-run.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-409 - 030-analyze-F2-LOW-headSha-at-audit-time-ambiguous-as-fix-commits-advance-HEAD-mid-run.md
@@ -3,9 +3,10 @@ id: TASK-409
 title: >-
   030 analyze F2 (LOW): headSha at-audit-time ambiguous as fix commits advance
   HEAD mid-run
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-21 17:57'
+updated_date: '2026-06-25 19:19'
 labels:
   - agent-found
   - 'type:gap'
@@ -20,3 +21,9 @@ ordinal: 409000
 <!-- SECTION:DESCRIPTION:BEGIN -->
 data-model.md:119 headSha is HEAD at audit time, but FR-009 autonomous apply+commit advances HEAD mid-run. Ambiguous whether headSha is run-start HEAD (chunk membership frozen, content refreshed — what TouchedSet implies) or post-fix HEAD. FR-004 determinism is phrased for re-runs, not within-run rounds. Fix: state chunk membership is frozen at run-start governedSha..HEAD; re-audit refreshes touched-chunk content only.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-450 (same convergence-record headSha fidelity: symbolic HEAD / mid-run HEAD advance). One headSha-resolved-at-audit-time fix closes both.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-424 - Wire-FR-009-autonomous-fix-fanout-backend-deferred-from-US9.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-424 - Wire-FR-009-autonomous-fix-fanout-backend-deferred-from-US9.md
@@ -4,9 +4,11 @@ title: Wire FR-009 autonomous fix-fanout backend (deferred from US9)
 status: To Do
 assignee: []
 created_date: '2026-06-22 02:50'
+updated_date: '2026-06-25 19:22'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 ordinal: 424000
 ---
@@ -16,3 +18,9 @@ ordinal: 424000
 <!-- SECTION:DESCRIPTION:BEGIN -->
 US9 (030) wired the chunked end-govern AUDIT system with agent-in-the-loop fix (govern audits, surfaces override-eligible, the driving agent fixes, re-govern); applyFixes is undefined at the CLI. FR-009 autonomous govern-dispatched fix (real FixRunner: headless fix-subagent dispatch + git worktree lifecycle; real MergeAttempt: conflict-aware merge) is UNBUILT (worktree-dispatch.ts/merge-serialize.ts are orchestration over injected deps only). Operator deferred 2026-06-22. Revisit: build the backend OR amend spec to adopt agent-in-the-loop fix as canonical (execute already provides a fix loop).
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:impl:feature/autonomous-loop
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-443 - govern-has-no-first-class-audit-an-arbitrary-non-spec-diff-front-door-—-barraging-a-non-spec-session-diff-needs-hand-assembled-payload.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-443 - govern-has-no-first-class-audit-an-arbitrary-non-spec-diff-front-door-—-barraging-a-non-spec-session-diff-needs-hand-assembled-payload.md
@@ -6,9 +6,11 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-06-22 21:07'
+updated_date: '2026-06-25 19:22'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 ordinal: 442000
 ---
@@ -18,3 +20,9 @@ ordinal: 442000
 <!-- SECTION:DESCRIPTION:BEGIN -->
 govern --mode implement is structurally coupled to a spec feature (resolveFeatureSlug/resolveFeatureFromItem require a spec dir + write to that feature's audit-log.md). A point-fix/bookkeeping session diff spans multiple subsystems with no spec and no spec: pointer on its umbrella roadmap node, so govern cannot run on it. To realize 'govern the session diff' (2026-06-22 bookkeeping-hardening session) the operator had to hand-assemble the audit-barrage payload: git diff base..HEAD -> vars.json (7 EXPECTED_VARS keys) -> audit-barrage-render -> audit-barrage --prompt-file. Suggested: a first-class 'govern/barrage an arbitrary diff' entry (e.g. govern --diff-only --diff-base <ref> --feature <label>, or an audit-barrage --diff-base convenience that assembles the payload) so non-spec diffs get the same cross-model audit without manual payload assembly.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:multi:feature/migrate-audit-barrage
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-447 - 032-validating-gate-had-no-mechanical-record-path-—-added-roadmap-approve-design-validated.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-447 - 032-validating-gate-had-no-mechanical-record-path-—-added-roadmap-approve-design-validated.md
@@ -3,10 +3,10 @@ id: TASK-447
 title: >-
   032 validating gate had no mechanical record path â€” added roadmap
   approve-design --validated
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-24 01:30'
-updated_date: '2026-06-24 01:30'
+updated_date: '2026-06-25 19:19'
 labels:
   - agent-found
   - 'type:gap'
@@ -24,4 +24,6 @@ Found dogfooding the ship of multi:feature/ship-stage: 032 added the validatingâ
 
 <!-- SECTION:NOTES:BEGIN -->
 - **Node:** multi:feature/ship-stage
+
+Closed: Already fixed: commit 76c86be3 landed roadmap approve-design --validated marker + close-skill wiring (commit message names TASK-447)
 <!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-448 - stackctl-roadmap-reconcile-unorphan-mints-a-duplicate-node-instead-of-reusing-the-existing-correspondence.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-448 - stackctl-roadmap-reconcile-unorphan-mints-a-duplicate-node-instead-of-reusing-the-existing-correspondence.md
@@ -1,0 +1,80 @@
+---
+id: TASK-448
+title: >-
+  stackctl roadmap reconcile --unorphan mints a duplicate node instead of
+  reusing the existing correspondence
+status: To Do
+assignee: []
+created_date: '2026-06-25 19:02'
+labels:
+  - 'type:imported-issue'
+dependencies: []
+references:
+  - gh-506
+ordinal: 447000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Summary
+
+`stackctl roadmap reconcile --unorphan <spec-dir>` mints a **new** roadmap node even when an
+existing node already corresponds to that spec, producing two nodes for one spec dir. The operator
+must then `roadmap remove-node` the duplicate by hand. Unorphan should reuse/attach to an existing
+node's correspondence rather than create a parallel one.
+
+## Environment
+
+- stack-control plugin (deskwork cache) version 0.55.1; `stackctl` on PATH
+- Host: macOS (darwin 24.6.0), run from the installation root
+- Roadmap model: one long-lived `main` branch, numbered spec dirs under `specs/`
+
+## Reproduction
+
+Starting state: an existing roadmap node `design:feature/faithful-capture-substrate` (with a
+`design:` design record + `design-approved: yes`) and a spec dir
+`specs/010-faithful-capture-substrate` that `reconcile` reports as an orphan (no correspondence
+recorded yet):
+
+```
+$ stackctl roadmap reconcile
+  orphan spec dirs: 1
+    - specs/010-faithful-capture-substrate
+
+$ stackctl roadmap reconcile --unorphan specs/010-faithful-capture-substrate --apply
+roadmap reconcile --unorphan: resolved specs/010-faithful-capture-substrate into a node
+```
+
+The ROADMAP.md diff shows a brand-new node was appended:
+
+```
++## impl:feature/010-faithful-capture-substrate
++- status: planned
++- spec: specs/010-faithful-capture-substrate
+```
+
+…even though `design:feature/faithful-capture-substrate` is the real node for this feature (the
+design record is literally `…faithful-capture-substrate-design.md`). Result: two nodes for one
+spec. The workaround was to set the spec pointer on the design node manually
+(`workflow link-spec design:feature/faithful-capture-substrate specs/010-... --apply`) and then
+`roadmap remove-node impl:feature/010-faithful-capture-substrate --apply`.
+
+## Expected
+
+When a node already plausibly corresponds to the orphan spec (e.g. a `*:feature/<slug>` node whose
+slug matches the spec dir's slug, or whose `design:` pointer is in the same feature family),
+`--unorphan` should attach the spec pointer to that existing node — or, at minimum, detect the
+likely-existing correspondence and refuse/prompt rather than silently minting a parallel
+`impl:feature/<NNN-slug>` node that the operator must then reconcile away.
+
+## Impact
+
+Medium friction: it silently doubles the node count for a feature and leaves the roadmap
+internally inconsistent (two nodes, two phase states) until the operator notices and removes the
+duplicate. An agent following the reconcile flow could easily proceed against the wrong node.
+
+## Surfaced by
+
+Reconciling spec-010 (faithful-capture-substrate) before `/stack-control:execute`, 2026-06-25.
+<!-- SECTION:DESCRIPTION:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-448 - stackctl-roadmap-reconcile-unorphan-mints-a-duplicate-node-instead-of-reusing-the-existing-correspondence.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-448 - stackctl-roadmap-reconcile-unorphan-mints-a-duplicate-node-instead-of-reusing-the-existing-correspondence.md
@@ -3,9 +3,10 @@ id: TASK-448
 title: >-
   stackctl roadmap reconcile --unorphan mints a duplicate node instead of
   reusing the existing correspondence
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-25 19:02'
+updated_date: '2026-06-25 20:30'
 labels:
   - 'type:imported-issue'
 dependencies: []
@@ -78,3 +79,9 @@ duplicate. An agent following the reconcile flow could easily proceed against th
 
 Reconciling spec-010 (faithful-capture-substrate) before `/stack-control:execute`, 2026-06-25.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit 10100480): reconcile --unorphan now matches an existing node by slug family and attaches the spec (setField) instead of minting a duplicate; refuses zero-write on ambiguous/clobbering matches; mint path preserved when no match. RED-first reconcile-unorphan.test.ts; full suite 415/2645 green. gh-506 open pending release verification.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-449 - stackctl-execute-check-rejects-the-relative-spec-path-that-spec-check-accepts-requires-absolute.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-449 - stackctl-execute-check-rejects-the-relative-spec-path-that-spec-check-accepts-requires-absolute.md
@@ -3,9 +3,10 @@ id: TASK-449
 title: >-
   stackctl execute-check rejects the relative --spec path that spec-check
   accepts (requires absolute)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-25 19:02'
+updated_date: '2026-06-25 20:13'
 labels:
   - 'type:imported-issue'
 dependencies: []
@@ -64,3 +65,9 @@ execute skill invokes back-to-back, and the FATAL wording ("spec dir not found")
 
 Driving `/stack-control:execute` on spec-010 (faithful-capture-substrate), 2026-06-25.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit a301128a): shared resolveSpecDir() — spec-check and execute-check resolve --spec identically; cwd-relative preserved, install-root-relative rescue so specs/NNN works from any subdir. RED-first spec-dir-resolution.test.ts; full suite 415/2637 green. gh-505 stays open pending release verification.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-449 - stackctl-execute-check-rejects-the-relative-spec-path-that-spec-check-accepts-requires-absolute.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-449 - stackctl-execute-check-rejects-the-relative-spec-path-that-spec-check-accepts-requires-absolute.md
@@ -1,0 +1,66 @@
+---
+id: TASK-449
+title: >-
+  stackctl execute-check rejects the relative --spec path that spec-check
+  accepts (requires absolute)
+status: To Do
+assignee: []
+created_date: '2026-06-25 19:02'
+labels:
+  - 'type:imported-issue'
+dependencies: []
+references:
+  - gh-505
+ordinal: 448000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Summary
+
+`stackctl execute-check --spec <dir>` resolves its `--spec` path differently than its sibling
+`stackctl spec-check --spec <dir>`. In the same front-door flow, `spec-check` accepts a
+repo-relative path while `execute-check` rejects the identical value as "not found" and requires an
+absolute path. Two sibling verbs in the same `/stack-control:execute` gate sequence should resolve
+the same path argument the same way.
+
+## Environment
+
+- stack-control plugin (deskwork cache) version 0.55.1 / 0.53.2 skills; `stackctl` on PATH
+- Host: macOS (darwin 24.6.0), run from the repo root of a stack-control installation
+- Installation root: repo root containing `.stack-control/config.yaml`, spec dirs under `specs/`
+
+## Reproduction
+
+From the installation root (`/Users/orion/work/offing`), with spec dir
+`specs/010-faithful-capture-substrate` present and runnable (`tasks.md` exists):
+
+```
+$ stackctl spec-check --spec specs/010-faithful-capture-substrate
+spec=yes plan=yes tasks=yes            # exit 0 — repo-relative path accepted
+
+$ stackctl execute-check --spec specs/010-faithful-capture-substrate
+execute-check: FATAL — spec dir specs/010-faithful-capture-substrate not found   # exit 1
+
+$ stackctl execute-check --spec "$(pwd)/specs/010-faithful-capture-substrate"
+runnable                                # exit 0 — only the ABSOLUTE path works
+```
+
+## Expected
+
+`execute-check` accepts the same repo-relative `--spec` value `spec-check` does (resolve both
+relative to the installation root, or document the difference). As-is, an agent following the
+`/stack-control:execute` skill — which calls `spec-check` then `execute-check` with the same path —
+hits a spurious FATAL on the second call and must discover the absolute-path workaround.
+
+## Impact
+
+Low severity but high friction: it breaks the obvious copy-the-same-arg flow between two verbs the
+execute skill invokes back-to-back, and the FATAL wording ("spec dir not found") misleads toward
+"the spec is missing" rather than "this verb wants an absolute path."
+
+## Surfaced by
+
+Driving `/stack-control:execute` on spec-010 (faithful-capture-substrate), 2026-06-25.
+<!-- SECTION:DESCRIPTION:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-450 - govern-convergence-record-headSha-stored-as-symbolic-HEAD-rounds-1-contradicts-multi-round-range-—-and-the-record-is-self-audited-every-round.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-450 - govern-convergence-record-headSha-stored-as-symbolic-HEAD-rounds-1-contradicts-multi-round-range-—-and-the-record-is-self-audited-every-round.md
@@ -1,0 +1,58 @@
+---
+id: TASK-450
+title: >-
+  govern convergence-record: headSha stored as symbolic 'HEAD' + rounds:1
+  contradicts multi-round range — and the record is self-audited every round
+status: To Do
+assignee: []
+created_date: '2026-06-25 19:02'
+labels:
+  - 'type:imported-issue'
+dependencies: []
+references:
+  - gh-502
+ordinal: 449000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Summary
+
+The cross-model audit-barrage, run via `stackctl govern --mode implement`, audits the **committed
+working tree** of the feature — which includes `stackctl`'s OWN governance convergence record
+(`.stack-control/govern/convergence/<item>.json`). Two structural defects in how that record is
+written cause the barrage to flag the record **every round**, so a govern loop driven purely by
+fixing the *feature* can never converge to clean — the audit keeps finding the same two issues in
+the harness's own artifact.
+
+## The two defects (both cross-model agreement, HIGH)
+
+1. **`"headSha": "HEAD"` — a symbolic ref, not a resolved SHA.**
+   The record pins the base concretely (`"governedShaBase": "1a93fd1"`) but stores the head as the
+   literal string `"HEAD"`. The moment another commit lands, `HEAD` no longer resolves to the commit
+   the run actually covered. A committed audit artifact whose job is "what range was governed?" is
+   non-reproducible. Fix: resolve and store the abbreviated/40-char SHA of HEAD at govern time,
+   symmetric with `governedShaBase`.
+
+2. **`"rounds": 1` contradicts the governed commit range.**
+   With `--ceiling 1`, each `govern` invocation records `"rounds": 1`, but a multi-invocation
+   fix→re-govern loop produces a commit range spanning several rounds (e.g. `…resolve govern
+   findings`, `…resolve round-2 govern findings`). A downstream consumer (`re-audit-fixed-findings`,
+   a release gate) reading `rounds: 1` + open `liftedFindings` would conclude earlier rounds never
+   ran. The record reflects only the latest invocation, not the cumulative converged state.
+
+## Why it matters
+
+The barrage including the harness's own freshly-written record means these two findings re-surface
+on every re-govern regardless of feature changes — a structural non-convergence. They are not
+defects in the audited *feature*; they are defects in the governance record format/writer.
+
+## Suggested fixes
+
+- Resolve `headSha` to a concrete commit SHA at write time.
+- Either make `rounds` cumulative across invocations for the same governed item, or document that it
+  is per-invocation and have consumers treat the record as the latest-state snapshot.
+- Consider excluding `.stack-control/govern/**` (the harness's own outputs) from the audited payload,
+  so the barrage audits the feature, not its own bookkeeping.
+<!-- SECTION:DESCRIPTION:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-450 - govern-convergence-record-headSha-stored-as-symbolic-HEAD-rounds-1-contradicts-multi-round-range-—-and-the-record-is-self-audited-every-round.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-450 - govern-convergence-record-headSha-stored-as-symbolic-HEAD-rounds-1-contradicts-multi-round-range-—-and-the-record-is-self-audited-every-round.md
@@ -3,9 +3,10 @@ id: TASK-450
 title: >-
   govern convergence-record: headSha stored as symbolic 'HEAD' + rounds:1
   contradicts multi-round range — and the record is self-audited every round
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-25 19:02'
+updated_date: '2026-06-25 20:24'
 labels:
   - 'type:imported-issue'
 dependencies: []
@@ -56,3 +57,9 @@ defects in the audited *feature*; they are defects in the governance record form
 - Consider excluding `.stack-control/govern/**` (the harness's own outputs) from the audited payload,
   so the barrage audits the feature, not its own bookkeeping.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit eddcfdb4): resolveHeadSha pins the record's headSha to a concrete SHA (base..final-HEAD); .stack-control/govern excluded from the audited diff (root fix for self-audit non-convergence); rounds documented per-invocation. RED-first payload-diff-scope.test.ts; full suite 415/2641 green. gh-502 open pending release verification.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-451 - govern-start-governing-gate-tasks-complete-blocks-on-manual-operator-acceptance-tasks-—-inverts-audit-before-acceptance.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-451 - govern-start-governing-gate-tasks-complete-blocks-on-manual-operator-acceptance-tasks-—-inverts-audit-before-acceptance.md
@@ -1,0 +1,56 @@
+---
+id: TASK-451
+title: >-
+  govern start-governing gate (tasks-complete) blocks on manual
+  operator-acceptance tasks — inverts audit-before-acceptance
+status: To Do
+assignee: []
+created_date: '2026-06-25 19:02'
+labels:
+  - 'type:imported-issue'
+dependencies: []
+references:
+  - gh-501
+ordinal: 450000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Summary
+
+The `start-governing` exit gate (`tasks-complete spec`) counts **every** `- [ ]` checkbox in
+`tasks.md`, including tasks that are inherently **manual, operator-executed acceptances** that should
+run *after* the cross-model govern pass — not before it. This inverts audit-before-acceptance and
+blocks `stackctl govern --mode implement` on work the implementing agent cannot (and should not) do.
+
+## Where
+
+- `src/workflow/gate-eval.ts` → `tasksComplete()` matches `^\s*-\s+\[( |x|X)\]` and requires
+  `done === total`.
+- The `governing` phase entry refuses with `verdict 'ahead' ... exit gate is unmet (tasks-complete spec)`
+  while any checkbox is unchecked.
+
+## Concrete case (offing, spec 007 capture-fidelity)
+
+`specs/007-capture-fidelity/tasks.md` ended with T001–T014 (the full hermetic implementation,
+committed + suite-green) plus **T015 = "Operator live re-bless (manual, read-only) ... Final
+acceptance (SC-005)"** — a live-production operation the operator runs by hand. With T015 unchecked,
+`stackctl govern --mode implement` refused (`tasks-complete` unmet), even though the *code* was ready
+to audit. The code audit logically belongs **before** the operator spends a live-prod run; the gate
+forced the opposite order.
+
+## Workaround used
+
+Relocated T015 out of the gated checkbox list into a non-checkbox "Acceptance (operator-executed,
+post-govern)" section, clearly marked **PENDING** (not faked-done, not deleted). This satisfied the
+gate honestly (all *implementation* tasks complete) without `--override`. It works, but it relies on
+authors knowing the gate only counts `- [ ]` lines — fragile and non-obvious.
+
+## Suggested fix
+
+Give `tasks.md` a first-class way to mark a task as a **manual/operator acceptance** that the
+`tasks-complete` gate excludes — e.g. a recognized marker (`- [~]` deferred / `- [manual]`) or a
+designated "Acceptance" section the parser skips — so audit-before-live-acceptance is the default and
+authors don't have to hand-roll a non-checkbox bullet to avoid gaming the count.
+<!-- SECTION:DESCRIPTION:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-451 - govern-start-governing-gate-tasks-complete-blocks-on-manual-operator-acceptance-tasks-—-inverts-audit-before-acceptance.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-451 - govern-start-governing-gate-tasks-complete-blocks-on-manual-operator-acceptance-tasks-—-inverts-audit-before-acceptance.md
@@ -3,9 +3,10 @@ id: TASK-451
 title: >-
   govern start-governing gate (tasks-complete) blocks on manual
   operator-acceptance tasks — inverts audit-before-acceptance
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-25 19:02'
+updated_date: '2026-06-25 20:01'
 labels:
   - 'type:imported-issue'
 dependencies: []
@@ -54,3 +55,9 @@ Give `tasks.md` a first-class way to mark a task as a **manual/operator acceptan
 designated "Acceptance" section the parser skips — so audit-before-live-acceptance is the default and
 authors don't have to hand-roll a non-checkbox bullet to avoid gaming the count.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit 2cfe8fe4): explicit classifyTasks() — [~]/[-] manual-acceptance markers excluded from the tasks-complete gate (audit-before-acceptance), unrecognized markers no longer silently dropped; documented in execute SKILL.md. RED-first gate-eval.test.ts; full suite 414/2630 green. gh-499/gh-501 stay open pending release verification (operator call).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-452 - design-to-spec-gate-solution-space-alternatives-counts-bullet-lines-not-subsections-silent-N-1-N-no-hint.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-452 - design-to-spec-gate-solution-space-alternatives-counts-bullet-lines-not-subsections-silent-N-1-N-no-hint.md
@@ -3,9 +3,10 @@ id: TASK-452
 title: >-
   design-to-spec gate: solution-space-alternatives counts bullet lines, not ###
   subsections (silent N-1/N, no hint)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-25 19:02'
+updated_date: '2026-06-25 20:05'
 labels:
   - 'type:imported-issue'
 dependencies: []
@@ -50,3 +51,9 @@ A correctly-structured design record fails the gate for a purely cosmetic reason
 - stack-control 0.53.0 (deskwork plugin cache), `plugins/stack-control/src/workflow/gate-eval.ts`.
 - Surfaced authoring the `design:feature/capture-fidelity` record in `~/work/offing`, 2026-06-23.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Fixed on feature/stack-control-hygiene (commit af9c4a0a): countSolutionSpaceAlternatives now counts ### subsections (precedence over detail bullets, no double-count); describeCriterion + design SKILL.md spell out the rule. RED-first gate-eval.test.ts; workflow suite green. gh-500 stays open pending release verification (operator call).
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-452 - design-to-spec-gate-solution-space-alternatives-counts-bullet-lines-not-subsections-silent-N-1-N-no-hint.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-452 - design-to-spec-gate-solution-space-alternatives-counts-bullet-lines-not-subsections-silent-N-1-N-no-hint.md
@@ -1,0 +1,52 @@
+---
+id: TASK-452
+title: >-
+  design-to-spec gate: solution-space-alternatives counts bullet lines, not ###
+  subsections (silent N-1/N, no hint)
+status: To Do
+assignee: []
+created_date: '2026-06-25 19:02'
+labels:
+  - 'type:imported-issue'
+dependencies: []
+references:
+  - gh-500
+ordinal: 451000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Summary
+
+The `design-to-spec` exit gate's `count-gte solution-space-alternatives 2` criterion counts **bullet lines** (`- ` / `* `) inside the `## Solution space` section of a design record — it does **not** count `### Chosen …` / `### Rejected …` subsection headings. A design record that lists its alternatives as `###` subsections (a natural, readable structure) scores **0** alternatives and the `designing` exit gate sits at N−1/N with the unhelpful line:
+
+```
+[ ] count-gte solution-space-alternatives 2
+```
+
+There is no hint that the counter wants bullets, so the author has to read `plugins/stack-control/src/workflow/gate-eval.ts` (`countSolutionSpaceAlternatives`) to discover the rule.
+
+## Reproduction
+
+1. `/stack-control:design <item>`; write a design record whose `## Solution space` section presents alternatives only as `### Chosen — (A) …` / `### Rejected — (B) …` subsections with prose (no top-level bullets).
+2. Record `design-approved`.
+3. `stackctl workflow status <item>` → `designing` shows `6 of 7` (or N−1/N) with `[ ] count-gte solution-space-alternatives 2`, despite the record clearly listing ≥2 alternatives.
+
+`countSolutionSpaceAlternatives` (gate-eval.ts) scans from the `solution-space` heading to the next same-or-higher heading and counts only lines matching `^\s*[-*]\s+\S` — so `###` subsections contribute nothing.
+
+## Impact
+
+A correctly-structured design record fails the gate for a purely cosmetic reason; the failure message gives no clue about the fix. Cost is a code-spelunking detour per author who hits it.
+
+## Possible directions
+
+- Also count `###` subsections within the `solution-space` section as alternatives (or `### Chosen`/`### Rejected` headings specifically).
+- Or make the failing-criterion message say what it counts (e.g. "needs ≥2 bullet items under `## Solution space`").
+- Or document the bullet-counting convention in the `/stack-control:design` skill body.
+
+## Environment
+
+- stack-control 0.53.0 (deskwork plugin cache), `plugins/stack-control/src/workflow/gate-eval.ts`.
+- Surfaced authoring the `design:feature/capture-fidelity` record in `~/work/offing`, 2026-06-23.
+<!-- SECTION:DESCRIPTION:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-453 - govern-mode-implement-tasks-complete-gate-refuses-when-the-only-open-task-is-a-manual-operator-acceptance-forces-govern-after-live.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-453 - govern-mode-implement-tasks-complete-gate-refuses-when-the-only-open-task-is-a-manual-operator-acceptance-forces-govern-after-live.md
@@ -1,0 +1,59 @@
+---
+id: TASK-453
+title: >-
+  govern --mode implement: tasks-complete gate refuses when the only open task
+  is a manual operator-acceptance (forces govern-after-live)
+status: Done
+assignee: []
+created_date: '2026-06-25 19:02'
+updated_date: '2026-06-25 19:19'
+labels:
+  - 'type:imported-issue'
+dependencies: []
+references:
+  - gh-499
+ordinal: 452000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Summary
+
+`stackctl govern --mode implement` refuses with compass verdict `ahead` (`tasks-complete spec` unmet) when the **only** open item in `tasks.md` is a **manual operator-acceptance task** — e.g. an "operator live re-bless (manual, read-only)" task that, by design, a coding agent cannot complete in-session. This forces governance to run *after* the live operation, when the natural order is to audit the code *before* asking the operator to run it against production.
+
+This is the same class as the previously-noted TASK-180; it recurred against a fresh feature (spec 006 capture-robustness, task T019) on 2026-06-23.
+
+## Reproduction
+
+1. Author a feature whose `tasks.md` ends with a manual operator-only acceptance task (e.g. `T019 Operator live re-bless (manual, read-only)`).
+2. Implement and commit every other (code) task; the manual task stays `- [ ]`.
+3. Run `stackctl govern --mode implement --item <id> --diff-base <pre-feature-sha>`.
+
+**Observed:** 
+```
+govern: REFUSED — compass verdict 'ahead' for '<item>': 'governing' targets the legitimate next phase 'governing', but its exit gate is unmet (tasks-complete spec) — complete the current phase's work first
+govern: terminal-outcome=fatal
+```
+The whole-feature cross-model audit never runs, even though all *code* tasks are complete and committed. `--override` is the prohibited offroad, so there is no sanctioned way to govern the code before the manual live step.
+
+## Impact
+
+You cannot get a cross-model code audit of the implementation before the operator runs the (often expensive, outward-facing, hard-to-reverse) live acceptance. The audit that would catch a defect before the live run is gated behind the live run.
+
+## Possible directions
+
+- Let `tasks-complete` distinguish **agent-completable** tasks from **manual/operator-acceptance** tasks (e.g. a `[manual]`/`[operator]` marker that the gate excludes, or counts as satisfied-for-govern), so govern can run once all code tasks are done.
+- Or a sanctioned "govern the code now, the manual acceptance is tracked separately" path that is not `--override`.
+
+## Environment
+
+- stack-control 0.53.0 (deskwork plugin cache).
+- Surfaced in `~/work/offing` (the prod-baseline thread), feature spec 006 task T019.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed: Duplicate of TASK-451 (same gate-eval.ts tasksComplete() defect: counts manual operator-acceptance checkboxes). gh-499 tracked here; canonical TASK-451 carries gh-501. Fix once, closes both issues.
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-6 - scope-discovery-v2-enhancement-class-discovery-agents-dom-visual-walker-a11y-audit-vestigial-copy-audit-component-roster.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-6 - scope-discovery-v2-enhancement-class-discovery-agents-dom-visual-walker-a11y-audit-vestigial-copy-audit-component-roster.md
@@ -6,13 +6,19 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-06-10 10:03'
+updated_date: '2026-06-25 19:26'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 references:
   - specs/010-migrate-scope-discovery (Captured for future expansion)
 ordinal: 6000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:design:gap/scope-discovery-v2-expansion
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-7 - scope-discovery-cross-language-scanner-packs-.go-.py-.rs-.kt-.java-via-the-customize-seam.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-7 - scope-discovery-cross-language-scanner-packs-.go-.py-.rs-.kt-.java-via-the-customize-seam.md
@@ -6,13 +6,19 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-06-10 10:03'
+updated_date: '2026-06-25 19:26'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 references:
   - specs/010-migrate-scope-discovery (Captured for future expansion)
 ordinal: 7000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:design:gap/scope-discovery-v2-expansion
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-8 - scope-discovery-studio-control-plane-surface-for-the-clones-backlog-sortable-table-per-row-disposition.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-8 - scope-discovery-studio-control-plane-surface-for-the-clones-backlog-sortable-table-per-row-disposition.md
@@ -6,13 +6,19 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-06-10 10:03'
+updated_date: '2026-06-25 19:26'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 references:
   - specs/010-migrate-scope-discovery (Captured for future expansion)
 ordinal: 8000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:design:gap/scope-discovery-v2-expansion
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/.stack-control/backlog/tasks/task-9 - scope-discovery-cross-repo-rollup-view-consuming-scope-export-output.md
+++ b/plugins/stack-control/.stack-control/backlog/tasks/task-9 - scope-discovery-cross-repo-rollup-view-consuming-scope-export-output.md
@@ -4,13 +4,19 @@ title: 'scope-discovery: cross-repo rollup view consuming scope-export output'
 status: To Do
 assignee: []
 created_date: '2026-06-10 10:03'
+updated_date: '2026-06-25 19:26'
 labels:
   - agent-found
   - 'type:gap'
+  - promoted
 dependencies: []
 references:
   - specs/010-migrate-scope-discovery (Captured for future expansion)
 ordinal: 9000
 ---
 
+## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
+- **Promoted-to:** roadmap:design:gap/scope-discovery-v2-expansion
+<!-- SECTION:NOTES:END -->

--- a/plugins/stack-control/DEVELOPMENT-NOTES.md
+++ b/plugins/stack-control/DEVELOPMENT-NOTES.md
@@ -2,6 +2,39 @@
 
 ---
 
+## 2026-06-25: backlog-hygiene — import friction issues, cross-model triage + dedupe, formalize Tier-2 to roadmap
+
+**Goal:** Use the `stack-control-hygiene` branch to start working down the stack-control backlog: import existing friction GitHub issues, triage + dedupe the open pile, and investigate whether it can be organized into burn-down tranches. (Orchestrator/bookkeeping session — no point-fix code written yet.)
+
+**Accomplished:**
+- **Imported friction issues:** `backlog import-github --apply` brought in the 6 open GitHub issues (gh-499..506 → TASK-448..453) as `imported-issue` items; 3 already-present skipped (idempotent; GitHub never mutated).
+- **Triaged all 139→149 open items via 6 parallel sub-agents** (one per theme slice: govern-gates, path-anchoring, audit-fleet, cli-help, capability-mediation, scope/roadmap/misc), each reading task bodies + cross-referencing specs/audit-logs. Synthesis written to `MASTER-tranche-map.md`: ~115 distinct fixes across ~30 tranches in two tiers, with a recommended burn order.
+- **Dedupe — 10 items closed** via `backlog done`: TASK-447 (verified already fixed, commit 76c86be3) + 9 genuine same-defect duplicates (453→451, 409→450, 339→356, 354→324, 340/342→351, 162→163, 106→108, 113→77). Net open backlog **149 → 139**.
+- **Formalized Tier-2 feature-shaped tranches to the roadmap:** recorded promotes TASK-150/424 → `impl:feature/autonomous-loop`, TASK-138 → `design:feature/spec-governance`, TASK-443 → `multi:feature/migrate-audit-barrage`; created new node `design:gap/scope-discovery-v2-expansion` (part-of migrate-scope-discovery) with a description, seeded TASK-6, linked TASK-7/8/9/296 (TASK-10 parked).
+- **Confirmed already-formalized tranches** (no action): anchor-unification (specs/016 + node), TASK-134/135 (release-resolution-cycle / backlog-promotion-mechanization), TASK-47/75/76 (specs/021).
+
+**Didn't Work:**
+- **Bash cwd drifted to the repo root between tool calls**, where 5 nested installations make `session-start`/`backlog --apply` ambiguous (correct ambiguity-guard behavior, not a defect) — had to re-`cd` into / `--at` the `plugins/stack-control` installation.
+- **Two small `stackctl` ergonomic gaps** surfaced (captured as tooling friction): the roadmap reasoner has no single-node `show`/inspect subaction (verifying one node after add/edit needs a full graph dump); and `check-front-door` rejects `--at` unlike its sibling verbs.
+
+**Course Corrections:**
+- None from the operator — the operator's inputs were scope/formalization *choices* (apply cleanup now; formalize Tier-2 first; one umbrella node), not corrections of approach.
+- **[self-correction]** Narrowed the dedup-CLOSE set from the agents' ~16 proposed "collapses" to **9 true same-defect duplicates**, keeping the land-together test-cluster members (help-nondrift, no-backend-writes, mediate-check families) OPEN as tranche members — closing distinct audit findings as duplicates would erase work before its fix lands (preserve-don't-erase).
+
+**Insights:**
+- **Parallel sub-agents over thematic slices is the right shape for triaging a 149-item pile** — descriptive task titles let me pre-bucket cleanly, and bodies (pulled from task files + audit-logs) confirmed real dedup signal (e.g. TASK-453 self-references the recurring tasks-complete-gate defect = TASK-451).
+- **"Collapse" in a triage report ≠ "duplicate."** The dampener/preserve discipline matters: same-file audit findings are tranche members to land together, not dupes to close.
+- **Much of "formalize to roadmap" was reconciliation, not creation** — 13 items were already promoted to existing nodes/specs; only one genuinely-new node was needed. Minting nodes blind is literally TASK-448's bug, so existing-node mapping came first.
+
+**Quantitative:**
+- Commits: **2** — `fd06c59d` (hygiene work: import + dedupe + Tier-2 formalize, 25 files) + `5d92364c` (this session-end journal). Auto-derive reported 1 because the journal commit post-dates the `git log` boundary.
+- Files changed: 25 (work commit).
+- Messages: ~7
+- Corrections: 0 (operator), 1 (self)
+- Backlog: 149 → 139 open; +6 imported, −10 closed (1 fixed + 9 dup), 9 promoted (4 to existing nodes, 5 to the new node).
+- Backlog touched (auto-derived): TASK-10, TASK-134, TASK-138, TASK-150, TASK-424, TASK-443, TASK-447, TASK-448, TASK-47, TASK-6, TASK-7
+- Open findings at session end: 0 audit findings worked this session (triage/bookkeeping only).
+
 ## 2026-06-23: ship-stage — orchestrator session: design → runnable spec (4-phase, F1-corrected) via the full front-door lifecycle
 
 **Goal:** Pick up where the last session left off — the captured `multi:feature/ship-stage` node — and drive it through the stack-control front door from design to a runnable spec. Orchestrator-session work only; implementation is a separate session per the two-session boundary.

--- a/plugins/stack-control/ROADMAP.md
+++ b/plugins/stack-control/ROADMAP.md
@@ -628,6 +628,7 @@ Closing everything CONTAINED in a roadmap item — its resolved backlog ids AND 
 
 ## multi:feature/ship-stage
 - status: closed
+- closes: TASK-447
 - validated: yes
 - spec: specs/032-ship-stage
 - analyze-clean: yes
@@ -636,4 +637,9 @@ Closing everything CONTAINED in a roadmap item — its resolved backlog ids AND 
 - design-approved: yes
 - design: docs/superpowers/specs/2026-06-23-ship-stage-design.md
 A single mediated ship waypoint that makes recording status:shipped non-optional, designed AND implemented as ONE unit. Problem: transition:graduate (governing to shipped) already records status:shipped plus journal plus commit, but firing it is a separate manual workflow advance that is easy to skip, and PR open/merge runs through raw gh off the mediated surface, so the compass never sees shipping happen. Observed 2026-06-23 on multi:gap/transitive-item-closure: work merged and released in v0.54.0 while the roadmap status stayed in-flight; only the close gate caught it, and by luck. Feature: a stack-control:ship skill that is the one on-rail ship step (open PR, merge when green, CI-gated and operator-owned), then NON-DISCRETIONARILY fires transition:graduate to record status:shipped. No skip/defer/shortcut branch (no-offroading rule). Fire graduate AT MERGE, not at govern-converge: shipped means merged, not just graduated. Enforcement layers: (1) merge and graduate welded into one skill so you cannot merge without recording; (2) a BACKSTOP refusal gate at WORKFLOW waypoints (the close step and the next lifecycle steps via the compass) that refuses to proceed while a merged-but-status-in-flight item exists. HARD CONSTRAINT: the backstop must NOT live in session-start or session-end, which are orthogonal to the workflow and always available, never blocked (advisory-only surfacing is fine) per the session-skills-never-block rule. Honest boundary (026 pattern): a deliberate raw gh pr merge outside the skill surface cannot be prevented; the load-bearing guarantee is the gate, not interception. Coherence half (folds backlog TASK-445): the close gate reads the recorded status while compass and workflow status read the derived phase, so they diverge in the graduated-but-not-status-shipped window; reconcile so they cannot disagree. Mechanism: built on multi:feature/unskippable-workflow-protocol (wire it into the execute/ship loop, same shape as the mandatory after_implement govern), not a rule. BUILD AS ONE UNIT: design and implement the entire ship feature together in a single delivery; do not split design from implementation or ship partial increments, or the surfaces drift into incoherent goo.
+
+## design:gap/scope-discovery-v2-expansion
+- status: planned
+- part-of: design:feature/migrate-scope-discovery
+Second-wave scope-discovery expansion beyond the migrated v1: additional discovery-agent classes (TASK-6: dom-visual-walker, a11y-audit, vestigial-copy-audit, component-roster), cross-language scanner packs (TASK-7: .go/.py/.rs/.kt/.java via the customize seam), language-aware clone detection in the govern clone-step (TASK-296), and aggregation/reporting surfaces (TASK-8: studio clones-backlog table; TASK-9: cross-repo rollup over scope-export). TASK-10 (plugin-extension intercept to auto-wrap every Agent dispatch) stays parked on upstream Claude Code support. Seeded from backlog TASK-6.
 

--- a/plugins/stack-control/skills/design/SKILL.md
+++ b/plugins/stack-control/skills/design/SKILL.md
@@ -82,6 +82,12 @@ overrides on top.
    alternatives, ≥2), **decisions**, **open-questions**, **provenance**. Use the
    Write tool to persist it to disk.
 
+   > **The `≥2 alternatives` gate counts either top-level bullets OR `###`
+   > subsections under `## Solution space` (gh-500).** List the alternatives as
+   > `- …` bullets, or as `### Chosen — …` / `### Rejected — …` subsections —
+   > both satisfy `count-gte solution-space-alternatives 2`. (Pre-fix, only
+   > bullets counted and a subsection-structured record scored 0.)
+
 4. **Record operator approval (the judgment gate, FR-009/D5).** The design is not
    done until the operator records approval — a recorded fact, not a gate-time
    judgment. The operator sets the `design-approved:` marker on the node:

--- a/plugins/stack-control/skills/execute/SKILL.md
+++ b/plugins/stack-control/skills/execute/SKILL.md
@@ -68,6 +68,8 @@ stackctl check-front-door
 
 4. **Govern once, at the end, over the whole committed feature (030 — chunked govern-at-end; non-discretionary).** When every `tasks.md` task is complete and committed (the workflow's `start-governing` gate is `tasks-complete spec`), run the single whole-feature governance pass — a skill-body post-condition, **not** an agent choice (FR-006):
 
+   > **Manual / operator-acceptance tasks use the `- [~]` marker (gh-499 / gh-501).** A task a coding agent cannot complete in-session — e.g. *"operator live re-bless (manual, read-only)"* — is written `- [~]` (or `- [-]`), which the `tasks-complete` gate **excludes**, so the cross-model audit runs **before** the operator spends a live-prod acceptance (audit-before-acceptance). Do **not** leave such a task as `- [ ]` (it would block govern) and do **not** fake it `- [x]`. A normal unchecked `- [ ]` still blocks; an unrecognized marker (a typo'd `[?]`) is counted as open, never silently excluded.
+
    ```bash
    stackctl govern --mode implement          # feature derived from the SPECKIT marker / branch
    # or, when driven by a roadmap item:

--- a/plugins/stack-control/specs/030-chunked-end-govern/data-model.md
+++ b/plugins/stack-control/specs/030-chunked-end-govern/data-model.md
@@ -116,9 +116,9 @@ The single per-feature record the graduate gate evaluates (FR-015, FR-018). **Pe
 | `mode` | `'impl'` | (the spec-mode record is unchanged/separate) |
 | `item` | `string` | the feature/roadmap item id |
 | `governedShaBase` | `string` (sha) | the resolved feature base anchor (029 US5; `--diff-base` override) |
-| `headSha` | `string` (sha) | HEAD at audit time (the `governedSha`..HEAD endpoint) |
+| `headSha` | `string` (sha) | the CONCRETE head SHA of the governed range, resolved at record-write time = the final HEAD after any in-loop fix commits (the `governedShaBase`..`headSha` endpoint). Never the symbolic `HEAD` — the committed record must stay reproducible after the next commit lands (gh-502 / TASK-409). |
 | `chunkIds` | `string[]` | the stable ids of the chunk set governed |
-| `rounds` | `number` | re-audit rounds run (≤ round cap) |
+| `rounds` | `number` | re-audit rounds run in THIS invocation (≤ round cap) — a per-invocation snapshot, not cumulative across re-govern invocations (gh-502) |
 | `liftedFindings` | `Finding[]` | findings STILL open at graduation (lifted to backlog) |
 | `closedInLoopFindings` | `Finding[]` | findings fixed within the loop, closed BEFORE lift (NOT lifted — FR-016) |
 | `seamResultRef` | `SeamResult` ref | the seam pass outcome |

--- a/plugins/stack-control/src/__tests__/_setup-hermetic-git.ts
+++ b/plugins/stack-control/src/__tests__/_setup-hermetic-git.ts
@@ -1,0 +1,22 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Hermetic git harness (TASK-116). Vitest setupFile: neutralizes the host's
+ * GLOBAL and SYSTEM git config for the whole worker so every throwaway repo a
+ * fixture creates is hermetic — no inherited `commit.gpgsign=true`, a
+ * deterministic identity — regardless of the operator's machine or the CI
+ * image. Fixtures that already set local config still work (local overrides
+ * global); fixtures that forget identity now also work. New fixtures inherit
+ * the property by default, so this is the root fix rather than a per-call-site
+ * `git config commit.gpgsign false` sprinkled across each suite.
+ *
+ * `git` subprocesses spawned by fixtures inherit this process's environment, so
+ * pointing GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM at the checked-in hermetic
+ * config takes effect for every spawnSync('git', ...) call.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const hermetic = resolve(here, 'fixtures/hermetic.gitconfig');
+
+process.env.GIT_CONFIG_GLOBAL = hermetic;
+process.env.GIT_CONFIG_SYSTEM = hermetic;

--- a/plugins/stack-control/src/__tests__/fixtures/hermetic.gitconfig
+++ b/plugins/stack-control/src/__tests__/fixtures/hermetic.gitconfig
@@ -1,0 +1,11 @@
+[user]
+	name = stack-control test
+	email = test@stack-control.invalid
+[commit]
+	gpgsign = false
+[tag]
+	gpgsign = false
+[gpg]
+	format = openpgp
+[init]
+	defaultBranch = main

--- a/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
+++ b/plugins/stack-control/src/__tests__/govern/payload-diff-scope.test.ts
@@ -15,6 +15,7 @@ import {
   scopeCommittedDiff,
   filterDiffScope,
   resolveImplementExclusion,
+  resolveHeadSha,
 } from '../../govern/payload-diff-scope.js';
 
 function git(repo: string, ...args: string[]): string {
@@ -334,6 +335,41 @@ describe('030 — diff-scope exclusion (AUDIT-20260622-02)', () => {
   it('filterDiffScope with no exclusions returns the scope unchanged', () => {
     const scope = { base: 'B', head: 'H', files: ['a.ts'], fileDiffs: new Map([['a.ts', 'x']]) };
     expect(filterDiffScope(scope, [])).toBe(scope);
+  });
+
+  it('resolveImplementExclusion always excludes the harness own govern outputs (gh-502)', () => {
+    // The barrage audits the committed tree, which includes stackctl's OWN
+    // convergence record under .stack-control/govern — auditing it manufactures
+    // findings about the harness's bookkeeping every round (structural
+    // non-convergence). It must be excluded unconditionally, even with no
+    // feature root / caller excludes.
+    const ex = resolveImplementExclusion('/install', '/install/specs/030-feat', [], []);
+    expect(ex.excludeDiffRels).toContain('.stack-control/govern');
+    const exBare = resolveImplementExclusion('/install', undefined, undefined, undefined);
+    expect(exBare.excludeDiffRels).toContain('.stack-control/govern');
+  });
+
+  it('filterDiffScope drops the harness convergence record under .stack-control/govern (gh-502)', () => {
+    const scope = {
+      base: 'B',
+      head: 'H',
+      files: ['src/app.ts', '.stack-control/govern/convergence/multi-feature-x.json'],
+      fileDiffs: new Map([
+        ['src/app.ts', 'a'],
+        ['.stack-control/govern/convergence/multi-feature-x.json', 'b'],
+      ]),
+    };
+    const filtered = filterDiffScope(scope, ['.stack-control/govern']);
+    expect(filtered.files).toEqual(['src/app.ts']);
+  });
+
+  it('resolveHeadSha resolves HEAD to a concrete 40-char SHA, not the symbolic ref (gh-502)', () => {
+    const repo = setup();
+    const sha = resolveHeadSha(repo);
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(sha).toBe(head(repo));
+    expect(sha).not.toBe('HEAD');
+    rmSync(repo, { recursive: true, force: true });
   });
 
   it('resolveImplementExclusion excludes the OWN audit-log, WHOLE other-feature roots, and caller excludePaths (TASK-428)', () => {

--- a/plugins/stack-control/src/__tests__/hermetic-git-fixtures.test.ts
+++ b/plugins/stack-control/src/__tests__/hermetic-git-fixtures.test.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * TASK-116 — test fixtures must be hermetic: a throwaway git repo created in a
+ * tmpdir inherits the host's GLOBAL git config, including `commit.gpgsign=true`
+ * (operator setup). In keyless CI there is no signing key, so any fixture that
+ * commits without disabling signing fails with "failed to write commit object".
+ *
+ * The hermetic harness (`_setup-hermetic-git.ts`, wired via vitest setupFiles)
+ * neutralizes the host global/system config for the whole test run, so this
+ * test asserts the property behaviorally: a fresh repo can commit even when the
+ * signing program is deliberately broken (the deterministic stand-in for
+ * "keyless CI"). If signing were still required, the broken program would make
+ * the commit fail.
+ */
+describe('hermetic git fixtures (TASK-116)', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  function freshRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'hermetic-git-'));
+    dirs.push(dir);
+    const init = spawnSync('git', ['-C', dir, 'init', '-q'], { encoding: 'utf8' });
+    expect(init.status).toBe(0);
+    return dir;
+  }
+
+  it('a throwaway repo commits without a signing key (keyless-CI safe)', () => {
+    const dir = freshRepo();
+    // Do NOT disable gpgsign locally — rely on the hermetic harness. Force a
+    // signing program that cannot exist; if signing were on, commit would fail.
+    const res = spawnSync(
+      'git',
+      ['-C', dir, '-c', 'gpg.program=/nonexistent-signer', 'commit', '--allow-empty', '-q', '-m', 'seed'],
+      { encoding: 'utf8' },
+    );
+    expect(res.stderr).not.toMatch(/failed to write commit object/);
+    expect(res.status).toBe(0);
+  });
+
+  it('the hermetic harness reports commit.gpgsign=false for a fresh repo', () => {
+    const dir = freshRepo();
+    const res = spawnSync('git', ['-C', dir, 'config', '--get', 'commit.gpgsign'], { encoding: 'utf8' });
+    expect(res.stdout.trim()).toBe('false');
+  });
+});

--- a/plugins/stack-control/src/__tests__/roadmap/reconcile-unorphan.test.ts
+++ b/plugins/stack-control/src/__tests__/roadmap/reconcile-unorphan.test.ts
@@ -76,4 +76,65 @@ describe('roadmap.reconcileUnorphan (T073)', () => {
     ).toThrow(DocumentModelError);
     expect(readFileSync(docPath, 'utf8')).toBe(before);
   });
+
+  // gh-506: an existing `*:feature/<slug>` node whose slug matches the orphan
+  // spec's slug (the NNN- numeric prefix stripped) is the real node — attach the
+  // spec to it instead of minting a parallel `impl:feature/<NNN-slug>` duplicate.
+  it('attaches the spec to an existing same-slug node instead of minting a duplicate (gh-506)', () => {
+    const docPath = writeTempRoadmap(['## design:feature/faithful-capture-substrate', '- status: planned']);
+    const orphanRel = writeSpecDir(docPath, '010-faithful-capture-substrate');
+    const baseDir = dirname(docPath);
+    expect(reconcile(docPath, ROADMAP_OPTS, baseDir).orphans).toContain(orphanRel);
+
+    const before = loadRoadmap(docPath, ROADMAP_OPTS).items.length;
+    reconcileUnorphan(docPath, orphanRel, ROADMAP_OPTS, baseDir, true);
+
+    const model = loadRoadmap(docPath, ROADMAP_OPTS);
+    // No duplicate node minted.
+    expect(model.items.length).toBe(before);
+    expect(model.items.find((i) => i.identifier === 'impl:feature/010-faithful-capture-substrate')).toBeUndefined();
+    // The EXISTING design node now carries the spec correspondence.
+    const node = model.items.find((i) => i.identifier === 'design:feature/faithful-capture-substrate');
+    expect(node?.spec?.replace(/\/$/, '')).toBe(orphanRel);
+    expect(reconcile(docPath, ROADMAP_OPTS, baseDir).orphans).not.toContain(orphanRel);
+  });
+
+  it('refuses (zero-write) when MULTIPLE existing nodes plausibly match the orphan slug (gh-506)', () => {
+    const docPath = writeTempRoadmap([
+      '## design:feature/ambig',
+      '- status: planned',
+      '## impl:feature/ambig',
+      '- status: planned',
+    ]);
+    const orphanRel = writeSpecDir(docPath, '011-ambig');
+    const baseDir = dirname(docPath);
+    const before = readFileSync(docPath, 'utf8');
+    expect(() => reconcileUnorphan(docPath, orphanRel, ROADMAP_OPTS, baseDir, true)).toThrow(DocumentModelError);
+    expect(readFileSync(docPath, 'utf8')).toBe(before);
+  });
+
+  it('refuses (zero-write) when the matching node already corresponds to a DIFFERENT spec (gh-506)', () => {
+    const docPath = writeTempRoadmap([
+      '## design:feature/taken',
+      '- status: planned',
+      '- spec: specs/100-other',
+    ]);
+    writeSpecDir(docPath, '100-other');
+    const orphanRel = writeSpecDir(docPath, '012-taken');
+    const baseDir = dirname(docPath);
+    const before = readFileSync(docPath, 'utf8');
+    expect(() => reconcileUnorphan(docPath, orphanRel, ROADMAP_OPTS, baseDir, true)).toThrow(DocumentModelError);
+    expect(readFileSync(docPath, 'utf8')).toBe(before);
+  });
+
+  it('still mints a new node when NO existing node corresponds to the orphan slug (gh-506)', () => {
+    const docPath = writeTempRoadmap(['## impl:feature/unrelated', '- status: planned']);
+    const orphanRel = writeSpecDir(docPath, '013-brand-new');
+    const baseDir = dirname(docPath);
+    reconcileUnorphan(docPath, orphanRel, ROADMAP_OPTS, baseDir, true);
+    const model = loadRoadmap(docPath, ROADMAP_OPTS);
+    const minted = model.items.find((i) => i.identifier === 'impl:feature/013-brand-new');
+    expect(minted).toBeDefined();
+    expect(minted?.spec?.replace(/\/$/, '')).toBe(orphanRel);
+  });
 });

--- a/plugins/stack-control/src/__tests__/spec-dir-resolution.test.ts
+++ b/plugins/stack-control/src/__tests__/spec-dir-resolution.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCli } from './_run-helpers.js';
+import { resolveSpecDir } from '../subcommands/spec-dir.js';
+
+// gh-505 / TASK-449: `spec-check` and `execute-check` must resolve the SAME
+// `--spec` argument the SAME way. Both share `resolveSpecDir`, which preserves
+// cwd-relative resolution (never breaks a working call) and then rescues with an
+// installation-root-relative path so `specs/NNN` works from any subdir of the
+// installation — instead of a spurious "spec dir not found" FATAL.
+describe('resolveSpecDir (gh-505)', () => {
+  let work: string;
+  beforeEach(() => {
+    work = realpathSync(mkdtempSync(join(tmpdir(), 'stackctl-specdir-')));
+    // A full installation: `.stack-control/config.yaml` + a runnable spec dir.
+    mkdirSync(join(work, '.stack-control'), { recursive: true });
+    writeFileSync(join(work, '.stack-control', 'config.yaml'), 'version: 1\n', 'utf8');
+    const spec = join(work, 'specs', '999-fixture');
+    mkdirSync(spec, { recursive: true });
+    writeFileSync(join(spec, 'spec.md'), '# fixture\n');
+    writeFileSync(join(spec, 'plan.md'), '# fixture\n');
+    writeFileSync(join(spec, 'tasks.md'), '# fixture\n');
+  });
+  afterEach(() => {
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  it('resolves a cwd-relative path when it exists (unchanged behavior)', () => {
+    const got = resolveSpecDir('specs/999-fixture', work);
+    expect(got).toBe(join(work, 'specs', '999-fixture'));
+  });
+
+  it('rescues an installation-root-relative path from a subdir', () => {
+    const sub = join(work, 'specs'); // a subdir of the installation
+    const got = resolveSpecDir('specs/999-fixture', sub);
+    expect(got).toBe(join(work, 'specs', '999-fixture'));
+  });
+
+  it('passes an absolute path through unchanged', () => {
+    const abs = join(work, 'specs', '999-fixture');
+    expect(resolveSpecDir(abs, work)).toBe(abs);
+  });
+
+  it('execute-check and spec-check both accept the install-root-relative path from a subdir', () => {
+    const sub = join(work, 'specs');
+    const exec = runCli(['execute-check', '--spec', 'specs/999-fixture'], { cwd: sub });
+    const spec = runCli(['spec-check', '--spec', 'specs/999-fixture'], { cwd: sub });
+    expect(exec.status).toBe(0);
+    expect(exec.stdout).toMatch(/runnable/);
+    expect(spec.status).toBe(0);
+    expect(spec.stdout).toMatch(/tasks=yes/);
+  });
+});

--- a/plugins/stack-control/src/__tests__/subcommands/capability-reconcile.test.ts
+++ b/plugins/stack-control/src/__tests__/subcommands/capability-reconcile.test.ts
@@ -116,6 +116,14 @@ describe('capability reconcile — US3 backstop (026 T022, 030-rewired)', () => 
     expect(reconcileVerb(['--nope']).code).toBe(2);
     expect(reconcileVerb(['--at']).code).toBe(2);
   });
+
+  it('reconcile verb rejects --at <flag> instead of swallowing it (AUDIT-20260618-139)', () => {
+    // `--at --json` must NOT take `--json` as the path (resolving install root
+    // `--json` → not-found → false "all clean", silently swallowing --json).
+    const r = reconcileVerb(['--at', '--json']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toMatch(/--at requires a value/);
+  });
 });
 
 describe('US3 backstop: a reconcile-flagged feature cannot graduate (026 T024, 030 FR-025)', () => {

--- a/plugins/stack-control/src/__tests__/workflow/gate-eval.test.ts
+++ b/plugins/stack-control/src/__tests__/workflow/gate-eval.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { join } from 'node:path';
 import {
   classifyTasks,
+  describeCriterion,
   evaluateCriterion,
   evaluateGate,
   type GateContext,
@@ -154,6 +155,59 @@ describe('US1 criterion evaluation — each kind → definite true/false', () =>
     const c = ctxFor(f, { designRecordPath: path });
     expect(evaluateCriterion({ kind: 'count-gte', target: 'solution-space-alternatives', param: 2 }, c)).toBe(true);
     expect(evaluateCriterion({ kind: 'count-gte', target: 'solution-space-alternatives', param: 3 }, c)).toBe(false);
+  });
+
+  it('count-gte counts ### subsection alternatives, not just bullets (gh-500)', () => {
+    const f = fixture();
+    // A record that structures its alternatives as `### Chosen`/`### Rejected`
+    // subsections (no top-level bullets) must score its alternatives, not 0.
+    const record = [
+      '# Design record',
+      '',
+      '## Solution space',
+      '',
+      '### Rejected — (A) task DB',
+      'prose about A.',
+      '',
+      '### Chosen — (B) governed markdown',
+      'prose about B.',
+      '',
+      '## Decisions',
+      'we chose B.',
+    ].join('\n');
+    const path = f.write('docs/superpowers/specs/sub-design.md', record);
+    const c = ctxFor(f, { designRecordPath: path });
+    expect(evaluateCriterion({ kind: 'count-gte', target: 'solution-space-alternatives', param: 2 }, c)).toBe(true);
+  });
+
+  it('count-gte uses subsections over their detail bullets (no double-count, gh-500)', () => {
+    const f = fixture();
+    // Two `###` alternatives, each with detail bullets — counts the 2
+    // alternatives, NOT the 4 detail bullets.
+    const record = [
+      '# Design record',
+      '',
+      '## Solution space',
+      '### Rejected — (A)',
+      '- detail a1',
+      '- detail a2',
+      '### Chosen — (B)',
+      '- detail b1',
+      '- detail b2',
+      '',
+      '## Decisions',
+      'B.',
+    ].join('\n');
+    const path = f.write('docs/superpowers/specs/mixed-design.md', record);
+    const c = ctxFor(f, { designRecordPath: path });
+    expect(evaluateCriterion({ kind: 'count-gte', target: 'solution-space-alternatives', param: 2 }, c)).toBe(true);
+    expect(evaluateCriterion({ kind: 'count-gte', target: 'solution-space-alternatives', param: 3 }, c)).toBe(false);
+  });
+
+  it('describeCriterion hints what solution-space-alternatives counts (gh-500)', () => {
+    const d = describeCriterion({ kind: 'count-gte', target: 'solution-space-alternatives', param: 2 });
+    expect(d).toContain('solution-space-alternatives');
+    expect(d).toMatch(/bullets or ###|### subsection/i);
   });
 
   it('file-exists reads whether the resolved artifact exists', () => {

--- a/plugins/stack-control/src/__tests__/workflow/gate-eval.test.ts
+++ b/plugins/stack-control/src/__tests__/workflow/gate-eval.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { join } from 'node:path';
 import {
+  classifyTasks,
   evaluateCriterion,
   evaluateGate,
   type GateContext,
@@ -97,6 +98,45 @@ describe('US1 criterion evaluation — each kind → definite true/false', () =>
     expect(evaluateCriterion({ kind: 'tasks-complete', target: 'spec' }, incomplete)).toBe(false);
     f.writeSpecTasks('specs/022-x', true);
     expect(evaluateCriterion({ kind: 'tasks-complete', target: 'spec' }, incomplete)).toBe(true);
+  });
+
+  // gh-499 / gh-501 (TASK-451): the tasks-complete gate must EXCLUDE manual /
+  // operator-acceptance tasks so the cross-model audit runs BEFORE the operator
+  // spends a live-prod acceptance. The `[~]` (and `[-]`) markers are the
+  // first-class, documented way to mark such a task — and the exclusion must be
+  // intentional, not an accident of a narrow regex.
+  describe('manual-acceptance marker (gh-499/gh-501)', () => {
+    it('classifyTasks splits gateable / done / manual', () => {
+      const t = classifyTasks(
+        ['- [x] T001 code', '- [X] T002 code', '- [ ] T003 code', '- [~] T004 [manual] operator re-bless', '- [-] T005 deferred'].join(
+          '\n',
+        ),
+      );
+      expect(t).toEqual({ gateable: 3, done: 2, manual: 2 });
+    });
+
+    it('a manual [~] task does not block once every code task is done', () => {
+      const f = fixture();
+      f.write('specs/007-x/tasks.md', ['# Tasks', '', '- [x] T001 code', '- [x] T002 code', '- [~] T015 [manual] operator live re-bless', ''].join('\n'));
+      const ctx = ctxFor(f, { specPointer: 'specs/007-x', specDirPath: join(f.root, 'specs/007-x') });
+      expect(evaluateCriterion({ kind: 'tasks-complete', target: 'spec' }, ctx)).toBe(true);
+    });
+
+    it('a plain [ ] task still blocks (the marker is the explicit opt-out)', () => {
+      const f = fixture();
+      f.write('specs/007-y/tasks.md', ['# Tasks', '', '- [x] T001 code', '- [ ] T015 operator live re-bless', ''].join('\n'));
+      const ctx = ctxFor(f, { specPointer: 'specs/007-y', specDirPath: join(f.root, 'specs/007-y') });
+      expect(evaluateCriterion({ kind: 'tasks-complete', target: 'spec' }, ctx)).toBe(false);
+    });
+
+    it('an unrecognized checkbox marker is NOT silently excluded (no-silent-caps)', () => {
+      const f = fixture();
+      // A typo'd `[?]` must count as an open gateable task — never silently drop
+      // out of the count and let an unfinished task satisfy the gate.
+      f.write('specs/007-z/tasks.md', ['# Tasks', '', '- [x] T001 code', '- [?] T002 typo', ''].join('\n'));
+      const ctx = ctxFor(f, { specPointer: 'specs/007-z', specDirPath: join(f.root, 'specs/007-z') });
+      expect(evaluateCriterion({ kind: 'tasks-complete', target: 'spec' }, ctx)).toBe(false);
+    });
   });
 
   it('section-present finds a required design-record heading', () => {

--- a/plugins/stack-control/src/govern/chunk-artifacts.ts
+++ b/plugins/stack-control/src/govern/chunk-artifacts.ts
@@ -95,8 +95,20 @@ export interface WholeFeatureConvergenceRecord {
   readonly mode: 'impl';
   readonly item: string;
   readonly governedShaBase: string;
+  /**
+   * The CONCRETE head SHA of the governed range (`governedShaBase..headSha`),
+   * resolved at record-write time — never the symbolic `'HEAD'` (gh-502), so the
+   * record stays reproducible after the next commit lands.
+   */
   readonly headSha: string;
   readonly chunkIds: readonly string[];
+  /**
+   * Audit→fix rounds in THIS govern invocation — a per-invocation snapshot, not a
+   * cumulative count across re-govern invocations (gh-502). A multi-invocation
+   * fix→re-govern loop spans several commits but each invocation records only its
+   * own rounds; consumers treat this record as the latest-state snapshot, not a
+   * running total.
+   */
   readonly rounds: number;
   readonly liftedFindings: readonly Finding[];
   readonly closedInLoopFindings: readonly Finding[];

--- a/plugins/stack-control/src/govern/govern-arms.ts
+++ b/plugins/stack-control/src/govern/govern-arms.ts
@@ -26,7 +26,7 @@ import { recordOverrideGraduation } from './override-graduate.js';
 import { resolveConvergenceItem } from './feature-resolution.js';
 import { runCloneDetectionStep } from './clone-step.js';
 import { runConvergenceLoop } from './convergence-loop.js';
-import { resolveImplementExclusion } from './payload-diff-scope.js';
+import { resolveImplementExclusion, resolveHeadSha } from './payload-diff-scope.js';
 import { runEndGovern } from './end-govern-pipeline.js';
 import { makeEndGovernRuntime } from './end-govern-runtime.js';
 import { writeWholeFeatureConvergenceRecord } from './chunk-artifacts.js';
@@ -282,10 +282,16 @@ export async function runImplementArm(ctx: GovernRunContext): Promise<void> {
     stderr: (s) => process.stderr.write(s),
   });
 
-  const { record } = await runEndGovern(
+  const { record: pipelineRecord } = await runEndGovern(
     { installationRoot: repoRoot, item: convergenceItem, base, head: 'HEAD' },
     runtime.deps,
   );
+  // gh-502: the pipeline carries the SYMBOLIC 'HEAD' so its mid-loop re-scope
+  // tracks fix commits that advance HEAD (FR-007). The DURABLE record must instead
+  // pin the CONCRETE head SHA of the range actually governed (base..final-HEAD) —
+  // a committed audit artifact whose job is "what was governed?" must stay
+  // reproducible after the next commit lands. Symmetric with governedShaBase.
+  const record = { ...pipelineRecord, headSha: resolveHeadSha(repoRoot) };
 
   // Persist the ONE whole-feature record the impl graduate gate reads (FR-025).
   // A record-write failure is FATAL — never report graduation the durable gate

--- a/plugins/stack-control/src/govern/payload-diff-scope.ts
+++ b/plugins/stack-control/src/govern/payload-diff-scope.ts
@@ -66,6 +66,12 @@ export function resolveImplementExclusion(
   const excludePathRels =
     featureRoot !== undefined ? (excludePaths ?? []).map(relify).filter(inRepo) : [];
   const excludeDiffRels = [
+    // gh-502: the harness's OWN govern outputs (the convergence record under
+    // `.stack-control/govern/`) are committed into the tree the barrage audits.
+    // Auditing them manufactures findings about stackctl's own bookkeeping every
+    // round (structural non-convergence). Always exclude them — this is the
+    // harness's scaffolding, never the feature under audit.
+    GOVERN_OUTPUT_REL,
     // The feature's OWN root: exclude only its audit-log (self-reference generator) —
     // its code is the audit target and must stay in scope.
     ...(featureInside ? [`${featureRel}/audit-log.md`] : []),
@@ -173,6 +179,28 @@ function resolveDefaultBranch(gitRoot: string): string | undefined {
  * documented fallback to HEAD~1 covers the degenerate cases (on the default branch, a
  * detached HEAD, or an unresolvable default branch) where there is no feature span.
  */
+/** Installation-relative path of the harness's own govern outputs (gh-502). */
+export const GOVERN_OUTPUT_REL = '.stack-control/govern';
+
+/**
+ * The concrete commit SHA of HEAD (gh-502). The durable convergence record must
+ * pin the head of the governed range to a reproducible 40-char SHA — symmetric
+ * with the resolved `governedShaBase` — never the symbolic `'HEAD'`, which stops
+ * resolving to the governed commit the moment another commit lands. Fail-loud
+ * (no fallback): a record that cannot pin its head is a broken audit artifact.
+ */
+export function resolveHeadSha(installationRoot: string): string {
+  const gitRoot = gitTry(installationRoot, ['rev-parse', '--show-toplevel']) ?? installationRoot;
+  const sha = gitTry(gitRoot, ['rev-parse', 'HEAD']);
+  if (sha === undefined || sha.trim() === '') {
+    throw new Error(
+      `govern: FATAL — could not resolve HEAD to a concrete SHA for the convergence record ` +
+        `(git rev-parse HEAD failed in ${gitRoot}). The record must pin a reproducible head SHA.`,
+    );
+  }
+  return sha.trim();
+}
+
 export function resolveImplementDiffBase(installationRoot: string, explicit: string | undefined): string {
   if (explicit !== undefined && explicit.trim() !== '') return explicit;
   const gitRoot = gitTry(installationRoot, ['rev-parse', '--show-toplevel']) ?? installationRoot;

--- a/plugins/stack-control/src/release/portable.ts
+++ b/plugins/stack-control/src/release/portable.ts
@@ -42,6 +42,10 @@ function readJson(path: string): Record<string, unknown> {
   return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 function readJsonVersion(path: string): string {
   const parsed = readJson(path);
   if (typeof parsed.version !== 'string' || parsed.version === '') {
@@ -94,7 +98,7 @@ function readCodexMarketplaceEntry(
     throw new Error(`release-check: missing Codex marketplace entry for plugin '${pluginName}' in ${path}`);
   }
   const source = match.source;
-  if (typeof source !== 'object' || source === null) {
+  if (!isRecord(source)) {
     throw new Error(`release-check: missing source object for Codex marketplace entry '${pluginName}' in ${path}`);
   }
   if (source.source !== 'local' || source.path !== './plugins/stack-control') {

--- a/plugins/stack-control/src/roadmap/reconcile.ts
+++ b/plugins/stack-control/src/roadmap/reconcile.ts
@@ -15,7 +15,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import type { LoadOptions } from '../document-model/document.js';
 import { DocumentModelError } from '../document-model/types.js';
-import { add, type MutationResult } from './mutations.js';
+import { add, setField, type MutationResult } from './mutations.js';
 import { loadRoadmap } from './roadmap-model.js';
 
 export interface StatusDrift {
@@ -182,8 +182,44 @@ export function reconcileUnorphan(
         `refusing to reconcile against a non-orphan`,
     );
   }
-  // `spec:` records the spec DIRECTORY (the project convention, e.g.
-  // `specs/005-document-primitives`), NOT a path to `spec.md` — reconcile
-  // resolves `<spec>/spec.md` itself.
+  // gh-506: before minting, check whether an EXISTING node already corresponds to
+  // this spec by slug family — an orphan `specs/010-faithful-capture-substrate`
+  // and a node `design:feature/faithful-capture-substrate` are the same feature
+  // (the node slug equals the spec slug with the `NNN-` numeric prefix stripped).
+  // Silently minting a parallel `impl:feature/<NNN-slug>` doubles the node count
+  // and leaves the roadmap internally inconsistent. Reuse the existing
+  // correspondence; refuse (never mint a duplicate) when the match is ambiguous.
+  const specSlug = basename(target);
+  const featureSlug = specSlug.replace(/^\d+-/, '');
+  const slugOf = (id: string): string => id.slice(id.lastIndexOf('/') + 1);
+  const matches = loadRoadmap(docPath, opts).items.filter((i) => {
+    const s = slugOf(i.identifier);
+    return s === featureSlug || s === specSlug;
+  });
+  if (matches.length > 1) {
+    throw new DocumentModelError(
+      `reconcile --unorphan: ${matches.length} existing nodes plausibly correspond to '${spec}' ` +
+        `(${matches.map((m) => m.identifier).join(', ')}) — refusing to mint a duplicate. ` +
+        `Attach the spec to the right one with \`workflow link-spec <node> ${spec}\`.`,
+    );
+  }
+  if (matches.length === 1) {
+    const node = matches[0]!;
+    const existingSpec = node.spec === null ? null : normalize(node.spec);
+    if (existingSpec !== null && existingSpec !== target) {
+      throw new DocumentModelError(
+        `reconcile --unorphan: existing node '${node.identifier}' already corresponds to spec ` +
+          `'${node.spec}' (not '${spec}') — refusing to clobber. Relink it deliberately with ` +
+          `\`workflow link-spec\`, or remove the stale pointer first.`,
+      );
+    }
+    // Reuse the existing node's correspondence instead of minting a parallel node
+    // (the `setField` substrate behind `workflow link-spec`). The node's own type
+    // is authoritative, so any `--type` is moot on the reuse path.
+    return setField(docPath, node.identifier, 'spec', target, opts, apply);
+  }
+  // No existing correspondence — mint a new node. `spec:` records the spec
+  // DIRECTORY (the project convention, e.g. `specs/005-document-primitives`), NOT
+  // a path to `spec.md` — reconcile resolves `<spec>/spec.md` itself.
   return add(docPath, { identifier: nodeIdForOrphan(target, typePrefix), spec: target }, opts, apply);
 }

--- a/plugins/stack-control/src/subcommands/capability-reconcile.ts
+++ b/plugins/stack-control/src/subcommands/capability-reconcile.ts
@@ -110,7 +110,10 @@ export function reconcileVerb(args: readonly string[]): ReconcileVerbResult {
     if (arg === '--json') json = true;
     else if (arg === '--at') {
       const value = args[i + 1];
-      if (value === undefined) {
+      // Reject a missing value AND a following flag (AUDIT-20260618-139): `--at
+      // --json` must not swallow `--json` as the path (→ install root `--json` →
+      // not-found → false "all clean").
+      if (value === undefined || value.startsWith('--')) {
         return { code: 2, stdout: '', stderr: 'capability reconcile: --at requires a value\n' };
       }
       at = value;

--- a/plugins/stack-control/src/subcommands/execute-check.ts
+++ b/plugins/stack-control/src/subcommands/execute-check.ts
@@ -10,7 +10,8 @@
 // gating artifact is tasks.md (what /speckit-tasks produces).
 
 import { existsSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
+import { resolveSpecDir } from './spec-dir.js';
 
 // Strict arg parsing (AUDIT-20260605-09): the dispatcher contract is "no flag
 // silently ignored." Accept ONLY `--spec <value>`; reject a missing value,
@@ -46,7 +47,7 @@ function parseArgs(args: string[]): { spec: string } {
 export async function runExecuteCheck(args: string[]): Promise<void> {
   const { spec } = parseArgs(args);
 
-  const specDir = resolve(spec);
+  const specDir = resolveSpecDir(spec);
   if (!existsSync(specDir)) {
     process.stderr.write(`execute-check: FATAL — spec dir ${spec} not found\n`);
     process.exit(1);

--- a/plugins/stack-control/src/subcommands/spec-check.ts
+++ b/plugins/stack-control/src/subcommands/spec-check.ts
@@ -12,7 +12,8 @@
 // missing flag / absent dir / a file masquerading as a spec dir.
 
 import { existsSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
+import { resolveSpecDir } from './spec-dir.js';
 
 // Strict arg parsing — mirrors execute-check (AUDIT-20260605-09): the dispatcher
 // contract is "no flag silently ignored." Accept ONLY `--spec <value>`; reject a
@@ -47,7 +48,7 @@ function parseArgs(args: string[]): { spec: string } {
 export async function runSpecCheck(args: string[]): Promise<void> {
   const { spec } = parseArgs(args);
 
-  const specDir = resolve(spec);
+  const specDir = resolveSpecDir(spec);
   if (!existsSync(specDir)) {
     process.stderr.write(`spec-check: FATAL — spec dir ${spec} not found\n`);
     process.exit(1);

--- a/plugins/stack-control/src/subcommands/spec-dir.ts
+++ b/plugins/stack-control/src/subcommands/spec-dir.ts
@@ -1,0 +1,34 @@
+// Shared `--spec <dir>` resolution for the spec-check / execute-check sibling
+// verbs (gh-505 / TASK-449). Two verbs the `/stack-control:execute` gate
+// sequence invokes back-to-back with the SAME argument MUST resolve it the same
+// way — so both call this one helper rather than each calling `resolve(spec)`
+// independently.
+//
+// Resolution order for a relative path (absolute paths pass through unchanged):
+//   1. cwd-relative — the long-standing behavior; preserved so a call that
+//      works today never breaks (purely additive).
+//   2. installation-root-relative — a RESCUE: when the cwd-relative path does
+//      not exist, try the path under the nearest enclosing installation root, so
+//      `specs/NNN` resolves from any subdir of the installation instead of a
+//      spurious "spec dir not found" FATAL.
+// When neither exists, the cwd-relative path is returned so the caller's
+// not-found diagnostic names the value the user actually passed.
+
+import { existsSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+import { findInstallation } from '../config/installation.js';
+
+export function resolveSpecDir(spec: string, startDir: string = process.cwd()): string {
+  if (isAbsolute(spec)) return spec;
+
+  const cwdRelative = resolve(startDir, spec);
+  if (existsSync(cwdRelative)) return cwdRelative;
+
+  const installation = findInstallation(startDir);
+  if (installation !== null) {
+    const rootRelative = join(installation.root, spec);
+    if (existsSync(rootRelative)) return rootRelative;
+  }
+
+  return cwdRelative;
+}

--- a/plugins/stack-control/src/workflow/gate-eval.ts
+++ b/plugins/stack-control/src/workflow/gate-eval.ts
@@ -70,21 +70,30 @@ function countSolutionSpaceAlternatives(path: string | null): number {
   const lines = readFileSync(path, 'utf8').split('\n');
   let inSection = false;
   let sectionLevel = 0;
-  let count = 0;
+  let bullets = 0;
+  let subheadings = 0;
   for (const line of lines) {
     const h = /^(#{1,6})\s+(.*)$/.exec(line);
-    if (h) {
-      const level = h[1]!.length;
+    if (h !== null) {
+      const level = h[1]?.length ?? 0;
+      const title = h[2] ?? '';
       if (inSection && level <= sectionLevel) break; // section ended
-      if (!inSection && headingSlug(h[2]!) === 'solution-space') {
+      if (!inSection && headingSlug(title) === 'solution-space') {
         inSection = true;
         sectionLevel = level;
+      } else if (inSection && level > sectionLevel) {
+        subheadings++; // a nested `### Chosen …` / `### Rejected …` alternative
       }
       continue;
     }
-    if (inSection && /^\s*[-*]\s+\S/.test(line)) count++;
+    if (inSection && /^\s*[-*]\s+\S/.test(line)) bullets++;
   }
-  return count;
+  // Alternatives may be expressed as nested `###` subsections OR as top-level
+  // bullets. When subsections are present they ARE the alternatives (their
+  // bullets are detail), so count subheadings; otherwise fall back to bullets.
+  // (gh-500: a record structuring alternatives as `### Chosen`/`### Rejected`
+  // no longer scores 0.)
+  return subheadings > 0 ? subheadings : bullets;
 }
 
 /** True when every checkbox in `<specDir>/tasks.md` is checked (and there is at least one). */
@@ -226,6 +235,11 @@ export function evaluateGate(criteria: readonly Criterion[], ctx: GateContext): 
 /** A human-readable one-line description of a criterion (for query output). */
 export function describeCriterion(c: Criterion): string {
   const param = c.param === undefined ? '' : ` ${c.param}`;
+  // gh-500: the solution-space counter's rule is non-obvious — spell out what it
+  // counts so an author who hits an N−1/N gate doesn't have to read the source.
+  if (c.kind === 'count-gte' && c.target === 'solution-space-alternatives') {
+    return `count-gte solution-space-alternatives${param} (need ≥${c.param} alternatives as bullets or ### subsections under "## Solution space")`;
+  }
   return `${c.kind} ${c.target}${param}`;
 }
 

--- a/plugins/stack-control/src/workflow/gate-eval.ts
+++ b/plugins/stack-control/src/workflow/gate-eval.ts
@@ -88,19 +88,60 @@ function countSolutionSpaceAlternatives(path: string | null): number {
 }
 
 /** True when every checkbox in `<specDir>/tasks.md` is checked (and there is at least one). */
+/** Done-marker checkbox states (`- [x]` / `- [X]`). */
+const DONE_MARKERS = new Set(['x', 'X']);
+/**
+ * Manual / operator-acceptance (or deliberately-deferred / superseded) markers
+ * the tasks-complete gate EXCLUDES (gh-499 / gh-501): an "operator live re-bless"
+ * task a coding agent cannot complete in-session must not gate the cross-model
+ * audit — audit-before-acceptance. `[~]` is the documented manual/deferred
+ * marker (already used in-repo, e.g. specs/006 T052); `[-]` is accepted as an
+ * equivalent deferred form.
+ */
+const MANUAL_MARKERS = new Set(['~', '-']);
+
+/** Tally of `tasks.md` checkbox tasks by gate disposition. */
+export interface TaskTally {
+  /** Open-or-done code tasks the gate waits on. */
+  readonly gateable: number;
+  /** Gateable tasks marked done. */
+  readonly done: number;
+  /** Manual / operator-acceptance / deferred tasks the gate excludes. */
+  readonly manual: number;
+}
+
+/**
+ * Classify every checkbox-shaped bullet in a `tasks.md` body. The marker is read
+ * EXPLICITLY (not via a narrow regex that incidentally drops anything it does
+ * not recognize): `[x]`/`[X]` are done, `[~]`/`[-]` are manual-excluded, `[ ]`
+ * is open. Any OTHER single-char marker (a typo like `[?]`) counts as an open
+ * gateable task so a malformed checkbox can never silently satisfy the gate
+ * (no-silent-caps).
+ */
+export function classifyTasks(text: string): TaskTally {
+  let gateable = 0;
+  let done = 0;
+  let manual = 0;
+  for (const line of text.split('\n')) {
+    const m = /^\s*-\s+\[(.)\]/.exec(line);
+    const mark = m?.[1];
+    if (mark === undefined) continue;
+    if (MANUAL_MARKERS.has(mark)) {
+      manual++;
+      continue;
+    }
+    gateable++;
+    if (DONE_MARKERS.has(mark)) done++;
+  }
+  return { gateable, done, manual };
+}
+
 function tasksComplete(specDirPath: string | null): boolean {
   if (specDirPath === null) return false;
   const tasksPath = join(specDirPath, 'tasks.md');
   if (!existsSync(tasksPath)) return false;
-  let total = 0;
-  let done = 0;
-  for (const line of readFileSync(tasksPath, 'utf8').split('\n')) {
-    const m = /^\s*-\s+\[( |x|X)\]/.exec(line);
-    if (!m) continue;
-    total++;
-    if (m[1]!.toLowerCase() === 'x') done++;
-  }
-  return total > 0 && done === total;
+  const { gateable, done } = classifyTasks(readFileSync(tasksPath, 'utf8'));
+  return gateable > 0 && done === gateable;
 }
 
 /** Evaluate one criterion to a definite boolean (FR-008). */

--- a/plugins/stack-control/tooling-feedback.md
+++ b/plugins/stack-control/tooling-feedback.md
@@ -127,3 +127,7 @@
 
 ## session-end 2026-06-23
 - Validating the installed v0.54.0 surfaced that the dw-lifecycle retirement left ~34 skills with unparseable YAML frontmatter (dangling --- opener + a > **RETIRED** notice, no closing fence) → they load with empty metadata and trip the reload "1 error during load". Pre-existing (0.53.2 cache had 34 too); retired plugin; clean fix = give retired skills minimal valid frontmatter or drop the dangling opener.
+
+## session-end 2026-06-25
+- roadmap reasoner has no single-node inspect/show subaction (known: next/blocked/blocks/order/graph/add/advance/... but no 'show'); verifying one node after add/edit requires a full graph dump or session-start grep
+- check-front-door rejects '--at <dir>' unlike sibling verbs (session-start/backlog/govern accept it); must cd into the installation dir to run it — anchoring-flag inconsistency

--- a/plugins/stack-control/vitest.config.ts
+++ b/plugins/stack-control/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     // collected so every RED-first test actually runs (Constitution I).
     include: ['src/__tests__/**/*.test.ts', 'tests/**/*.test.ts'],
     globals: false,
+    // Hermetic git harness (TASK-116): neutralize the host global/system git
+    // config so throwaway-repo fixtures never inherit commit.gpgsign=true and
+    // fail in keyless CI. Must run before any fixture spawns git.
+    setupFiles: ['./src/__tests__/_setup-hermetic-git.ts'],
     // Front-door verb tests spawn the stackctl dispatcher as a child
     // process against tmp fixture trees; the default 5000ms per-test
     // budget is tight on slower runners. Mirror dw-lifecycle's 30s.


### PR DESCRIPTION
## stack-control backlog hygiene — friction-issue point-fixes

Imports the open friction GitHub issues into the backlog, triages + dedupes the pile, and burns down the issue-backed point-fix tranche. Each code fix is RED-first TDD (no governance — these are point fixes, not spec-driven features), full suite green, `tsc --noEmit` clean.

### Fixes (issue-backed)

| Area | Fix | Issue |
|---|---|---|
| release | narrow Codex marketplace `source` through an `isRecord` guard — restores a green `tsc --noEmit` on a clean tree | TASK-389 |
| test harness | hermetic git harness (`GIT_CONFIG_GLOBAL/SYSTEM` → checked-in `hermetic.gitconfig`) so throwaway-repo fixtures never inherit `commit.gpgsign=true` and fail in keyless CI | TASK-116 |
| gate | first-class `- [~]` manual/operator-acceptance marker the `tasks-complete` gate excludes (audit-before-acceptance); unrecognized markers no longer silently dropped | gh-499, gh-501 |
| gate | design-to-spec `count-gte solution-space-alternatives` counts `###` subsections, not just bullets; failing-criterion line now self-explains | gh-500 |
| CLI | `spec-check` / `execute-check` resolve `--spec` identically via a shared `resolveSpecDir` (cwd-relative preserved + installation-root rescue) | gh-505 |
| CLI | `capability reconcile --at <flag>` rejected instead of swallowing the following flag into a false "all clean" | TASK-188 |
| govern | convergence record pins a concrete `headSha` (base..final-HEAD), and `.stack-control/govern` is excluded from the audited diff — fixes the self-audit-every-round structural non-convergence; `rounds` documented per-invocation | gh-502 (HIGH) |
| roadmap | `reconcile --unorphan` reuses an existing same-slug node (attaches the spec) instead of minting a duplicate; refuses zero-write on ambiguous/clobbering matches | gh-506 |

### Bookkeeping
- `chore(backlog)`: imported the open friction issues, triaged + deduped, formalized the feature-shaped tranches to the roadmap, and recorded the 9 closed items.

### Verification
- Full suite green: **415 files / 2645 tests**; `tsc --noEmit` clean.
- The GitHub issues (gh-499/500/501/502/505/506) remain **open pending verification in a formally-installed release** — per the issue-closure discipline, a merge/commit is evidence, not closure.

### Not in this PR
- The H-series audit-migrated hygiene tranches (no gh backing) and TASK-444 remain in the backlog for a later pass.
