### PR TITLE
fix(stack-control): drop redundant manifest hooks key (duplicate-hooks load error)

### DIFF
--- a/plugins/stack-control/.claude-plugin/plugin.json
+++ b/plugins/stack-control/.claude-plugin/plugin.json
@@ -2,6 +2,5 @@
   "name": "stack-control",
   "version": "0.56.0",
   "description": "Provider-agnostic control plane for spec-driven development — define / extend / execute a Spec Kit spec in-session, with cross-model governance firing automatically after native execution. Successor to dw-lifecycle (absorb-then-retire).",
-  "license": "GPL-3.0-or-later",
-  "hooks": "./hooks/hooks.json"
+  "license": "GPL-3.0-or-later"
 }

--- a/plugins/stack-control/src/__tests__/capability/interceptor-loaded.test.ts
+++ b/plugins/stack-control/src/__tests__/capability/interceptor-loaded.test.ts
@@ -71,11 +71,20 @@ describe('interceptor-loaded (028 T116; T7 / FR-035 / SC-007)', () => {
     expect(existsSync(INTERCEPT), 'bin/intercept must exist').toBe(true);
   });
 
-  it('registration: plugin.json auto-discovers hooks/hooks.json (manifest wiring)', () => {
+  it('registration: plugin.json does NOT redundantly reference the auto-loaded hooks/hooks.json', () => {
+    // Claude Code auto-loads the standard hooks/hooks.json from the plugin root. A
+    // manifest.hooks reference to that SAME file double-registers it → a "Duplicate
+    // hooks file detected" load error (regressed when CC began auto-loading; the
+    // manifest key was added under AUDIT-20260618-73 before that, when it was required).
+    // manifest.hooks must only reference ADDITIONAL hook files — none here — so the key
+    // must be ABSENT. The auto-load still wires the interceptor (the firing tests below
+    // exercise bin/intercept directly and are unaffected).
     const manifest: unknown = JSON.parse(readFileSync(PLUGIN_JSON, 'utf8'));
     expect(typeof manifest).toBe('object');
     const hooksRef = prop(manifest, 'hooks');
-    expect(hooksRef, 'plugin.json must reference hooks/hooks.json').toBe('./hooks/hooks.json');
+    expect(hooksRef, 'plugin.json must NOT reference the auto-loaded hooks/hooks.json').not.toBe(
+      './hooks/hooks.json',
+    );
   });
 
   it('firing: a fronted backend (Bash `backlog capture`) with NO marker emits deny', () => {


### PR DESCRIPTION
Removes the redundant `"hooks": "./hooks/hooks.json"` key from `plugins/stack-control/.claude-plugin/plugin.json`. Claude Code now auto-loads the standard `hooks/hooks.json` from the plugin root, so the manifest reference double-registers it and triggers a 'Duplicate hooks file detected' load error on every plugin reload (surfaced post-0.56.0 install via /reload-plugins). The key was added under AUDIT-20260618-73 (028 US4) before CC auto-loaded; that no longer holds. The 026 interceptor still loads via auto-discovery — the bin/intercept firing tests are unaffected. interceptor-loaded.test.ts flipped RED-first to assert the manifest must NOT reference the auto-loaded file. Full suite 422 files / 2682 tests green; tsc clean.