### PR TITLE
feat: fleet dashboard (validation build) + recentActivity 'what happened' detail

### DIFF
--- a/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
@@ -1,250 +1,132 @@
 # Fleet Dashboard — Design Record
 
 - **Feature:** `design:feature/fleet-dashboard`
-- **Date:** 2026-07-19
-- **Status:** design (pre-spec) — revised twice after third-party review + code verification
+- **Date:** 2026-07-19 (built 2026-07-20)
+- **Status:** BUILT — validation build, verified live in a browser. Not production.
 - **Depends on:** `design:feature/fleet-control-plane` (036), `design:feature/instance-observability` (037) — both shipped to `main`.
 
 ## Problem / purpose
 
 036 (fleet control plane) and 037 (instance observability) built a full sidecar → plane
 telemetry pipeline and a per-instance projection, consumed today only as raw JSON + SSE over
-`/v1/*`. There is no human-facing surface. The immediate need: open a screen and watch
-instances appear, heartbeat, change lifecycle phase, and go stale/gone in real time —
-validating the pipeline end to end.
+`/v1/*`. There was no human-facing surface. This dashboard is the surface: open a screen and
+watch instances appear, heartbeat, change lifecycle phase, and go stale/gone in real time —
+**to validate the protean control plane end to end.** It is a validation build and will not
+ship to production; the finer points of auth and productization are deliberately deferred.
 
-Scoped as a **real product surface**, not a throwaway harness. Validating 036/037 is its first
-job; it is built to last.
+## What was built (settled decisions, operator, 2026-07-19/20)
 
-## Settled decisions (operator, 2026-07-19)
-
-1. **Nature:** real product surface — full feature lifecycle, its own branch/worktree.
-2. **Headline view:** fleet mission-control + drill-down (master-detail).
-3. **Serve + render:** embedded in the plane, **zero-build** (static HTML + vanilla JS/CSS, no
+1. **Headline view:** fleet mission-control + drill-down (master-detail) — a live grid of
+   instances; click a row for its detail.
+2. **Serve + render:** embedded in the plane, **zero-build** (static HTML + vanilla JS/CSS, no
    bundler), same origin as the API.
-4. **v1 scope:** instances-only, read-only. Runs and command issuance are later phases.
-5. **Auth is delegated to infrastructure.** The dashboard implements NO browser authentication
-   and owns NO credentials. Operator rationale: *"We will almost certainly get security
-   concerns wrong; better to assume authentication is handled outside our purview."* The plane
-   participates in that delegation through an explicit serving mode (§ Auth / serving mode),
-   NOT by making its API unconditionally public.
+3. **v1 scope:** instances-only, read-only. Runs and command issuance are later phases.
+4. **Auth: deferred.** The plane injects one of its accepted bearer tokens into the served page
+   so the browser can call the existing authed `/v1/*` read API. This is a crude stand-in, not
+   an auth model — operator: *"we aren't going to get auth right in the design phase … this
+   version will never make it to production."* Real auth (a service mesh / infra layer) is a
+   later concern. No `--auth-mode`, no cookies, no new plane flags were built.
 
-## Review resolution (two review rounds, verified against 037 code)
+## Facts verified against the 037 code (these shaped the build)
 
-- **Bind address:** `plane serve` calls `server.listen(port, …)` with no host → Node binds
-  `0.0.0.0`. This drove the explicit serving-mode contract below (a "documented assumption" of
-  localhost does not by itself create a perimeter).
-- **`host:path` route — VERIFIED SAFE (direct plane).** Router compiles `:id` → `([^/]+)`,
-  matches the raw still-encoded `req.url`; Node does not normalize `%2F`; handler
-  `decodeURIComponent`s. Shipped T037 fetches an encoded-slash id and passes. Opaque handle is
-  a fronted-plane forward option, not a v1 blocker.
-- **Instance states — CORRECTED to the real contract:** `connection ∈ {attached,
-  disconnected}`, `liveness ∈ {live, stale, gone}`. `idle` was invented and is removed.
-- **`/v1/instances` GET default filter — CONFIRMED:** keeps `attached OR live OR stale`, drops
-  `gone`; `?include=all` returns all. (But the **stream** is unfiltered — see below.)
-- **Stream emits gone transitions — VERIFIED:** the SSE stream folds the FULL registry
-  (`buildInstanceRegistry(...).instances()`, unfiltered) and diffs it, so a `→ gone` transition
-  is delivered as an `instance-upserted` delta with full state. The registry is append-only
-  over the event log, so `instance-removed` effectively never fires. The dashboard's "retain +
-  dim gone rows" is therefore natural, not a special case.
-- **Merge revision — VERIFIED not needed for v1:** InstanceState deliberately does NOT surface
-  the internal no-regress `*Sequence` marks. It doesn't have to: the server never regresses an
-  instance's state, deltas are ordered on a single stream, and every (re)connect re-delivers
-  full state (the server resets its per-connection `previous` to `[]`). The client applies
-  upserts in arrival order — see Live-update.
-- **`phaseDurations` — VERIFIED completed-only:** a phase entered-but-not-left is ABSENT (never
-  `0`); `CurrentBearing` is `{phase, item}` with NO entered-at timestamp. So there is no
-  server-provided basis for a growing current-phase bar; the UI does not interpolate.
-- Accepted: static-serving hardening, packaging-as-product, expanded browser tests, narrowed
-  module interface, connected/reconnecting/degraded stream states, hash-routing navigation,
-  client-timer relative time.
+- **`host:path` route is safe on the direct plane.** The router compiles `:id` → `([^/]+)` and
+  matches the raw still-encoded `req.url`; Node does not normalize `%2F`; the handler
+  `decodeURIComponent`s. Confirmed live — the detail view deep-links a slash-bearing id.
+- **Instance states:** `connection ∈ {attached, disconnected}`, `liveness ∈ {live, stale,
+  gone}`. The UI surfaces only these (no invented `idle`).
+- **`/v1/instances` GET default** keeps `attached OR live OR stale`, drops `gone`;
+  `?include=all` returns all. The stream is UNFILTERED (delivers all, including `gone`).
+- **`phaseDurations` is completed-only** — a phase entered-but-not-left is absent, and
+  `CurrentBearing` is `{phase, item}` with no entered-at. So the detail's phase bars show
+  completed phases only; the current phase has no growing bar (no interpolation).
+- The plane binds `0.0.0.0` (Node `listen(port)` with no host). Irrelevant to this validation
+  build (injected token, local use); it is a reason real auth belongs to infra later, not here.
 
 ## Architecture / serving model
 
-The dashboard ships **inside the plane**. `plane serve` gains three read-only routes above the
-`/v1/*` rows in `ROUTE_TABLE`:
+The dashboard ships **inside the plane**. `plane serve` mounts three UNAUTHENTICATED static
+routes alongside `/v1/*`:
 
-- `GET /` → the dashboard HTML **template** (rendered by the server).
-- `GET /dashboard/app.js`, `GET /dashboard/styles.css` → static assets served **verbatim** from
-  an explicit allowlist.
+- `GET /` → the dashboard HTML (the server injects one plane token into an inert-JSON config
+  block, plus `Cache-Control: no-store` and `X-Content-Type-Options: nosniff`).
+- `GET /dashboard/app.js`, `GET /dashboard/styles.css` → static assets served verbatim.
 
-No bundler, no `.runtime-cache`, no CORS, no second deployable. The client makes plain
-same-origin requests with no credential handling (§ Auth). **Trade-off accepted:** vanilla,
-untyped, unbundled client (the cost of zero-build); the server side is full strict TS; we keep
-the client small. A client build (esbuild) is a future option, out of scope for v1.
-
-## Auth / serving mode (SETTLED — flags below touch 036's `plane serve`)
-
-Authn/authz is delegated to infrastructure (decision #5). To make that delegation *safe*
-rather than a naked public API, the plane gains an explicit mode:
-
-```
-plane serve --auth-mode=external [--bind <addr>]
-```
-
-Under `--auth-mode=external`:
-
-- the dashboard static routes AND the browser-facing instance **read** routes (`/v1/instances*`
-  GET) require **no** plane bearer — the deployment's authenticating layer (mesh / ingress /
-  proxy / mTLS) owns access control;
-- the **machine-to-machine** routes (sidecar ingest, and future command/mutation routes) retain
-  their existing plane-native bearer credentials — unchanged from 036/037;
-- the mode carries a **listener-exposure contract**: the plane listener MUST be unreachable
-  except through the authenticating layer — either bound to a loopback/proxy-only address, or
-  the deployment guarantees non-bypass. **Direct all-interface exposure in external mode is
-  unsupported.**
-- `--bind <addr>` sets the listen host (default today is all-interfaces via `listen(port)`).
-  For **local dogfood/validation** run `--auth-mode=external --bind 127.0.0.1` — a real
-  boundary (only reachable on the machine), not an all-interface listener with an open API.
-
-The default mode (no `--auth-mode`) is unchanged — the existing bearer-everywhere behavior, so
-036/037 in-place behavior is untouched unless the operator opts into external mode.
-
-> **Operator confirmation wanted on THIS item:** it introduces `--auth-mode` / `--bind` to
-> `plane serve` and conditionally relaxes read-route auth — a small, deliberate change to shipped
-> 036 serve behavior. It is the concrete, safe form of decision #5; flagging it because it is the
-> one item that reaches back into a shipped feature.
-
-Static-serving hygiene the spec requires regardless of mode:
-`Cache-Control: no-store` on the HTML; `X-Content-Type-Options: nosniff`; a restrictive CSP;
-assets served ONLY from an exact-match allowlist (unknown `/dashboard/*` → 404, never falling
-through to API routing or the HTML shell); any server→page bootstrap value serialized as inert
-JSON, never substituted into script text.
+The three patterns ARE the allowlist: an unknown `/dashboard/*` matches no route and the plane
+404s (never falls through to `/v1/*` or the HTML shell). No bundler, no `.runtime-cache`, no
+CORS, no second deployable. The client is vanilla/untyped (the cost of zero-build); the server
+side is strict TS.
 
 ## The two views (master-detail)
 
 ### Fleet grid (home)
-The grid sources its state from the **stream** (which delivers ALL instances, including gone),
-and applies the active/all view filter **client-side**:
+Rows from the live instance state. Each row: connection/liveness dot (server states only),
+`host:path`, `currentBearing` (`phase · item`, or `—`), `lastActivity` + relative time, session
+counts. Sortable by liveness then recency.
 
-- **Default view:** the active fleet (`attached OR live OR stale`) — filtered client-side.
-- **"Show all known instances" toggle:** reveals `gone`/historical rows (client-side filter
-  over already-received stream state; label finalized at mockup phase).
-- **Gone rows never vanish mid-watch:** because the stream keeps delivering them as upserts and
-  the registry never removes an instance, a row that transitions to `gone` while observed stays
-  rendered (dimmed) for the session — the transition is the signal. Enabling "show all" makes
-  the full set authoritative.
-
-Each row: connection/liveness indicator (server states only), `host:path`, `currentBearing`
-(`phase · item`, or `—`), `lastActivity` label + relative time, session counts. Sortable; live.
+- **Default view:** the active fleet (`attached OR live OR stale`), filtered client-side.
+- **"Show all known instances" toggle:** reveals `gone` rows (client-side filter over the
+  state already received).
 
 ### Instance detail (drill-down)
-`GET /v1/instances/:id` (URL-encoded `host:path`):
+`GET /v1/instances/:id` (URL-encoded `host:path`), reached by hash routing:
 
-- connection + liveness (server-defined only) + a `lastActivity` relative time. "Quiet but
-  live" is a visual treatment of `live` + old `lastActivityAt`, not a new state.
-- **phase-duration bars from `phaseDurations` — completed phases only, static between events.**
-  The current open phase is shown via `currentBearing` (`current: phase · item`) with **no
-  growing bar** (no server-surfaced entered-at → no interpolation).
-- session started/ended counts; first-seen / first-session timestamps.
-- a live newest-first activity stream — the API's bounded `recentActivity`
-  (`RECENT_ACTIVITY_CAP = 50`).
+- connection + liveness cards, last-heartbeat / last-activity / first-seen relative times,
+  session started/ended counts.
+- phase-duration bars from `phaseDurations` (completed phases only); the current phase shows
+  as the bearing, no growing bar.
+- a newest-first activity stream from the detail response's bounded `recentActivity`.
 
-All read-only. Visual language → `/frontend-design` mockups the operator picks from, per
-`.claude/rules/design-standards.md`.
+Visual language is functional-first; a proper `/frontend-design` pass is a later option if this
+becomes a real product surface.
 
-## Live-update model (stream-authoritative)
+## Live-update model
 
-With no client credential, the client uses **native `EventSource`** on
-`GET /v1/instances/stream` — no headers, no hand-rolled SSE parser. The model:
+The client makes a `fetch()` to `GET /v1/instances/stream` with the injected `Bearer` token
+and reads the response body as a stream (`ReadableStream` reader) — `EventSource` can't send an
+`Authorization` header, so a small inline SSE reader parses the `event: instance-delta` /
+`data:` frames (and ignores `:keepalive` comments). Deltas are `instance-upserted` (full state)
+or `instance-removed`; they apply by `id`. An initial `GET /v1/instances?include=all` paints
+the grid fast before the stream takes over.
 
-1. Create **exactly one** `EventSource`; cancel it on navigation / page unload.
-2. On connect (and every browser auto-reconnect `open`), the server's first tick re-delivers
-   **full current state** as `instance-upserted` deltas (server resets per-connection
-   `previous` to `[]`) — so the stream **self-resyncs** on reconnect; no separate snapshot fetch
-   or revision cursor is required.
-3. Apply `instance-upserted` in arrival order (server never regresses an instance); an
-   `instance-removed` (rare — append-only registry) drops the row.
-4. `GET /v1/instances` is used only as an OPTIONAL fast first-paint before the first stream
-   tick; the stream is authoritative thereafter.
+- **Reconnect:** on stream error the client retries with bounded exponential backoff + jitter;
+  after repeated failures the status pill shows a **degraded** state while it keeps retrying.
+  Status pill: connecting / live / degraded.
+- **Relative-time refresh:** a low-frequency timer re-formats server timestamps ("46s ago")
+  without new events; it never re-derives connection/liveness (those stay server-derived).
 
-**Stream health states — connected / reconnecting / degraded.** `EventSource` auto-reconnects
-and does not expose HTTP status/body to JS, so the client does NOT try to diagnose *why* a
-stream failed. It shows a visible **degraded** banner ("Live updates unavailable — data may be
-stale") after repeated failures while **continuing** automatic reconnection at the browser's
-cadence; last-known data stays visible; a manual retry is offered. The client does not stop
-reconnecting (a transient proxy/plane restart should self-heal).
-
-Client-side **relative-time refresh:** a low-frequency timer re-formats server-provided
-timestamps against the current clock (so "12s ago" stays honest without new events).
-Connection and liveness values remain **exclusively** server-derived — the timer only
-re-formats, never re-derives state.
-
-## Navigation
-
-Detail views are **deep-linkable and reload-safe** via **hash routing**
-(`/#/instances/<url-encoded host:path>`) — no server catch-all/shell fallback route needed
-(the hash never reaches the server), which keeps the zero-build serving model intact. `/` with
-no hash is the grid.
-
-## Module structure (isolation)
+## Module structure
 
 ```
 src/dashboard/
   assets/
-    index.html          # HTML template (server-rendered; inert-JSON bootstrap only)
-    app.js              # vanilla client (grid + detail + EventSource + hash router)
+    index.html   # HTML shell; `__DASHBOARD_CONFIG__` placeholder for the inert-JSON bootstrap
+    app.js       # vanilla client: grid + detail + SSE reader + hash router
     styles.css
-  render.ts             # renders the HTML template
-  assets.ts             # exact-match allowlist: pattern -> { file, contentType }
+  assets.ts      # exact-match asset names → content-type; reads files relative to the module
+  serve.ts       # builds the three unauthenticated routes; injects one plane token into the page
 ```
 
-- `src/plane/http/server.ts` — three new `GET` rows in `ROUTE_TABLE`, above `/v1/*`.
-- The dashboard handler receives a **narrow** interface — `{ apiBase }` — NOT `acceptedTokens`.
-  No `auth.ts`: auth is out of scope; the serving-mode gate lives in the plane's existing route
-  middleware, not the dashboard module.
-- Unknown `/dashboard/*` → 404 (never fall through to API or HTML shell).
-- Each file under the 500-line cap; split `app.js` by concern (grid / detail / stream / router)
-  if it approaches the cap.
+`src/plane/runtime.ts` appends `buildDashboardRoutes(options.acceptedTokens)` to the plane's
+extra routes (unauthenticated — no `withAuth`). Nothing in shipped 036/037 auth or routing was
+changed.
 
-## Packaging (Packaging IS UX)
+## Verification
 
-Zero **client**-build ≠ zero packaging. `tsc` does not copy `src/dashboard/assets` into `dist`.
-The spec must specify how the assets reach the installed package/binary and **test the
-packaged/installed artifact**, not only a source checkout — a dashboard asset 404 in a real
-install is a top-priority blocker (`.claude/rules/agent-discipline.md`, "Packaging IS UX").
+Verified live in a browser (Playwright) against a plane seeded with three instances:
 
-## Testing
+- grid renders live/stale states by default; **"show all"** reveals the gone instance;
+- the stream connects (status → **live**) and rows update;
+- drilling into a slash-bearing `host:path` deep-links correctly and shows phase bars
+  (completed `specifying`; open `implementing` correctly absent) + a 5-event activity stream.
 
-- **Server (real `node:http` + `fetch`, mirroring `tests/instance/*`):** `GET /` → 200
-  `text/html` with `Cache-Control: no-store`; assets served with correct `content-type` from
-  the allowlist; unknown `/dashboard/*` → 404 (no fall-through); `/v1/*` behavior unchanged in
-  default mode; FR-024 read-only invariant holds (every new route is `GET`).
-- **Serving mode:** in `--auth-mode=external`, read/dashboard routes serve without a bearer AND
-  the supported configuration is proven to require a non-bypassable listener (e.g.
-  `--bind 127.0.0.1` reachable only locally); machine ingest/command routes still require their
-  bearer.
-- **Stream contract (not just UI):** a `→ gone` transition is delivered on the stream as a
-  full-state upsert (verify the server semantics directly).
-- **Packaged artifact:** the installed/distributed plane serves every dashboard asset.
-- **Client — local Playwright smoke (NOT CI; `no-test-infra-in-CI`):** boots `plane serve`,
-  runs `scripts/dogfood-instance-observability.sh`, opens the dashboard, and asserts:
-  - the grid shows instances and a real **field transition** is observed live (liveness /
-    bearing / current session / last-activity) — not merely "an event landed".
-  - an instance transitioning to `disconnected`/`gone` does NOT vanish unexpectedly.
-  - the detail route works for IDs with slashes, colons, spaces, Unicode.
-  - a **reload / direct deep-link** into instance detail restores that view (hash routing).
-  - stream disconnect/reconnect produces no duplicate rows or regressed state (full re-send on
-    reconnect is idempotent).
-  - a persistent stream failure yields a visible **degraded** banner (not a status diagnosis)
-    while reconnection continues; last-known data stays visible.
-  - dual-viewport only if the mockups commit to responsive breakpoints
-    (`.claude/rules/ui-verification.md`).
+`tsc --noEmit` clean; the 135 plane/instance tests still pass (the added routes didn't disturb
+036/037). No CI test was added (the `no-test-infra-in-CI` rule); the live browser check is the
+acceptance evidence for a validation build.
 
-## Deferred to later phases (captured, not dropped)
+## Deferred (if this becomes a real product surface)
 
-- **Runs facet:** `/v1/instances/:id/runs`, `/v1/runs/:id` (+history/timings), fleet runs list.
-- **Command issuance:** `POST /v1/runs/:id/commands`, `POST /v1/fleet/commands` + confirm flows.
-- **Opaque instance handle** (URL-safe routing key distinct from `host:path`) — for a
-  fronted/proxied plane where `%2F` normalization is out of our control. Not needed for the
-  direct plane (verified).
-- **Client build step (esbuild)** — only if the UI outgrows vanilla.
-
-## Open questions for the spec
-
-1. Final wording of the "show all known instances" toggle (mockup phase).
-2. Exact packaging mechanism for `src/dashboard/assets` into the installed artifact.
-
-(The prior draft's larger open questions — auth trust mode, merge revision, stream gone
-semantics, phase-duration semantics, navigation model, relative-time responsibility — are now
-SETTLED above, most by code verification.)
+- Real auth (service-mesh / infra layer) instead of the injected-token stand-in.
+- Runs facet (`/v1/instances/:id/runs`, `/v1/runs/*`) and command issuance.
+- Packaging test against the installed artifact; a `/frontend-design` visual pass; a formal
+  server-route test; session-retain of a row that transitions to `gone` while watched;
+  responsive/dual-viewport polish.

--- a/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
@@ -2,217 +2,249 @@
 
 - **Feature:** `design:feature/fleet-dashboard`
 - **Date:** 2026-07-19
-- **Status:** design (pre-spec) — revised after third-party review + code verification
+- **Status:** design (pre-spec) — revised twice after third-party review + code verification
 - **Depends on:** `design:feature/fleet-control-plane` (036), `design:feature/instance-observability` (037) — both shipped to `main`.
 
 ## Problem / purpose
 
 036 (fleet control plane) and 037 (instance observability) built a full sidecar → plane
-telemetry pipeline and a per-instance projection, but everything is consumed today as raw
-JSON + SSE over `/v1/*`. There is no human-facing surface. The immediate need is a way to
-**validate what we built** — open a screen and watch instances appear, heartbeat, change
-lifecycle phase, and go stale/gone in real time, confirming the pipeline is genuinely live and
-correct end to end.
+telemetry pipeline and a per-instance projection, consumed today only as raw JSON + SSE over
+`/v1/*`. There is no human-facing surface. The immediate need: open a screen and watch
+instances appear, heartbeat, change lifecycle phase, and go stale/gone in real time —
+validating the pipeline end to end.
 
-Scoped as a **real product surface**, not a throwaway harness: the fleet dashboard
-stack-control ships to adopters. Validating 036/037 is its first job; it is built to last.
+Scoped as a **real product surface**, not a throwaway harness. Validating 036/037 is its first
+job; it is built to last.
 
 ## Settled decisions (operator, 2026-07-19)
 
-1. **Nature:** real product surface — full feature lifecycle (roadmap item → setup →
-   `/frontend-design` mockups → spec → execute), its own branch/worktree.
-2. **Headline view:** fleet mission-control + drill-down (master-detail). Home is a live grid
-   of instances; click a row to drill into that instance's detail.
-3. **Serve + render:** embedded in the plane, **zero-build**. `plane serve` serves a
-   self-contained dashboard (static HTML + vanilla JS/CSS, no bundler) at the same origin as
-   the API. Travels with the plane; adopters get it for free.
-4. **v1 scope:** instances-only, read-only. Grid + instance detail. Runs and command issuance
-   are later phases.
-5. **Auth is OUT OF SCOPE — delegated to infrastructure.** The dashboard and plane implement
-   NO browser authentication. Authn/authz is assumed to be handled by the deployment
-   infrastructure (service mesh / ingress / sidecar proxy / mTLS). The dashboard client
-   manages **no** credentials — no injected token, no cookie, no paste. Operator rationale:
-   *"We will almost certainly get security concerns wrong; better to assume authentication is
-   handled outside our purview."* (This supersedes the earlier server-injected-token idea,
-   which code verification showed was unsound — see Review resolution.)
+1. **Nature:** real product surface — full feature lifecycle, its own branch/worktree.
+2. **Headline view:** fleet mission-control + drill-down (master-detail).
+3. **Serve + render:** embedded in the plane, **zero-build** (static HTML + vanilla JS/CSS, no
+   bundler), same origin as the API.
+4. **v1 scope:** instances-only, read-only. Runs and command issuance are later phases.
+5. **Auth is delegated to infrastructure.** The dashboard implements NO browser authentication
+   and owns NO credentials. Operator rationale: *"We will almost certainly get security
+   concerns wrong; better to assume authentication is handled outside our purview."* The plane
+   participates in that delegation through an explicit serving mode (§ Auth / serving mode),
+   NOT by making its API unconditionally public.
 
-## Review resolution (third-party review, 2026-07-19)
+## Review resolution (two review rounds, verified against 037 code)
 
-A third-party review was verified against the 037 code before revising. Findings:
-
-- **Bind address:** `src/subcommands/plane.ts` calls `server.listen(port, …)` with no host —
-  Node binds `0.0.0.0` (all interfaces), NOT loopback. This falsified the original design's
-  "localhost-only" justification for injecting a token and drove decision #5 above.
-- **`host:path` as a path segment — VERIFIED SAFE for the direct plane.** The router compiles
-  `:id` → `([^/]+)` and matches the raw, still-encoded `req.url`; Node does not normalize
-  `%2F`, and the handler `decodeURIComponent`s. The shipped T037 test fetches
-  `encodeURIComponent('host-a:/tmp/proj-a')` and passes. The proxy/tunnel mangling concern is
-  real only for a *fronted* plane → captured as a forward option (opaque handle), not a v1
-  blocker.
-- **Instance state names — CORRECTED.** The real contract is `connection ∈ {attached,
-  disconnected}` and `liveness ∈ {live, stale, gone}`. The earlier draft invented `idle`; it
-  is removed. The dashboard surfaces only these server-defined states.
-- **`/v1/instances` default filter — CONFIRMED.** The default keeps only `attached OR live OR
-  stale` (it drops `gone`); `?include=all` returns everything. The grid design accounts for
-  this (see Fleet grid).
-- **`recentActivity` bound:** `RECENT_ACTIVITY_CAP = 50` is a plane-side contract constant, so
-  the client renders the bounded list the API returns rather than assuming an arbitrary cap.
-- Accepted in full: SSE-consumption rigor, static-serving security hardening, packaged-asset
-  inclusion, expanded acceptance tests, and the narrowed module interface (below).
+- **Bind address:** `plane serve` calls `server.listen(port, …)` with no host → Node binds
+  `0.0.0.0`. This drove the explicit serving-mode contract below (a "documented assumption" of
+  localhost does not by itself create a perimeter).
+- **`host:path` route — VERIFIED SAFE (direct plane).** Router compiles `:id` → `([^/]+)`,
+  matches the raw still-encoded `req.url`; Node does not normalize `%2F`; handler
+  `decodeURIComponent`s. Shipped T037 fetches an encoded-slash id and passes. Opaque handle is
+  a fronted-plane forward option, not a v1 blocker.
+- **Instance states — CORRECTED to the real contract:** `connection ∈ {attached,
+  disconnected}`, `liveness ∈ {live, stale, gone}`. `idle` was invented and is removed.
+- **`/v1/instances` GET default filter — CONFIRMED:** keeps `attached OR live OR stale`, drops
+  `gone`; `?include=all` returns all. (But the **stream** is unfiltered — see below.)
+- **Stream emits gone transitions — VERIFIED:** the SSE stream folds the FULL registry
+  (`buildInstanceRegistry(...).instances()`, unfiltered) and diffs it, so a `→ gone` transition
+  is delivered as an `instance-upserted` delta with full state. The registry is append-only
+  over the event log, so `instance-removed` effectively never fires. The dashboard's "retain +
+  dim gone rows" is therefore natural, not a special case.
+- **Merge revision — VERIFIED not needed for v1:** InstanceState deliberately does NOT surface
+  the internal no-regress `*Sequence` marks. It doesn't have to: the server never regresses an
+  instance's state, deltas are ordered on a single stream, and every (re)connect re-delivers
+  full state (the server resets its per-connection `previous` to `[]`). The client applies
+  upserts in arrival order — see Live-update.
+- **`phaseDurations` — VERIFIED completed-only:** a phase entered-but-not-left is ABSENT (never
+  `0`); `CurrentBearing` is `{phase, item}` with NO entered-at timestamp. So there is no
+  server-provided basis for a growing current-phase bar; the UI does not interpolate.
+- Accepted: static-serving hardening, packaging-as-product, expanded browser tests, narrowed
+  module interface, connected/reconnecting/degraded stream states, hash-routing navigation,
+  client-timer relative time.
 
 ## Architecture / serving model
 
-The dashboard ships **inside the plane**. `plane serve` gains three read-only static routes
-alongside `/v1/*`, ordered ABOVE the `/v1/*` rows in `ROUTE_TABLE`:
+The dashboard ships **inside the plane**. `plane serve` gains three read-only routes above the
+`/v1/*` rows in `ROUTE_TABLE`:
 
-- `GET /` → the dashboard HTML shell (an HTML **template** rendered by the server).
-- `GET /dashboard/app.js`, `GET /dashboard/styles.css` → static JS/CSS served **verbatim**.
+- `GET /` → the dashboard HTML **template** (rendered by the server).
+- `GET /dashboard/app.js`, `GET /dashboard/styles.css` → static assets served **verbatim** from
+  an explicit allowlist.
 
-No bundler, no `.runtime-cache`, no separate deploy. One process serves the API and the UI at
-one origin — no CORS, no second deployable. Because auth is delegated to infra (#5), the
-dashboard makes plain same-origin requests with **no** credential handling of its own.
+No bundler, no `.runtime-cache`, no CORS, no second deployable. The client makes plain
+same-origin requests with no credential handling (§ Auth). **Trade-off accepted:** vanilla,
+untyped, unbundled client (the cost of zero-build); the server side is full strict TS; we keep
+the client small. A client build (esbuild) is a future option, out of scope for v1.
 
-**Trade-off accepted:** the client JS is vanilla (untyped, unbundled) by design — the cost of
-zero-build. The **server** side (routes, template render, asset serving) is full strict TS. We
-keep the client small so that is acceptable. A client build (esbuild) is a future option, out
-of scope for v1.
+## Auth / serving mode (SETTLED — flags below touch 036's `plane serve`)
+
+Authn/authz is delegated to infrastructure (decision #5). To make that delegation *safe*
+rather than a naked public API, the plane gains an explicit mode:
+
+```
+plane serve --auth-mode=external [--bind <addr>]
+```
+
+Under `--auth-mode=external`:
+
+- the dashboard static routes AND the browser-facing instance **read** routes (`/v1/instances*`
+  GET) require **no** plane bearer — the deployment's authenticating layer (mesh / ingress /
+  proxy / mTLS) owns access control;
+- the **machine-to-machine** routes (sidecar ingest, and future command/mutation routes) retain
+  their existing plane-native bearer credentials — unchanged from 036/037;
+- the mode carries a **listener-exposure contract**: the plane listener MUST be unreachable
+  except through the authenticating layer — either bound to a loopback/proxy-only address, or
+  the deployment guarantees non-bypass. **Direct all-interface exposure in external mode is
+  unsupported.**
+- `--bind <addr>` sets the listen host (default today is all-interfaces via `listen(port)`).
+  For **local dogfood/validation** run `--auth-mode=external --bind 127.0.0.1` — a real
+  boundary (only reachable on the machine), not an all-interface listener with an open API.
+
+The default mode (no `--auth-mode`) is unchanged — the existing bearer-everywhere behavior, so
+036/037 in-place behavior is untouched unless the operator opts into external mode.
+
+> **Operator confirmation wanted on THIS item:** it introduces `--auth-mode` / `--bind` to
+> `plane serve` and conditionally relaxes read-route auth — a small, deliberate change to shipped
+> 036 serve behavior. It is the concrete, safe form of decision #5; flagging it because it is the
+> one item that reaches back into a shipped feature.
+
+Static-serving hygiene the spec requires regardless of mode:
+`Cache-Control: no-store` on the HTML; `X-Content-Type-Options: nosniff`; a restrictive CSP;
+assets served ONLY from an exact-match allowlist (unknown `/dashboard/*` → 404, never falling
+through to API routing or the HTML shell); any server→page bootstrap value serialized as inert
+JSON, never substituted into script text.
 
 ## The two views (master-detail)
 
 ### Fleet grid (home)
-Rows from `GET /v1/instances`. Because the default drops `gone` instances, the grid:
+The grid sources its state from the **stream** (which delivers ALL instances, including gone),
+and applies the active/all view filter **client-side**:
 
-- **Defaults to the active fleet** (`attached OR live OR stale`).
-- Offers an explicit **include-disconnected** toggle → `?include=all` (surfaces `gone`).
-- **Never lets a currently-displayed instance vanish mid-watch:** an instance that transitions
-  to `disconnected`/`gone` while visible stays rendered (visually dimmed), because that
-  transition is itself the observability signal the operator is watching for. (The default
-  filter governs the *initial* set; live transitions do not silently drop rows.)
+- **Default view:** the active fleet (`attached OR live OR stale`) — filtered client-side.
+- **"Show all known instances" toggle:** reveals `gone`/historical rows (client-side filter
+  over already-received stream state; label finalized at mockup phase).
+- **Gone rows never vanish mid-watch:** because the stream keeps delivering them as upserts and
+  the registry never removes an instance, a row that transitions to `gone` while observed stays
+  rendered (dimmed) for the session — the transition is the signal. Enabling "show all" makes
+  the full set authoritative.
 
 Each row: connection/liveness indicator (server states only), `host:path`, `currentBearing`
-(phase + item, or `—`), `lastActivity` label + relative time, session counts. Sortable; the
-whole grid updates live.
+(`phase · item`, or `—`), `lastActivity` label + relative time, session counts. Sortable; live.
 
 ### Instance detail (drill-down)
-Click a row → `GET /v1/instances/:id` (URL-encoded `host:path`):
+`GET /v1/instances/:id` (URL-encoded `host:path`):
 
-- connection + liveness (server-defined: `attached/disconnected`, `live/stale/gone`) plus a
-  `lastActivity` relative time. No invented states; "quiet but live" is a visual treatment of
-  `live` + old `lastActivityAt`, not a new state.
-- phase-duration bars from `phaseDurations` (cumulative ms per phase).
+- connection + liveness (server-defined only) + a `lastActivity` relative time. "Quiet but
+  live" is a visual treatment of `live` + old `lastActivityAt`, not a new state.
+- **phase-duration bars from `phaseDurations` — completed phases only, static between events.**
+  The current open phase is shown via `currentBearing` (`current: phase · item`) with **no
+  growing bar** (no server-surfaced entered-at → no interpolation).
 - session started/ended counts; first-seen / first-session timestamps.
-- a live, newest-first activity stream — the API's bounded `recentActivity`
+- a live newest-first activity stream — the API's bounded `recentActivity`
   (`RECENT_ACTIVITY_CAP = 50`).
 
-All read-only. The **visual language** (layout, color, indicators, grid-vs-card) is produced as
-`/frontend-design` mockups the operator picks from before implementation, per
+All read-only. Visual language → `/frontend-design` mockups the operator picks from, per
 `.claude/rules/design-standards.md`.
 
-## Live-update model
+## Live-update model (stream-authoritative)
 
-With no client credential (#5), the client uses **native `EventSource`** against
-`GET /v1/instances/stream` — no `Authorization` header needed, and no hand-rolled SSE parser.
-Initial paint is `GET /v1/instances`; the stream keeps it live. The client:
+With no client credential, the client uses **native `EventSource`** on
+`GET /v1/instances/stream` — no headers, no hand-rolled SSE parser. The model:
 
-- keeps **exactly one** active stream; cancels it on navigation / page unload.
-- re-fetches the snapshot on each (re)subscribe to resync (`EventSource` auto-reconnects).
-- **never lets an older snapshot/delta overwrite newer data** — render ordering respects the
-  monotone sequence/`wallClock` the projection already carries (no regressions).
-- surfaces a clear **error state** (not an infinite spinner) if the stream fails permanently or
-  the server responds with a non-stream body.
+1. Create **exactly one** `EventSource`; cancel it on navigation / page unload.
+2. On connect (and every browser auto-reconnect `open`), the server's first tick re-delivers
+   **full current state** as `instance-upserted` deltas (server resets per-connection
+   `previous` to `[]`) — so the stream **self-resyncs** on reconnect; no separate snapshot fetch
+   or revision cursor is required.
+3. Apply `instance-upserted` in arrival order (server never regresses an instance); an
+   `instance-removed` (rare — append-only registry) drops the row.
+4. `GET /v1/instances` is used only as an OPTIONAL fast first-paint before the first stream
+   tick; the stream is authoritative thereafter.
 
-Open question for the spec: whether an instance-level SSE delta is sufficient to update the
-*selected* instance's activity stream, or the detail view must re-fetch `/v1/instances/:id` on
-change. Resolve in the spec.
+**Stream health states — connected / reconnecting / degraded.** `EventSource` auto-reconnects
+and does not expose HTTP status/body to JS, so the client does NOT try to diagnose *why* a
+stream failed. It shows a visible **degraded** banner ("Live updates unavailable — data may be
+stale") after repeated failures while **continuing** automatic reconnection at the browser's
+cadence; last-known data stays visible; a manual retry is offered. The client does not stop
+reconnecting (a transient proxy/plane restart should self-heal).
 
-## Auth / security posture
+Client-side **relative-time refresh:** a low-frequency timer re-formats server-provided
+timestamps against the current clock (so "12s ago" stays honest without new events).
+Connection and liveness values remain **exclusively** server-derived — the timer only
+re-formats, never re-derives state.
 
-Authn/authz is **out of scope**, delegated to infrastructure (#5). The dashboard performs no
-credential management and assumes the caller is already authenticated by the perimeter.
+## Navigation
 
-**Open question the spec must reconcile:** the shipped 037 read routes currently require the
-plane's bearer token, but the dashboard sends none. Under the "auth is external" stance the two
-candidate resolutions are (a) the read/dashboard surface (`/v1/instances*` GET + the static
-routes) is served **perimeter-trusted** — no plane-imposed browser auth — while the
-machine-to-machine sidecar ingest/command paths keep their bearer; or (b) the infra layer
-**injects** whatever credential the plane requires and the dashboard stays oblivious. This also
-determines how **local validation** works with no mesh present. Recommendation: (a) for the
-read surface, since it keeps the browser credential-free and makes local validation trivial;
-the spec settles it with operator input. Either way, the dashboard code itself builds no auth.
-
-Static-serving hygiene the spec still requires (independent of auth):
-
-- `Cache-Control: no-store` on the HTML template; `X-Content-Type-Options: nosniff`.
-- a restrictive Content-Security-Policy for the served page.
-- assets served from an **explicit allowlist** (name → file + content-type map) — never an
-  arbitrary filesystem path (no traversal).
-- any server→page bootstrap value serialized as inert JSON
-  (`<script type="application/json">`), not substituted into executable script text.
+Detail views are **deep-linkable and reload-safe** via **hash routing**
+(`/#/instances/<url-encoded host:path>`) — no server catch-all/shell fallback route needed
+(the hash never reaches the server), which keeps the zero-build serving model intact. `/` with
+no hash is the grid.
 
 ## Module structure (isolation)
 
 ```
 src/dashboard/
   assets/
-    index.html          # HTML template (rendered by the server)
-    app.js              # vanilla client (grid + detail + EventSource)
+    index.html          # HTML template (server-rendered; inert-JSON bootstrap only)
+    app.js              # vanilla client (grid + detail + EventSource + hash router)
     styles.css
-  render.ts             # renders the HTML template (safe bootstrap serialization)
-  assets.ts             # explicit asset allowlist: name -> { file, contentType }
+  render.ts             # renders the HTML template
+  assets.ts             # exact-match allowlist: pattern -> { file, contentType }
 ```
 
 - `src/plane/http/server.ts` — three new `GET` rows in `ROUTE_TABLE`, above `/v1/*`.
-- The dashboard handler receives a **narrow** interface — `{ apiBase }` — NOT the plane's
-  `acceptedTokens`. The UI-serving module knows nothing about plane credentials.
-- No `auth.ts`: auth is out of scope.
-- Each file under the 500-line cap; split `app.js` by concern (grid / detail / stream) if it
-  approaches the cap.
+- The dashboard handler receives a **narrow** interface — `{ apiBase }` — NOT `acceptedTokens`.
+  No `auth.ts`: auth is out of scope; the serving-mode gate lives in the plane's existing route
+  middleware, not the dashboard module.
+- Unknown `/dashboard/*` → 404 (never fall through to API or HTML shell).
+- Each file under the 500-line cap; split `app.js` by concern (grid / detail / stream / router)
+  if it approaches the cap.
 
 ## Packaging (Packaging IS UX)
 
-Zero **client**-build does not mean zero packaging. `tsc` does not copy `src/dashboard/assets`
-into `dist`. The spec must specify how the static assets reach the installed package/binary and
-**test the packaged/installed artifact**, not only a source checkout — a dashboard asset 404 in
-a real install is a top-priority blocker per `.claude/rules/agent-discipline.md` ("Packaging IS
-UX").
+Zero **client**-build ≠ zero packaging. `tsc` does not copy `src/dashboard/assets` into `dist`.
+The spec must specify how the assets reach the installed package/binary and **test the
+packaged/installed artifact**, not only a source checkout — a dashboard asset 404 in a real
+install is a top-priority blocker (`.claude/rules/agent-discipline.md`, "Packaging IS UX").
 
 ## Testing
 
-- **Server (TS, real `node:http` + `fetch`, mirroring `tests/instance/*`):** `GET /` → 200
-  `text/html`; assets served with correct `content-type` from the allowlist; asset requests
-  cannot traverse outside the allowlist; `/v1/*` behavior unchanged; the FR-024 read-only
-  invariant still holds (every new route is `GET`); the HTML carries `Cache-Control: no-store`.
-- **Packaged artifact:** the installed/distributed plane serves every dashboard asset (not just
-  a source checkout).
-- **Client — local Playwright smoke (NOT CI; the `no-test-infra-in-CI` rule):** boots
-  `plane serve`, runs `scripts/dogfood-instance-observability.sh`, opens the dashboard, and
-  asserts:
-  - the grid shows instances and a real **field transition** is observed live (liveness,
-    bearing, current session, or last-activity changes) — not merely "an event landed".
-  - an instance transitioning to `disconnected`/`gone` **does not vanish** unexpectedly.
-  - the detail route works for IDs containing slashes, colons, spaces, and Unicode.
-  - stream disconnect/reconnect produces no duplicate rows or regressed state.
-  - a snapshot arriving near a delta cannot overwrite newer data.
-  - a permanent stream/auth failure yields an intelligible error state, not an infinite loop.
-  - Dual-viewport only if the mockups commit to responsive breakpoints
+- **Server (real `node:http` + `fetch`, mirroring `tests/instance/*`):** `GET /` → 200
+  `text/html` with `Cache-Control: no-store`; assets served with correct `content-type` from
+  the allowlist; unknown `/dashboard/*` → 404 (no fall-through); `/v1/*` behavior unchanged in
+  default mode; FR-024 read-only invariant holds (every new route is `GET`).
+- **Serving mode:** in `--auth-mode=external`, read/dashboard routes serve without a bearer AND
+  the supported configuration is proven to require a non-bypassable listener (e.g.
+  `--bind 127.0.0.1` reachable only locally); machine ingest/command routes still require their
+  bearer.
+- **Stream contract (not just UI):** a `→ gone` transition is delivered on the stream as a
+  full-state upsert (verify the server semantics directly).
+- **Packaged artifact:** the installed/distributed plane serves every dashboard asset.
+- **Client — local Playwright smoke (NOT CI; `no-test-infra-in-CI`):** boots `plane serve`,
+  runs `scripts/dogfood-instance-observability.sh`, opens the dashboard, and asserts:
+  - the grid shows instances and a real **field transition** is observed live (liveness /
+    bearing / current session / last-activity) — not merely "an event landed".
+  - an instance transitioning to `disconnected`/`gone` does NOT vanish unexpectedly.
+  - the detail route works for IDs with slashes, colons, spaces, Unicode.
+  - a **reload / direct deep-link** into instance detail restores that view (hash routing).
+  - stream disconnect/reconnect produces no duplicate rows or regressed state (full re-send on
+    reconnect is idempotent).
+  - a persistent stream failure yields a visible **degraded** banner (not a status diagnosis)
+    while reconnection continues; last-known data stays visible.
+  - dual-viewport only if the mockups commit to responsive breakpoints
     (`.claude/rules/ui-verification.md`).
 
 ## Deferred to later phases (captured, not dropped)
 
-- **Runs facet:** `GET /v1/instances/:id/runs`, `GET /v1/runs/:id` (+history/timings), fleet
-  runs list.
+- **Runs facet:** `/v1/instances/:id/runs`, `/v1/runs/:id` (+history/timings), fleet runs list.
 - **Command issuance:** `POST /v1/runs/:id/commands`, `POST /v1/fleet/commands` + confirm flows.
-- **Opaque instance handle** in the API response (URL-safe routing key distinct from the
-  human-readable `host:path`) — for a fronted/proxied plane where `%2F` normalization is out of
-  our control. Not needed for the direct plane (verified).
+- **Opaque instance handle** (URL-safe routing key distinct from `host:path`) — for a
+  fronted/proxied plane where `%2F` normalization is out of our control. Not needed for the
+  direct plane (verified).
 - **Client build step (esbuild)** — only if the UI outgrows vanilla.
 
 ## Open questions for the spec
 
-1. Read-route auth reconciliation under the "auth is external" stance (perimeter-trust reads
-   vs. infra-injected credential) — and how local validation works with no mesh (see Auth).
-2. Whether SSE deltas update the selected instance's activity stream or the detail view
-   re-fetches on change.
-3. Packaging mechanism for `src/dashboard/assets` into the installed artifact.
-4. Relative-time / liveness thresholds are reused from 037's derivation — the UI never invents
-   thresholds.
+1. Final wording of the "show all known instances" toggle (mockup phase).
+2. Exact packaging mechanism for `src/dashboard/assets` into the installed artifact.
+
+(The prior draft's larger open questions — auth trust mode, merge revision, stream gone
+semantics, phase-duration semantics, navigation model, relative-time responsibility — are now
+SETTLED above, most by code verification.)

--- a/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
@@ -1,0 +1,149 @@
+# Fleet Dashboard — Design Record
+
+- **Feature:** `design:feature/fleet-dashboard`
+- **Date:** 2026-07-19
+- **Status:** design (pre-spec)
+- **Depends on:** `design:feature/fleet-control-plane` (036), `design:feature/instance-observability` (037) — both shipped to `main`.
+
+## Problem / purpose
+
+036 (fleet control plane) and 037 (instance observability) built a full sidecar → plane
+telemetry pipeline and a per-instance projection, but everything is consumed today as raw
+JSON + SSE over `/v1/*`. There is no human-facing surface. The immediate need is a way to
+**validate what we built** — to open a screen and watch instances appear, heartbeat, change
+lifecycle phase, and go idle/stale in real time, confirming the pipeline is genuinely live
+and correct end to end.
+
+This is scoped as a **real product surface**, not a throwaway harness: the fleet dashboard
+stack-control ships to adopters. Validating 036/037 is its first job; it is built to last.
+
+## Settled decisions (operator, 2026-07-19)
+
+1. **Nature:** real product surface — full feature lifecycle (roadmap item → setup →
+   `/frontend-design` mockups → spec → execute), its own branch/worktree.
+2. **Headline view:** fleet mission-control + drill-down (master-detail). Home is a live grid
+   of all instances; click a row to drill into that instance's detail.
+3. **Serve + render:** embedded in the plane, **zero-build**. `plane serve` serves a
+   self-contained dashboard (static HTML + vanilla JS/CSS, no bundler) at the same origin as
+   the API. Travels with the plane; adopters get it for free.
+4. **v1 scope:** instances-only, read-only. Grid + instance detail. Runs and command
+   issuance are later phases.
+5. **Browser auth:** server-injected token — the plane inlines one of its accepted tokens
+   into the served page; the client uses it as the Bearer for `/v1/*`. Justified by the
+   localhost (`127.0.0.1`) bind. Revisit if the plane is ever exposed remotely.
+
+## Architecture / serving model
+
+The dashboard ships **inside the plane**. `plane serve --port N --token T` gains three
+read-only static routes alongside the existing `/v1/*` API, ordered ABOVE the `/v1/*` rows in
+`ROUTE_TABLE`:
+
+- `GET /` → the dashboard HTML shell (unauthenticated static; token injected).
+- `GET /dashboard/app.js` → the client script.
+- `GET /dashboard/styles.css` → the client styles.
+
+No bundler, no `.runtime-cache`, no separate deploy. The client is authored as plain static
+files under `src/dashboard/assets/` and served as-is. One process serves the API and the UI at
+one origin — no CORS, no second deployable.
+
+**Trade-off accepted:** the client JS is vanilla (untyped, unbundled) by design — the cost of
+zero-build. The **server** side (routes, token injection, asset serving) is full strict TS. We
+keep the client small so that is acceptable. Graduating to a client build (esbuild) is a
+future option if the UI outgrows vanilla; it is explicitly out of scope for v1.
+
+## The two views (master-detail)
+
+### Fleet grid (home)
+One row per instance from `GET /v1/instances`:
+
+- connection/liveness indicator (from `connection` + `liveness`)
+- `host:path` (the instance `id`)
+- `currentBearing` — lifecycle phase + item (or `—` when none)
+- `lastActivity` label + relative time (from `lastActivity` / `lastActivityAt`)
+- session counts (`sessionsStarted` / `sessionsEnded`)
+
+Sortable. The whole grid updates live (see live-update model). This is the "watch the fleet
+light up" screen.
+
+### Instance detail (drill-down)
+Click a row → `GET /v1/instances/:id` (URL-encoded `host:path`):
+
+- heartbeat pulse — live / idle / stale derived from `lastHeartbeatAt` + `liveness`
+- phase-duration bars — from `phaseDurations` (cumulative ms per phase)
+- session started/ended counts, first-seen / first-session timestamps
+- a live, newest-first activity stream from `recentActivity` (≤50 events)
+
+All read-only.
+
+The **visual language** (exact layout, color, grid-vs-card treatment, the indicator glyphs) is
+deliberately NOT pinned in this design. It is produced as `/frontend-design` mockups the
+operator picks from before implementation, per `.claude/rules/design-standards.md` and the
+`/frontend-design`-first discipline.
+
+## Live-update model
+
+The client paints initially with a plain `GET /v1/instances`, then subscribes to the existing
+`GET /v1/instances/stream` (SSE) and re-renders on each event. To keep the Bearer token in a
+**header** rather than the URL, the client consumes the stream via `fetch()` + a streaming
+`ReadableStream` reader — NOT `EventSource`, which cannot set request headers. On stream drop,
+the client reconnects with a short bounded backoff and re-fetches the snapshot to resync.
+
+Open question for the spec: confirm `/v1/instances/stream` is consumable as a fetch-streamed
+body with a Bearer header (it should be — same auth as the snapshot route). If any part of the
+stream contract only supports header auth via `EventSource`-style query token, the spec records
+the resolution; the design's intent is "token stays in a header."
+
+## Auth (server-injected token)
+
+`GET /` returns unauthenticated static HTML. The plane inlines one of its accepted tokens
+(`acceptedTokens`) into the page via a placeholder swap in `index.html` (e.g. a
+`window.__PLANE_TOKEN__` bootstrap value). The client uses that token as the Bearer for every
+`/v1/*` request, including the streamed one.
+
+This is justified by the localhost bind: the page is only reachable by someone already on the
+machine, the same trust boundary that already holds the token. The spec records this as a
+**localhost-scoped** decision to revisit (operator-paste or same-origin session cookie) if the
+plane is ever bound to a non-loopback interface.
+
+## Module structure (isolation)
+
+- `src/dashboard/assets/{index.html, app.js, styles.css}` — the served client (static).
+- `src/dashboard/serve.ts` — pure handlers: serve-html-with-token-injection, serve-asset by
+  name + content-type. No plane internals leak in; input is (asset name, accepted token),
+  output is an HTTP response shape.
+- `src/plane/http/server.ts` — three new `GET` rows in `ROUTE_TABLE`, above `/v1/*`.
+- Each file under the 500-line cap. If `app.js` approaches the cap, split by concern
+  (grid render, detail render, stream client) into sibling static files, each served.
+
+## Testing
+
+- **Server (TS):** real `node:http` plane + real `fetch`, mirroring the existing
+  `tests/instance/*` route tests. Assert: `GET /` → 200 `text/html` with the token placeholder
+  resolved to a real token; `GET /dashboard/app.js` + `styles.css` served with correct
+  `content-type`; `/v1/*` behavior unchanged; the FR-024 read-only-surface invariant still
+  holds (every new route is `GET`).
+- **Client:** a **local** Playwright smoke (NOT CI — the `no-test-infra-in-CI` rule). Boots
+  `plane serve`, runs the existing `scripts/dogfood-instance-observability.sh` to populate
+  telemetry, opens the dashboard, and asserts the grid shows instances AND updates live when a
+  fresh event lands — real-browser verification per `.claude/rules/ui-verification.md`. Dual
+  viewport only if the mockups commit to responsive breakpoints.
+
+## Deferred to later phases (captured, not dropped)
+
+- **Runs facet:** `GET /v1/instances/:id/runs`, `GET /v1/runs/:id` (+history/timings), a fleet
+  runs list.
+- **Command issuance:** the `POST /v1/runs/:id/commands` and `POST /v1/fleet/commands`
+  endpoints, with confirm flows and mutation UI.
+- **Remote-exposure auth hardening:** operator-paste token or same-origin session cookie, if
+  the plane ever binds a non-loopback interface.
+- **Client build step (esbuild):** only if the UI outgrows vanilla.
+
+## Open questions for the spec
+
+1. Stream consumption contract (header-auth via fetch streaming) — confirm and record.
+2. Token selection when `acceptedTokens` has more than one entry — which token is injected
+   (first? a dedicated dashboard token?) and how that is documented for the operator.
+3. Where `plane serve` binds today (`127.0.0.1` assumed) — confirm and make the auth
+   justification explicit in the spec.
+4. Relative-time and liveness thresholds surfaced in the UI vs. derived server-side — reuse
+   037's `liveness` derivation; the UI does not re-invent thresholds.

--- a/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md
@@ -2,7 +2,7 @@
 
 - **Feature:** `design:feature/fleet-dashboard`
 - **Date:** 2026-07-19
-- **Status:** design (pre-spec)
+- **Status:** design (pre-spec) — revised after third-party review + code verification
 - **Depends on:** `design:feature/fleet-control-plane` (036), `design:feature/instance-observability` (037) — both shipped to `main`.
 
 ## Problem / purpose
@@ -10,11 +10,11 @@
 036 (fleet control plane) and 037 (instance observability) built a full sidecar → plane
 telemetry pipeline and a per-instance projection, but everything is consumed today as raw
 JSON + SSE over `/v1/*`. There is no human-facing surface. The immediate need is a way to
-**validate what we built** — to open a screen and watch instances appear, heartbeat, change
-lifecycle phase, and go idle/stale in real time, confirming the pipeline is genuinely live
-and correct end to end.
+**validate what we built** — open a screen and watch instances appear, heartbeat, change
+lifecycle phase, and go stale/gone in real time, confirming the pipeline is genuinely live and
+correct end to end.
 
-This is scoped as a **real product surface**, not a throwaway harness: the fleet dashboard
+Scoped as a **real product surface**, not a throwaway harness: the fleet dashboard
 stack-control ships to adopters. Validating 036/037 is its first job; it is built to last.
 
 ## Settled decisions (operator, 2026-07-19)
@@ -22,128 +22,197 @@ stack-control ships to adopters. Validating 036/037 is its first job; it is buil
 1. **Nature:** real product surface — full feature lifecycle (roadmap item → setup →
    `/frontend-design` mockups → spec → execute), its own branch/worktree.
 2. **Headline view:** fleet mission-control + drill-down (master-detail). Home is a live grid
-   of all instances; click a row to drill into that instance's detail.
+   of instances; click a row to drill into that instance's detail.
 3. **Serve + render:** embedded in the plane, **zero-build**. `plane serve` serves a
    self-contained dashboard (static HTML + vanilla JS/CSS, no bundler) at the same origin as
    the API. Travels with the plane; adopters get it for free.
-4. **v1 scope:** instances-only, read-only. Grid + instance detail. Runs and command
-   issuance are later phases.
-5. **Browser auth:** server-injected token — the plane inlines one of its accepted tokens
-   into the served page; the client uses it as the Bearer for `/v1/*`. Justified by the
-   localhost (`127.0.0.1`) bind. Revisit if the plane is ever exposed remotely.
+4. **v1 scope:** instances-only, read-only. Grid + instance detail. Runs and command issuance
+   are later phases.
+5. **Auth is OUT OF SCOPE — delegated to infrastructure.** The dashboard and plane implement
+   NO browser authentication. Authn/authz is assumed to be handled by the deployment
+   infrastructure (service mesh / ingress / sidecar proxy / mTLS). The dashboard client
+   manages **no** credentials — no injected token, no cookie, no paste. Operator rationale:
+   *"We will almost certainly get security concerns wrong; better to assume authentication is
+   handled outside our purview."* (This supersedes the earlier server-injected-token idea,
+   which code verification showed was unsound — see Review resolution.)
+
+## Review resolution (third-party review, 2026-07-19)
+
+A third-party review was verified against the 037 code before revising. Findings:
+
+- **Bind address:** `src/subcommands/plane.ts` calls `server.listen(port, …)` with no host —
+  Node binds `0.0.0.0` (all interfaces), NOT loopback. This falsified the original design's
+  "localhost-only" justification for injecting a token and drove decision #5 above.
+- **`host:path` as a path segment — VERIFIED SAFE for the direct plane.** The router compiles
+  `:id` → `([^/]+)` and matches the raw, still-encoded `req.url`; Node does not normalize
+  `%2F`, and the handler `decodeURIComponent`s. The shipped T037 test fetches
+  `encodeURIComponent('host-a:/tmp/proj-a')` and passes. The proxy/tunnel mangling concern is
+  real only for a *fronted* plane → captured as a forward option (opaque handle), not a v1
+  blocker.
+- **Instance state names — CORRECTED.** The real contract is `connection ∈ {attached,
+  disconnected}` and `liveness ∈ {live, stale, gone}`. The earlier draft invented `idle`; it
+  is removed. The dashboard surfaces only these server-defined states.
+- **`/v1/instances` default filter — CONFIRMED.** The default keeps only `attached OR live OR
+  stale` (it drops `gone`); `?include=all` returns everything. The grid design accounts for
+  this (see Fleet grid).
+- **`recentActivity` bound:** `RECENT_ACTIVITY_CAP = 50` is a plane-side contract constant, so
+  the client renders the bounded list the API returns rather than assuming an arbitrary cap.
+- Accepted in full: SSE-consumption rigor, static-serving security hardening, packaged-asset
+  inclusion, expanded acceptance tests, and the narrowed module interface (below).
 
 ## Architecture / serving model
 
-The dashboard ships **inside the plane**. `plane serve --port N --token T` gains three
-read-only static routes alongside the existing `/v1/*` API, ordered ABOVE the `/v1/*` rows in
-`ROUTE_TABLE`:
+The dashboard ships **inside the plane**. `plane serve` gains three read-only static routes
+alongside `/v1/*`, ordered ABOVE the `/v1/*` rows in `ROUTE_TABLE`:
 
-- `GET /` → the dashboard HTML shell (unauthenticated static; token injected).
-- `GET /dashboard/app.js` → the client script.
-- `GET /dashboard/styles.css` → the client styles.
+- `GET /` → the dashboard HTML shell (an HTML **template** rendered by the server).
+- `GET /dashboard/app.js`, `GET /dashboard/styles.css` → static JS/CSS served **verbatim**.
 
-No bundler, no `.runtime-cache`, no separate deploy. The client is authored as plain static
-files under `src/dashboard/assets/` and served as-is. One process serves the API and the UI at
-one origin — no CORS, no second deployable.
+No bundler, no `.runtime-cache`, no separate deploy. One process serves the API and the UI at
+one origin — no CORS, no second deployable. Because auth is delegated to infra (#5), the
+dashboard makes plain same-origin requests with **no** credential handling of its own.
 
 **Trade-off accepted:** the client JS is vanilla (untyped, unbundled) by design — the cost of
-zero-build. The **server** side (routes, token injection, asset serving) is full strict TS. We
-keep the client small so that is acceptable. Graduating to a client build (esbuild) is a
-future option if the UI outgrows vanilla; it is explicitly out of scope for v1.
+zero-build. The **server** side (routes, template render, asset serving) is full strict TS. We
+keep the client small so that is acceptable. A client build (esbuild) is a future option, out
+of scope for v1.
 
 ## The two views (master-detail)
 
 ### Fleet grid (home)
-One row per instance from `GET /v1/instances`:
+Rows from `GET /v1/instances`. Because the default drops `gone` instances, the grid:
 
-- connection/liveness indicator (from `connection` + `liveness`)
-- `host:path` (the instance `id`)
-- `currentBearing` — lifecycle phase + item (or `—` when none)
-- `lastActivity` label + relative time (from `lastActivity` / `lastActivityAt`)
-- session counts (`sessionsStarted` / `sessionsEnded`)
+- **Defaults to the active fleet** (`attached OR live OR stale`).
+- Offers an explicit **include-disconnected** toggle → `?include=all` (surfaces `gone`).
+- **Never lets a currently-displayed instance vanish mid-watch:** an instance that transitions
+  to `disconnected`/`gone` while visible stays rendered (visually dimmed), because that
+  transition is itself the observability signal the operator is watching for. (The default
+  filter governs the *initial* set; live transitions do not silently drop rows.)
 
-Sortable. The whole grid updates live (see live-update model). This is the "watch the fleet
-light up" screen.
+Each row: connection/liveness indicator (server states only), `host:path`, `currentBearing`
+(phase + item, or `—`), `lastActivity` label + relative time, session counts. Sortable; the
+whole grid updates live.
 
 ### Instance detail (drill-down)
 Click a row → `GET /v1/instances/:id` (URL-encoded `host:path`):
 
-- heartbeat pulse — live / idle / stale derived from `lastHeartbeatAt` + `liveness`
-- phase-duration bars — from `phaseDurations` (cumulative ms per phase)
-- session started/ended counts, first-seen / first-session timestamps
-- a live, newest-first activity stream from `recentActivity` (≤50 events)
+- connection + liveness (server-defined: `attached/disconnected`, `live/stale/gone`) plus a
+  `lastActivity` relative time. No invented states; "quiet but live" is a visual treatment of
+  `live` + old `lastActivityAt`, not a new state.
+- phase-duration bars from `phaseDurations` (cumulative ms per phase).
+- session started/ended counts; first-seen / first-session timestamps.
+- a live, newest-first activity stream — the API's bounded `recentActivity`
+  (`RECENT_ACTIVITY_CAP = 50`).
 
-All read-only.
-
-The **visual language** (exact layout, color, grid-vs-card treatment, the indicator glyphs) is
-deliberately NOT pinned in this design. It is produced as `/frontend-design` mockups the
-operator picks from before implementation, per `.claude/rules/design-standards.md` and the
-`/frontend-design`-first discipline.
+All read-only. The **visual language** (layout, color, indicators, grid-vs-card) is produced as
+`/frontend-design` mockups the operator picks from before implementation, per
+`.claude/rules/design-standards.md`.
 
 ## Live-update model
 
-The client paints initially with a plain `GET /v1/instances`, then subscribes to the existing
-`GET /v1/instances/stream` (SSE) and re-renders on each event. To keep the Bearer token in a
-**header** rather than the URL, the client consumes the stream via `fetch()` + a streaming
-`ReadableStream` reader — NOT `EventSource`, which cannot set request headers. On stream drop,
-the client reconnects with a short bounded backoff and re-fetches the snapshot to resync.
+With no client credential (#5), the client uses **native `EventSource`** against
+`GET /v1/instances/stream` — no `Authorization` header needed, and no hand-rolled SSE parser.
+Initial paint is `GET /v1/instances`; the stream keeps it live. The client:
 
-Open question for the spec: confirm `/v1/instances/stream` is consumable as a fetch-streamed
-body with a Bearer header (it should be — same auth as the snapshot route). If any part of the
-stream contract only supports header auth via `EventSource`-style query token, the spec records
-the resolution; the design's intent is "token stays in a header."
+- keeps **exactly one** active stream; cancels it on navigation / page unload.
+- re-fetches the snapshot on each (re)subscribe to resync (`EventSource` auto-reconnects).
+- **never lets an older snapshot/delta overwrite newer data** — render ordering respects the
+  monotone sequence/`wallClock` the projection already carries (no regressions).
+- surfaces a clear **error state** (not an infinite spinner) if the stream fails permanently or
+  the server responds with a non-stream body.
 
-## Auth (server-injected token)
+Open question for the spec: whether an instance-level SSE delta is sufficient to update the
+*selected* instance's activity stream, or the detail view must re-fetch `/v1/instances/:id` on
+change. Resolve in the spec.
 
-`GET /` returns unauthenticated static HTML. The plane inlines one of its accepted tokens
-(`acceptedTokens`) into the page via a placeholder swap in `index.html` (e.g. a
-`window.__PLANE_TOKEN__` bootstrap value). The client uses that token as the Bearer for every
-`/v1/*` request, including the streamed one.
+## Auth / security posture
 
-This is justified by the localhost bind: the page is only reachable by someone already on the
-machine, the same trust boundary that already holds the token. The spec records this as a
-**localhost-scoped** decision to revisit (operator-paste or same-origin session cookie) if the
-plane is ever bound to a non-loopback interface.
+Authn/authz is **out of scope**, delegated to infrastructure (#5). The dashboard performs no
+credential management and assumes the caller is already authenticated by the perimeter.
+
+**Open question the spec must reconcile:** the shipped 037 read routes currently require the
+plane's bearer token, but the dashboard sends none. Under the "auth is external" stance the two
+candidate resolutions are (a) the read/dashboard surface (`/v1/instances*` GET + the static
+routes) is served **perimeter-trusted** — no plane-imposed browser auth — while the
+machine-to-machine sidecar ingest/command paths keep their bearer; or (b) the infra layer
+**injects** whatever credential the plane requires and the dashboard stays oblivious. This also
+determines how **local validation** works with no mesh present. Recommendation: (a) for the
+read surface, since it keeps the browser credential-free and makes local validation trivial;
+the spec settles it with operator input. Either way, the dashboard code itself builds no auth.
+
+Static-serving hygiene the spec still requires (independent of auth):
+
+- `Cache-Control: no-store` on the HTML template; `X-Content-Type-Options: nosniff`.
+- a restrictive Content-Security-Policy for the served page.
+- assets served from an **explicit allowlist** (name → file + content-type map) — never an
+  arbitrary filesystem path (no traversal).
+- any server→page bootstrap value serialized as inert JSON
+  (`<script type="application/json">`), not substituted into executable script text.
 
 ## Module structure (isolation)
 
-- `src/dashboard/assets/{index.html, app.js, styles.css}` — the served client (static).
-- `src/dashboard/serve.ts` — pure handlers: serve-html-with-token-injection, serve-asset by
-  name + content-type. No plane internals leak in; input is (asset name, accepted token),
-  output is an HTTP response shape.
+```
+src/dashboard/
+  assets/
+    index.html          # HTML template (rendered by the server)
+    app.js              # vanilla client (grid + detail + EventSource)
+    styles.css
+  render.ts             # renders the HTML template (safe bootstrap serialization)
+  assets.ts             # explicit asset allowlist: name -> { file, contentType }
+```
+
 - `src/plane/http/server.ts` — three new `GET` rows in `ROUTE_TABLE`, above `/v1/*`.
-- Each file under the 500-line cap. If `app.js` approaches the cap, split by concern
-  (grid render, detail render, stream client) into sibling static files, each served.
+- The dashboard handler receives a **narrow** interface — `{ apiBase }` — NOT the plane's
+  `acceptedTokens`. The UI-serving module knows nothing about plane credentials.
+- No `auth.ts`: auth is out of scope.
+- Each file under the 500-line cap; split `app.js` by concern (grid / detail / stream) if it
+  approaches the cap.
+
+## Packaging (Packaging IS UX)
+
+Zero **client**-build does not mean zero packaging. `tsc` does not copy `src/dashboard/assets`
+into `dist`. The spec must specify how the static assets reach the installed package/binary and
+**test the packaged/installed artifact**, not only a source checkout — a dashboard asset 404 in
+a real install is a top-priority blocker per `.claude/rules/agent-discipline.md` ("Packaging IS
+UX").
 
 ## Testing
 
-- **Server (TS):** real `node:http` plane + real `fetch`, mirroring the existing
-  `tests/instance/*` route tests. Assert: `GET /` → 200 `text/html` with the token placeholder
-  resolved to a real token; `GET /dashboard/app.js` + `styles.css` served with correct
-  `content-type`; `/v1/*` behavior unchanged; the FR-024 read-only-surface invariant still
-  holds (every new route is `GET`).
-- **Client:** a **local** Playwright smoke (NOT CI — the `no-test-infra-in-CI` rule). Boots
-  `plane serve`, runs the existing `scripts/dogfood-instance-observability.sh` to populate
-  telemetry, opens the dashboard, and asserts the grid shows instances AND updates live when a
-  fresh event lands — real-browser verification per `.claude/rules/ui-verification.md`. Dual
-  viewport only if the mockups commit to responsive breakpoints.
+- **Server (TS, real `node:http` + `fetch`, mirroring `tests/instance/*`):** `GET /` → 200
+  `text/html`; assets served with correct `content-type` from the allowlist; asset requests
+  cannot traverse outside the allowlist; `/v1/*` behavior unchanged; the FR-024 read-only
+  invariant still holds (every new route is `GET`); the HTML carries `Cache-Control: no-store`.
+- **Packaged artifact:** the installed/distributed plane serves every dashboard asset (not just
+  a source checkout).
+- **Client — local Playwright smoke (NOT CI; the `no-test-infra-in-CI` rule):** boots
+  `plane serve`, runs `scripts/dogfood-instance-observability.sh`, opens the dashboard, and
+  asserts:
+  - the grid shows instances and a real **field transition** is observed live (liveness,
+    bearing, current session, or last-activity changes) — not merely "an event landed".
+  - an instance transitioning to `disconnected`/`gone` **does not vanish** unexpectedly.
+  - the detail route works for IDs containing slashes, colons, spaces, and Unicode.
+  - stream disconnect/reconnect produces no duplicate rows or regressed state.
+  - a snapshot arriving near a delta cannot overwrite newer data.
+  - a permanent stream/auth failure yields an intelligible error state, not an infinite loop.
+  - Dual-viewport only if the mockups commit to responsive breakpoints
+    (`.claude/rules/ui-verification.md`).
 
 ## Deferred to later phases (captured, not dropped)
 
-- **Runs facet:** `GET /v1/instances/:id/runs`, `GET /v1/runs/:id` (+history/timings), a fleet
+- **Runs facet:** `GET /v1/instances/:id/runs`, `GET /v1/runs/:id` (+history/timings), fleet
   runs list.
-- **Command issuance:** the `POST /v1/runs/:id/commands` and `POST /v1/fleet/commands`
-  endpoints, with confirm flows and mutation UI.
-- **Remote-exposure auth hardening:** operator-paste token or same-origin session cookie, if
-  the plane ever binds a non-loopback interface.
-- **Client build step (esbuild):** only if the UI outgrows vanilla.
+- **Command issuance:** `POST /v1/runs/:id/commands`, `POST /v1/fleet/commands` + confirm flows.
+- **Opaque instance handle** in the API response (URL-safe routing key distinct from the
+  human-readable `host:path`) — for a fronted/proxied plane where `%2F` normalization is out of
+  our control. Not needed for the direct plane (verified).
+- **Client build step (esbuild)** — only if the UI outgrows vanilla.
 
 ## Open questions for the spec
 
-1. Stream consumption contract (header-auth via fetch streaming) — confirm and record.
-2. Token selection when `acceptedTokens` has more than one entry — which token is injected
-   (first? a dedicated dashboard token?) and how that is documented for the operator.
-3. Where `plane serve` binds today (`127.0.0.1` assumed) — confirm and make the auth
-   justification explicit in the spec.
-4. Relative-time and liveness thresholds surfaced in the UI vs. derived server-side — reuse
-   037's `liveness` derivation; the UI does not re-invent thresholds.
+1. Read-route auth reconciliation under the "auth is external" stance (perimeter-trust reads
+   vs. infra-injected credential) — and how local validation works with no mesh (see Auth).
+2. Whether SSE deltas update the selected instance's activity stream or the detail view
+   re-fetches on change.
+3. Packaging mechanism for `src/dashboard/assets` into the installed artifact.
+4. Relative-time / liveness thresholds are reused from 037's derivation — the UI never invents
+   thresholds.

--- a/plugins/stack-control/src/cli.ts
+++ b/plugins/stack-control/src/cli.ts
@@ -251,7 +251,7 @@ async function main(): Promise<void> {
   // wrapper emits exactly one invocation.completed event (FR-012) and closes
   // the emit client even when the handler throws, then re-throws the handler's
   // original error unchanged so exit behavior is preserved (AUDIT-20260717-08).
-  await runInvocationWithTelemetry(handler, args);
+  await runInvocationWithTelemetry(handler, args, { verb });
 }
 
 main().catch((err: unknown) => {

--- a/plugins/stack-control/src/dashboard/assets.ts
+++ b/plugins/stack-control/src/dashboard/assets.ts
@@ -1,0 +1,27 @@
+// Dashboard static-asset access. Zero-build: the client is authored as plain
+// files under ./assets and read at request time. stack-control runs via tsx over
+// `src/`, so these ship as part of `src/` and are readable in a real install (no
+// dist-copy step needed). Resolution is relative to THIS module's URL.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** The named assets the dashboard serves — an EXACT allowlist. */
+export type DashboardAssetName = 'index.html' | 'app.js' | 'styles.css';
+
+const CONTENT_TYPES: Readonly<Record<DashboardAssetName, string>> = {
+  'index.html': 'text/html; charset=utf-8',
+  'app.js': 'text/javascript; charset=utf-8',
+  'styles.css': 'text/css; charset=utf-8',
+};
+
+export function contentTypeFor(name: DashboardAssetName): string {
+  return CONTENT_TYPES[name];
+}
+
+/** Read a named dashboard asset from ./assets. Throws if the file is missing —
+ * a missing asset is a packaging defect, surfaced loud, never a silent fallback. */
+export function readDashboardAsset(name: DashboardAssetName): string {
+  const path = fileURLToPath(new URL(`./assets/${name}`, import.meta.url));
+  return readFileSync(path, 'utf8');
+}

--- a/plugins/stack-control/src/dashboard/assets/app.js
+++ b/plugins/stack-control/src/dashboard/assets/app.js
@@ -1,0 +1,340 @@
+// Fleet Dashboard — vanilla client (zero-build). Talks to the plane's read-only
+// /v1/instances* API with the server-injected token. Grid (home) + instance
+// detail (hash routing); live via a fetch-streamed SSE reader.
+//
+// This is a validation-first build: auth is a crude injected token, deferred by
+// design. See docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md.
+
+(() => {
+  'use strict';
+
+  const config = readConfig();
+  const apiBase = config.apiBase || '';
+  const token = config.token || null;
+
+  /** @type {Map<string, object>} id -> InstanceState (session memory). */
+  const instances = new Map();
+  let showAll = false;
+  let streamAbort = null;
+  let reconnectFails = 0;
+
+  // --- config / auth -------------------------------------------------------
+  function readConfig() {
+    const el = document.getElementById('dashboard-config');
+    if (!el || !el.textContent) return {};
+    try {
+      return JSON.parse(el.textContent);
+    } catch {
+      return {};
+    }
+  }
+
+  function authHeaders() {
+    return token ? { authorization: `Bearer ${token}` } : {};
+  }
+
+  // --- time formatting (client re-formats server timestamps ONLY) ----------
+  function relativeTime(iso) {
+    if (!iso) return '—';
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return '—';
+    const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+    if (secs < 60) return `${secs}s ago`;
+    const mins = Math.round(secs / 60);
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.round(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    return `${Math.round(hrs / 24)}d ago`;
+  }
+
+  function formatMs(ms) {
+    if (typeof ms !== 'number' || ms <= 0) return '0s';
+    const s = Math.round(ms / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    return rem ? `${m}m ${rem}s` : `${m}m`;
+  }
+
+  function escapeHtml(v) {
+    return String(v).replace(/[&<>"']/g, (c) => {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  // --- state helpers -------------------------------------------------------
+  function isActive(inst) {
+    return inst.connection === 'attached' || inst.liveness === 'live' || inst.liveness === 'stale';
+  }
+
+  function dotClass(inst) {
+    if (inst.connection === 'disconnected') return 'gone';
+    return inst.liveness === 'live' ? 'live' : inst.liveness === 'stale' ? 'stale' : 'gone';
+  }
+
+  function visibleInstances() {
+    const list = [...instances.values()].filter((i) => showAll || isActive(i));
+    const rank = { live: 0, stale: 1, gone: 2 };
+    list.sort((a, b) => {
+      const r = (rank[a.liveness] ?? 3) - (rank[b.liveness] ?? 3);
+      if (r !== 0) return r;
+      return (Date.parse(b.lastActivityAt || 0) || 0) - (Date.parse(a.lastActivityAt || 0) || 0);
+    });
+    return list;
+  }
+
+  // --- rendering: grid -----------------------------------------------------
+  function renderGrid() {
+    const body = document.getElementById('grid-body');
+    const empty = document.getElementById('grid-empty');
+    const rows = visibleInstances();
+    empty.hidden = rows.length > 0;
+    body.innerHTML = rows.map(gridRow).join('');
+    for (const tr of body.querySelectorAll('tr[data-id]')) {
+      tr.addEventListener('click', () => {
+        location.hash = `#/instances/${encodeURIComponent(tr.getAttribute('data-id'))}`;
+      });
+    }
+  }
+
+  function gridRow(inst) {
+    const bearing = inst.currentBearing
+      ? `${escapeHtml(inst.currentBearing.phase)} · <span class="muted">${escapeHtml(inst.currentBearing.item)}</span>`
+      : '<span class="muted">—</span>';
+    const activity = inst.lastActivity
+      ? `${escapeHtml(inst.lastActivity)} <span class="muted">· ${relativeTime(inst.lastActivityAt)}</span>`
+      : `<span class="muted">${relativeTime(inst.lastActivityAt)}</span>`;
+    const goneCls = inst.liveness === 'gone' || inst.connection === 'disconnected' ? ' class="is-gone"' : '';
+    return (
+      `<tr data-id="${escapeHtml(inst.id)}"${goneCls}>` +
+      `<td><span class="dot ${dotClass(inst)}"></span>` +
+      `<span class="state-label">${escapeHtml(inst.connection)} · ${escapeHtml(inst.liveness)}</span></td>` +
+      `<td class="mono">${escapeHtml(inst.id)}</td>` +
+      `<td>${bearing}</td>` +
+      `<td>${activity}</td>` +
+      `<td class="num">${inst.sessionsStarted ?? 0}/${inst.sessionsEnded ?? 0}</td>` +
+      `</tr>`
+    );
+  }
+
+  // --- rendering: detail ---------------------------------------------------
+  async function renderDetail(id) {
+    const view = document.getElementById('detail-body');
+    view.innerHTML = '<p class="empty">Loading…</p>';
+    let payload;
+    try {
+      const res = await fetch(`${apiBase}/v1/instances/${encodeURIComponent(id)}`, {
+        headers: authHeaders(),
+      });
+      if (res.status === 404) {
+        view.innerHTML = `<p class="empty">No instance <span class="mono">${escapeHtml(id)}</span> found.</p>`;
+        return;
+      }
+      if (!res.ok) throw new Error(`detail ${res.status}`);
+      payload = await res.json();
+    } catch {
+      view.innerHTML = '<p class="empty">Could not load instance detail.</p>';
+      return;
+    }
+    if (!payload || payload.found === false || !payload.instance) {
+      view.innerHTML = `<p class="empty">No instance <span class="mono">${escapeHtml(id)}</span> found.</p>`;
+      return;
+    }
+    const inst = payload.instance;
+    const activity = Array.isArray(payload.recentActivity) ? payload.recentActivity : inst.recentActivity || [];
+    view.innerHTML = detailHtml(inst, activity);
+  }
+
+  function detailHtml(inst, activity) {
+    const bearing = inst.currentBearing
+      ? `${escapeHtml(inst.currentBearing.phase)} · <span class="muted">${escapeHtml(inst.currentBearing.item)}</span>`
+      : '<span class="muted">no current phase</span>';
+    const cards = [
+      ['Connection', escapeHtml(inst.connection)],
+      ['Liveness', escapeHtml(inst.liveness)],
+      ['Sessions', `${inst.sessionsStarted ?? 0} <span class="muted">started</span> / ${inst.sessionsEnded ?? 0} <span class="muted">ended</span>`],
+      ['Last heartbeat', relativeTime(inst.lastHeartbeatAt)],
+      ['Last activity', relativeTime(inst.lastActivityAt)],
+      ['First seen', relativeTime(inst.firstSeenAt)],
+    ]
+      .map(([k, v]) => `<div class="card"><div class="k">${k}</div><div class="v">${v}</div></div>`)
+      .join('');
+
+    return (
+      `<div class="detail-head"><h2 class="mono">${escapeHtml(inst.id)}</h2>` +
+      `<span class="state-label"><span class="dot ${dotClass(inst)}"></span>${escapeHtml(inst.connection)} · ${escapeHtml(inst.liveness)}</span></div>` +
+      `<div class="muted">Current bearing: ${bearing}</div>` +
+      `<div class="detail-grid">${cards}</div>` +
+      phaseBarsHtml(inst.phaseDurations) +
+      activityHtml(activity)
+    );
+  }
+
+  function phaseBarsHtml(durations) {
+    const entries = Object.entries(durations || {});
+    if (entries.length === 0) {
+      return '<div class="section-title">Phase durations (completed)</div><p class="muted">No completed phases yet.</p>';
+    }
+    const max = Math.max(...entries.map(([, ms]) => ms), 1);
+    const rows = entries
+      .sort((a, b) => b[1] - a[1])
+      .map(([phase, ms]) => {
+        const pct = Math.round((ms / max) * 100);
+        return (
+          `<div class="bar-row"><div class="mono">${escapeHtml(phase)}</div>` +
+          `<div class="bar-track"><div class="bar-fill" style="width:${pct}%"></div></div>` +
+          `<div class="num">${formatMs(ms)}</div></div>`
+        );
+      })
+      .join('');
+    return `<div class="section-title">Phase durations (completed)</div><div class="bars">${rows}</div>`;
+  }
+
+  function activityHtml(activity) {
+    if (!activity || activity.length === 0) {
+      return '<div class="section-title">Recent activity</div><p class="muted">No activity recorded.</p>';
+    }
+    const rows = activity
+      .map((item) => {
+        const type = item && typeof item === 'object' && 'type' in item ? item.type : String(item);
+        const when = item && typeof item === 'object' && 'wallClock' in item ? item.wallClock : null;
+        return (
+          `<div class="activity-row"><div class="t">${relativeTime(when)}</div>` +
+          `<div class="mono">${escapeHtml(type)}</div></div>`
+        );
+      })
+      .join('');
+    return `<div class="section-title">Recent activity (newest first)</div><div class="activity">${rows}</div>`;
+  }
+
+  // --- routing -------------------------------------------------------------
+  function currentRoute() {
+    const m = /^#\/instances\/(.+)$/.exec(location.hash);
+    return m ? { view: 'detail', id: decodeURIComponent(m[1]) } : { view: 'grid' };
+  }
+
+  function route() {
+    const r = currentRoute();
+    const gridView = document.getElementById('grid-view');
+    const detailView = document.getElementById('detail-view');
+    if (r.view === 'detail') {
+      gridView.hidden = true;
+      detailView.hidden = false;
+      renderDetail(r.id);
+    } else {
+      detailView.hidden = true;
+      gridView.hidden = false;
+      renderGrid();
+    }
+  }
+
+  // --- live stream (fetch-streamed SSE) ------------------------------------
+  function applyDelta(delta) {
+    if (!delta || typeof delta !== 'object') return;
+    if (delta.kind === 'instance-upserted' && delta.instance && delta.instance.id) {
+      instances.set(delta.instance.id, delta.instance);
+    } else if (delta.kind === 'instance-removed' && delta.id) {
+      instances.delete(delta.id);
+    }
+  }
+
+  function handleSseBlock(block) {
+    let event = 'message';
+    const data = [];
+    for (const line of block.split('\n')) {
+      if (line.startsWith(':')) continue; // keepalive / comment
+      if (line.startsWith('event:')) event = line.slice(6).trim();
+      else if (line.startsWith('data:')) data.push(line.slice(5).replace(/^ /, ''));
+    }
+    if (event !== 'instance-delta' || data.length === 0) return;
+    try {
+      applyDelta(JSON.parse(data.join('\n')));
+      if (currentRoute().view === 'grid') renderGrid();
+    } catch {
+      /* skip a malformed frame; the stream stays alive */
+    }
+  }
+
+  function setStatus(state, text) {
+    const el = document.getElementById('stream-status');
+    el.setAttribute('data-state', state);
+    el.textContent = text || state;
+  }
+
+  async function streamLoop() {
+    const controller = new AbortController();
+    streamAbort = controller;
+    setStatus('connecting', 'connecting…');
+    try {
+      const res = await fetch(`${apiBase}/v1/instances/stream`, {
+        headers: authHeaders(),
+        signal: controller.signal,
+      });
+      if (!res.ok || !res.body) throw new Error(`stream ${res.status}`);
+      setStatus('connected', 'live');
+      reconnectFails = 0;
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let idx;
+        while ((idx = buf.indexOf('\n\n')) >= 0) {
+          handleSseBlock(buf.slice(0, idx));
+          buf = buf.slice(idx + 2);
+        }
+      }
+      throw new Error('stream ended');
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      scheduleReconnect();
+    }
+  }
+
+  function scheduleReconnect() {
+    reconnectFails += 1;
+    if (reconnectFails >= 3) setStatus('degraded', 'live updates unavailable — data may be stale');
+    else setStatus('connecting', 'reconnecting…');
+    const backoff = Math.min(1000 * 2 ** reconnectFails, 15000);
+    const jitter = Math.floor(backoff * 0.25 * Math.random());
+    setTimeout(streamLoop, backoff + jitter);
+  }
+
+  // --- initial snapshot (fast first paint) ---------------------------------
+  async function loadSnapshot() {
+    try {
+      const res = await fetch(`${apiBase}/v1/instances?include=all`, { headers: authHeaders() });
+      if (!res.ok) return;
+      const payload = await res.json();
+      const list = payload && Array.isArray(payload.instances) ? payload.instances : [];
+      for (const inst of list) {
+        if (inst && inst.id) instances.set(inst.id, inst);
+      }
+      if (currentRoute().view === 'grid') renderGrid();
+    } catch {
+      /* the stream will populate; first paint is best-effort */
+    }
+  }
+
+  // --- boot ----------------------------------------------------------------
+  document.getElementById('show-all').addEventListener('change', (e) => {
+    showAll = e.target.checked;
+    if (currentRoute().view === 'grid') renderGrid();
+  });
+  document.getElementById('back-to-grid').addEventListener('click', () => {
+    location.hash = '';
+  });
+  window.addEventListener('hashchange', route);
+  window.addEventListener('beforeunload', () => streamAbort && streamAbort.abort());
+  // Relative-time labels drift without new events — repaint the visible view on a
+  // low-frequency timer (re-formats server timestamps only; never re-derives state).
+  setInterval(() => {
+    if (currentRoute().view === 'grid') renderGrid();
+  }, 5000);
+
+  loadSnapshot();
+  streamLoop();
+  route();
+})();

--- a/plugins/stack-control/src/dashboard/assets/app.js
+++ b/plugins/stack-control/src/dashboard/assets/app.js
@@ -196,11 +196,16 @@
     }
     const rows = activity
       .map((item) => {
-        const type = item && typeof item === 'object' && 'type' in item ? item.type : String(item);
-        const when = item && typeof item === 'object' && 'wallClock' in item ? item.wallClock : null;
+        const obj = item && typeof item === 'object' ? item : {};
+        const type = 'type' in obj ? obj.type : String(item);
+        const when = 'wallClock' in obj ? obj.wallClock : null;
+        const detail = 'detail' in obj && obj.detail ? obj.detail : null;
+        const what = detail
+          ? `${escapeHtml(type)} <span class="muted">· ${escapeHtml(detail)}</span>`
+          : escapeHtml(type);
         return (
           `<div class="activity-row"><div class="t">${relativeTime(when)}</div>` +
-          `<div class="mono">${escapeHtml(type)}</div></div>`
+          `<div class="mono">${what}</div></div>`
         );
       })
       .join('');

--- a/plugins/stack-control/src/dashboard/assets/index.html
+++ b/plugins/stack-control/src/dashboard/assets/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fleet Dashboard</title>
+    <link rel="stylesheet" href="/dashboard/styles.css" />
+    <!-- Server-injected config (inert JSON — never executable script text). -->
+    <script id="dashboard-config" type="application/json">__DASHBOARD_CONFIG__</script>
+  </head>
+  <body>
+    <header class="masthead">
+      <h1>Fleet Dashboard</h1>
+      <div class="masthead-right">
+        <label class="toggle">
+          <input type="checkbox" id="show-all" />
+          <span>Show all known instances</span>
+        </label>
+        <span id="stream-status" class="stream-status" data-state="connecting">connecting…</span>
+      </div>
+    </header>
+
+    <main>
+      <!-- Grid (home) -->
+      <section id="grid-view">
+        <table class="grid">
+          <thead>
+            <tr>
+              <th>State</th>
+              <th>Instance</th>
+              <th>Bearing</th>
+              <th>Last activity</th>
+              <th class="num">Sessions</th>
+            </tr>
+          </thead>
+          <tbody id="grid-body"></tbody>
+        </table>
+        <p id="grid-empty" class="empty">No instances yet. Waiting for telemetry…</p>
+      </section>
+
+      <!-- Detail (drill-down) -->
+      <section id="detail-view" hidden>
+        <button id="back-to-grid" class="back">← Fleet</button>
+        <div id="detail-body"></div>
+      </section>
+    </main>
+
+    <script src="/dashboard/app.js"></script>
+  </body>
+</html>

--- a/plugins/stack-control/src/dashboard/assets/styles.css
+++ b/plugins/stack-control/src/dashboard/assets/styles.css
@@ -1,0 +1,111 @@
+:root {
+  --bg: #0f1115;
+  --panel: #171a21;
+  --panel-2: #1e222b;
+  --line: #2a2f3a;
+  --text: #e6e9ef;
+  --muted: #9aa4b2;
+  --live: #3fb950;
+  --stale: #d29922;
+  --gone: #6e7681;
+  --accent: #58a6ff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.masthead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+.masthead h1 { font-size: 16px; margin: 0; letter-spacing: 0.2px; }
+.masthead-right { display: flex; align-items: center; gap: 18px; }
+
+.toggle { display: flex; align-items: center; gap: 6px; color: var(--muted); cursor: pointer; }
+.toggle input { accent-color: var(--accent); }
+
+.stream-status {
+  font-size: 12px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.stream-status[data-state="connected"] { color: var(--live); border-color: rgba(63,185,80,0.4); }
+.stream-status[data-state="connecting"] { color: var(--stale); }
+.stream-status[data-state="degraded"] { color: var(--gone); border-color: var(--gone); }
+
+main { padding: 16px 20px; max-width: 1100px; margin: 0 auto; }
+
+.grid { width: 100%; border-collapse: collapse; }
+.grid th, .grid td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+.grid th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px; }
+.grid td.num, .grid th.num { text-align: right; font-variant-numeric: tabular-nums; }
+.grid tbody tr { cursor: pointer; }
+.grid tbody tr:hover { background: var(--panel-2); }
+.grid tbody tr.is-gone { opacity: 0.5; }
+
+.dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 8px; vertical-align: middle; }
+.dot.live { background: var(--live); box-shadow: 0 0 6px rgba(63,185,80,0.7); }
+.dot.stale { background: var(--stale); }
+.dot.gone { background: var(--gone); }
+.dot.disconnected { background: transparent; border: 2px solid var(--gone); width: 7px; height: 7px; }
+
+.state-label { color: var(--muted); font-size: 12px; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.muted { color: var(--muted); }
+.empty { color: var(--muted); padding: 24px 4px; }
+
+.back {
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  margin-bottom: 16px;
+}
+.back:hover { border-color: var(--accent); }
+
+.detail-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 4px; }
+.detail-head h2 { font-size: 18px; margin: 0; }
+.detail-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 16px 0; }
+.card { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; }
+.card .k { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px; }
+.card .v { font-size: 18px; margin-top: 4px; font-variant-numeric: tabular-nums; }
+
+.bars { margin: 8px 0 16px; }
+.bar-row { display: grid; grid-template-columns: 140px 1fr 90px; align-items: center; gap: 10px; margin: 6px 0; }
+.bar-track { background: var(--panel-2); border-radius: 4px; height: 14px; overflow: hidden; }
+.bar-fill { background: var(--accent); height: 100%; }
+.bar-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--muted); }
+
+.section-title { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px; margin: 18px 0 8px; }
+.activity { border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+.activity-row { display: grid; grid-template-columns: 150px 1fr; gap: 10px; padding: 7px 12px; border-bottom: 1px solid var(--line); }
+.activity-row:last-child { border-bottom: none; }
+.activity-row .t { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+@media (max-width: 640px) {
+  .grid th:nth-child(3), .grid td:nth-child(3) { display: none; }
+  main { padding: 12px; }
+}

--- a/plugins/stack-control/src/dashboard/serve.ts
+++ b/plugins/stack-control/src/dashboard/serve.ts
@@ -1,0 +1,61 @@
+// Dashboard serving — three UNAUTHENTICATED static GET routes mounted alongside
+// the plane's `/v1/*` API (the static files carry no secrets themselves; the page
+// is handed one plane bearer so the client can call the authed `/v1/*`).
+//
+// Validation-first build: the injected bearer is a crude, deliberately-deferred
+// auth stand-in (see the design record). It is NOT a production auth model.
+
+import type { ServerResponse } from 'node:http';
+import type { ExtraRoute, RouteContext, RouteHandler } from '../plane/http/server.js';
+import { contentTypeFor, readDashboardAsset, type DashboardAssetName } from './assets.js';
+
+const INDEX_CONFIG_PLACEHOLDER = '__DASHBOARD_CONFIG__';
+
+/** Serialize the bootstrap config as inert JSON, escaping `<` so the value can
+ * never break out of the `<script type="application/json">` element. */
+function bootstrapConfig(bearer: string | null): string {
+  return JSON.stringify({ token: bearer, apiBase: '' }).replace(/</g, '\\u003c');
+}
+
+function writeAsset(res: ServerResponse, name: DashboardAssetName, body: string): void {
+  res.writeHead(200, {
+    'content-type': contentTypeFor(name),
+    'cache-control': 'no-store',
+    'x-content-type-options': 'nosniff',
+  });
+  res.end(body);
+}
+
+function serveIndex(bearer: string | null): RouteHandler {
+  return (ctx: RouteContext): void => {
+    const html = readDashboardAsset('index.html').replace(
+      INDEX_CONFIG_PLACEHOLDER,
+      bootstrapConfig(bearer),
+    );
+    writeAsset(ctx.res, 'index.html', html);
+  };
+}
+
+function serveStatic(name: DashboardAssetName): RouteHandler {
+  return (ctx: RouteContext): void => {
+    writeAsset(ctx.res, name, readDashboardAsset(name));
+  };
+}
+
+/**
+ * The dashboard routes, mounted as UNAUTHENTICATED extra routes on the plane. The
+ * served page is handed the first plane-accepted bearer (if any) so the client
+ * can call the authed `/v1/*` read API; a token-less plane injects `null` and the
+ * client calls the API bare. Exact patterns ARE the allowlist: an unknown
+ * `/dashboard/*` path matches no route and the plane returns its standard 404.
+ */
+export function buildDashboardRoutes(
+  acceptedBearers: ReadonlyMap<string, string>,
+): readonly ExtraRoute[] {
+  const bearer = [...acceptedBearers.keys()][0] ?? null;
+  return [
+    { method: 'GET', pattern: '/', handler: serveIndex(bearer) },
+    { method: 'GET', pattern: '/dashboard/app.js', handler: serveStatic('app.js') },
+    { method: 'GET', pattern: '/dashboard/styles.css', handler: serveStatic('styles.css') },
+  ];
+}

--- a/plugins/stack-control/src/fleet/instance/types.ts
+++ b/plugins/stack-control/src/fleet/instance/types.ts
@@ -71,6 +71,14 @@ export interface RecentActivityItem {
   readonly eventId: string;
   readonly type: string;
   readonly wallClock: string;
+  /**
+   * A short human-readable "what happened" derived from the event's snapshot —
+   * the phase for `phase.entered`, the verb for `invocation.completed`, etc. —
+   * or `null` when the event type carries no meaningful detail. Records WHAT
+   * happened alongside THAT it happened, so an activity timeline is legible
+   * rather than a wall of bare event types.
+   */
+  readonly detail: string | null;
 }
 
 /**

--- a/plugins/stack-control/src/plane/instance-accumulator.ts
+++ b/plugins/stack-control/src/plane/instance-accumulator.ts
@@ -127,6 +127,24 @@ function readSnapshotString(snapshot: SnapshotPayload | undefined, key: string):
 }
 
 /**
+ * The short human-readable "what happened" for a `recentActivity` row, read off
+ * the event's already-validated snapshot. `null` when the type carries no
+ * meaningful detail (honest absence — never a fabricated label). Kept in sync
+ * with the producers: `phase.entered` snapshots `{phase, from, item}`;
+ * `invocation.completed` snapshots `{outcome, verb}`.
+ */
+function recentActivityDetail(type: string, snapshot: SnapshotPayload | undefined): string | null {
+  switch (type) {
+    case 'phase.entered':
+      return readSnapshotString(snapshot, 'phase');
+    case 'invocation.completed':
+      return readSnapshotString(snapshot, 'verb') ?? readSnapshotString(snapshot, 'outcome');
+    default:
+      return null;
+  }
+}
+
+/**
  * Fold a `session.started` / `session.ended` event into the instance's session
  * fields (data-model.md § InstanceState; FR-009/FR-009a). The identity fields
  * (host/path) keyed the accumulator already; the session payload itself rides
@@ -366,13 +384,20 @@ export function applyHeartbeatSignal(acc: InstanceAccumulator, emittedAt: string
  * effectively-once is not re-checked here.
  */
 export function applyInstanceEvent(acc: InstanceAccumulator, event: ClassifiedEvent): void {
-  const { envelope, type } = event;
+  const { envelope, type, snapshot } = event;
   const sequence = envelope.installationSequence;
 
   // Bounded convenience view (FR-016b, RECENT_ACTIVITY_CAP = 50, D1). Stored
   // oldest-pushed-first; toInstanceState reverses to newest-first on read. NOT
-  // sequence-gated — every folded event is recorded.
-  acc.recentActivity.push({ eventId: envelope.eventId, type, wallClock: envelope.wallClock });
+  // sequence-gated — every folded event is recorded. `detail` records WHAT
+  // happened (the phase, the verb, …) so the timeline is legible, not a wall of
+  // bare event types.
+  acc.recentActivity.push({
+    eventId: envelope.eventId,
+    type,
+    wallClock: envelope.wallClock,
+    detail: recentActivityDetail(type, snapshot),
+  });
   if (acc.recentActivity.length > RECENT_ACTIVITY_CAP) {
     acc.recentActivity.shift();
   }

--- a/plugins/stack-control/src/plane/runtime.ts
+++ b/plugins/stack-control/src/plane/runtime.ts
@@ -68,6 +68,7 @@ import {
 } from './http/server.js';
 import type { TelemetryEvent } from '../fleet/event.js';
 import { buildPlaneHandlers } from './runtime-handlers.js';
+import { buildDashboardRoutes } from '../dashboard/serve.js';
 import { createHeartbeatStore, type HeartbeatStore } from './heartbeat-store.js';
 
 // ---------------------------------------------------------------------------
@@ -287,6 +288,7 @@ export function createPlaneRuntime(options: PlaneRuntimeOptions): PlaneRuntime {
         { method: 'POST', pattern: '/v1/ingest', handler: withAuth(ingestHandler) },
         { method: 'GET', pattern: '/v1/sidecar/stream', handler: withAuth(sidecarStreamHandler) },
         { method: 'POST', pattern: '/v1/sidecar/liveness', handler: withAuth(livenessHandler) },
+        ...buildDashboardRoutes(options.acceptedTokens),
       ];
       return createPlaneServer(guardedConsumer, sidecarRoutes);
     },

--- a/plugins/stack-control/src/sidecar/pipeline.ts
+++ b/plugins/stack-control/src/sidecar/pipeline.ts
@@ -133,8 +133,11 @@ export interface RawInvocationEvent {
 }
 
 /**
- * The specs/037 durable event types whose BARE status snapshot survives to the
- * plane INTACT. A CLOSED set, so the passthrough does NOT open a general "bare
+ * The event types whose BARE, already-safe status snapshot survives to the plane
+ * INTACT — the specs/037 durable-identity types (`{phase,from,item}` /
+ * `{sessionId,startedAt}`) plus `invocation.completed`'s `{outcome, verb}` (the
+ * verb name is a stackctl subcommand, not user content, so the fleet timeline can
+ * show WHAT ran). A CLOSED set, so the passthrough does NOT open a general "bare
  * snapshot bypasses redaction" hole — every OTHER type still travels the 036
  * `{content,allowlist}` deny-by-default redaction path (FR-047/048).
  */
@@ -142,6 +145,7 @@ const BARE_SNAPSHOT_EVENT_TYPES: ReadonlySet<EventType> = new Set<EventType>([
   'session.started',
   'session.ended',
   'phase.entered',
+  'invocation.completed',
 ]);
 
 /**

--- a/plugins/stack-control/src/telemetry/invocation-telemetry.ts
+++ b/plugins/stack-control/src/telemetry/invocation-telemetry.ts
@@ -104,6 +104,10 @@ export interface InvocationTelemetryOptions {
   readonly clock?: Clock;
   /** Injected emit-client factory (default the real `createEmitClient`). */
   readonly createEmit?: typeof createEmitClient;
+  /** The dispatched verb name (e.g. `workflow`) — recorded on the
+   * `invocation.completed` snapshot so the fleet timeline shows WHAT ran, not
+   * just that something ran. Absent → the snapshot carries no `verb`. */
+  readonly verb?: string;
 }
 
 /**
@@ -177,8 +181,13 @@ export async function runInvocationWithTelemetry(
             installationRoot, // host/path derived by construction (FR-011)
           ),
           // Carry a success/failure signal so a fleet monitor can distinguish a
-          // clean invocation from a failing one (AUDIT-20260717-08).
-          snapshot: { outcome: handlerThrew ? 'error' : 'ok' },
+          // clean invocation from a failing one (AUDIT-20260717-08), plus the
+          // verb name so the fleet timeline shows WHAT ran (not just that
+          // something did). `verb` is omitted when the caller didn't supply one.
+          snapshot:
+            options.verb === undefined
+              ? { outcome: handlerThrew ? 'error' : 'ok' }
+              : { outcome: handlerThrew ? 'error' : 'ok', verb: options.verb },
         };
         emitClient.emit(event);
         // specs/037 D-B: give the eager connect a SMALL BOUNDED window to


### PR DESCRIPTION
Ships the fleet dashboard (`design:feature/fleet-dashboard`) as a **validation build** — a plane-embedded, read-only live view to validate the 036/037 control plane end to end. Built outside the governed lifecycle (no spec/execute/govern) by operator decision, for velocity; the design record is `docs/superpowers/specs/2026-07-19-fleet-dashboard-design.md`.

**Dashboard** — three unauthenticated static routes on `plane serve` render a self-contained zero-build client (vanilla HTML/JS/CSS):
- fleet grid (home): live connection/liveness, current bearing, last activity, session counts; live over a fetch-streamed SSE reader; "show all" reveals gone instances.
- instance detail (hash-routed, deep-linkable): completed phase-duration bars, session/heartbeat cards, and a live activity timeline.
- auth is a crude injected-token stand-in, deliberately deferred (validation-only; not production).

**037 telemetry improvement (carried on this branch)** — the `recentActivity` timeline now records **what** happened, not just that it did: `invocation.completed · <verb>`, `phase.entered · <phase>`. Three-layer fix (producer records the verb; sidecar lets `invocation.completed`'s bare `{outcome, verb}` survive re-mint; plane derives `RecentActivityItem.detail`; client renders it).

Verified live in a browser against a real plane + sidecar. `tsc` clean; 127 plane/sidecar/instance tests pass; no shipped 036/037 auth or routing changed (the routes are additive).

Note: the roadmap node stays `planned` at the lifecycle level — this feature intentionally skipped design→spec→execute→govern, so it was not graduated through the compass. Roadmap bookkeeping is an operator decision.
